### PR TITLE
fix: optional chaining for auth fields in health route

### DIFF
--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -37,8 +37,8 @@ export const createRoutes = (): Router => {
       uptime: Math.floor((Date.now() - startTime) / 1000),
       machineId: config.machine.id,
       hubConnected: hubSync.isConnected(),
-      hubUrl: auth?.hub.url ?? null,
-      userEmail: auth?.user.email ?? null,
+      hubUrl: auth?.hub?.url ?? null,
+      userEmail: auth?.user?.email ?? null,
     });
   });
 


### PR DESCRIPTION
## Summary
- Fixed TypeError when daemon starts with a legacy desktop `auth.json` that lacks `hub`/`user` fields
- Changed `auth?.hub.url` → `auth?.hub?.url` and `auth?.user.email` → `auth?.user?.email`

## Test plan
- [x] 131 tests pass
- [x] Verified manually: daemon starts cleanly with no auth, old auth, and valid auth