### PR TITLE
chore: migrate to Zod v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "node-machine-id": "1.1.12",
         "open": "^11.0.0",
         "yaml": "^2.8.1",
-        "zod": "3.25.76"
+        "zod": "^4.3.6"
       },
       "bin": {
         "agent": "dist/cli.js",
@@ -8015,9 +8015,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "node-machine-id": "1.1.12",
     "open": "^11.0.0",
     "yaml": "^2.8.1",
-    "zod": "3.25.76"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/inquirer": "^9.0.9",

--- a/src/schemas/agent.schema.ts
+++ b/src/schemas/agent.schema.ts
@@ -5,7 +5,7 @@ export const agentYamlSchema = z.object({
   model: z.string().default('gpt-4'),
   instructions: z.string().min(1),
   tools: z.array(z.string()).optional().default([]),
-  variables: z.record(z.string()).optional().default({}),
+  variables: z.record(z.string(), z.string()).optional().default({}),
 });
 
 export type AgentYaml = z.infer<typeof agentYamlSchema>;

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -24,7 +24,7 @@ export const authFileSchema = z.object({
  * Registry configuration schema
  */
 export const registryConfigSchema = z.object({
-  url: z.string().url().default('https://dev.agentage.io'),
+  url: z.url().default('https://dev.agentage.io'),
 });
 
 /**


### PR DESCRIPTION
## Summary
- Bump zod from 3.25.76 to ^4.3.6
- `z.string().url()` → `z.url()` (v4 top-level validator)
- `z.record(z.string())` → `z.record(z.string(), z.string())` (v4 requires 2 args)

## Test plan
- [x] 168/168 tests pass
- [x] Type-check clean
- [x] Lint clean