### PR TITLE
chore: standardize prettier config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+build
+.next
+coverage
+package-lock.json
+*.snap

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "tabWidth": 2
+}


### PR DESCRIPTION
## Standardize Prettier Config

Align prettier config to the standard used across all repos.

### `.prettierrc`
```json
{
  "semi": true,
  "singleQuote": true,
  "trailingComma": "es5",
  "printWidth": 100,
  "tabWidth": 2
}
```

### Changes
- Standardize to `.prettierrc` (not `.prettierrc.json`)
- Remove redundant defaults (`useTabs`, `arrowParens`, `endOfLine`)
- Standardize `.prettierignore` — minimal, consistent across repos
- Only 5 non-default options — nothing extra