### PR TITLE
feat: use hub login page for OAuth flow

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -49,28 +49,10 @@ export const registerLogin = (program: Command): void => {
         return;
       }
 
-      // Fetch supabase config from hub health endpoint
-      let supabaseUrl: string;
-      let supabaseAnonKey: string;
-
-      try {
-        const healthRes = await fetch(`${hubUrl}/api/health`);
-        const health = (await healthRes.json()) as {
-          success: boolean;
-          data: { supabaseUrl: string; supabaseAnonKey: string };
-        };
-        supabaseUrl = health.data.supabaseUrl;
-        supabaseAnonKey = health.data.supabaseAnonKey;
-      } catch {
-        console.error(chalk.red(`Cannot reach hub at ${hubUrl}. Check the URL and try again.`));
-        process.exitCode = 1;
-        return;
-      }
-
-      // Start callback server, then open browser
+      // Start callback server, then open browser to hub login page
       console.log('Opening browser for authentication...');
 
-      const authPromise = startCallbackServer(supabaseUrl, supabaseAnonKey);
+      const authPromise = startCallbackServer();
 
       // Wait a tick for the server to start, then get the port
       await new Promise((r) => setTimeout(r, 100));
@@ -82,8 +64,7 @@ export const registerLogin = (program: Command): void => {
         return;
       }
 
-      const redirectUrl = `http://localhost:${port}/auth/callback`;
-      const authUrl = `${supabaseUrl}/auth/v1/authorize?provider=github&redirect_to=${encodeURIComponent(redirectUrl)}`;
+      const authUrl = `${hubUrl}/login?cli_port=${port}`;
 
       try {
         await open(authUrl);

--- a/src/hub/auth-callback.ts
+++ b/src/hub/auth-callback.ts
@@ -1,11 +1,27 @@
 import express from 'express';
-import { createClient } from '@supabase/supabase-js';
 import { type AuthState } from './auth.js';
 
-export const startCallbackServer = (
-  supabaseUrl: string,
-  supabaseAnonKey: string
-): Promise<AuthState> =>
+interface JwtPayload {
+  sub?: string;
+  email?: string;
+  user_metadata?: {
+    full_name?: string;
+    name?: string;
+    avatar_url?: string;
+  };
+}
+
+const decodeJwtPayload = (token: string): JwtPayload => {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    throw new Error('Invalid JWT format');
+  }
+  const payload = parts[1];
+  const json = Buffer.from(payload, 'base64url').toString('utf-8');
+  return JSON.parse(json) as JwtPayload;
+};
+
+export const startCallbackServer = (): Promise<AuthState> =>
   new Promise((resolve, reject) => {
     const app = express();
 
@@ -19,59 +35,56 @@ export const startCallbackServer = (
         reject(new Error('Login timed out — no callback received within 120 seconds'));
       }, 120_000);
 
-      app.get('/auth/callback', async (req, res) => {
+      app.get('/auth/callback', (req, res) => {
         clearTimeout(timeout);
 
-        const code = req.query.code as string | undefined;
+        const accessToken = req.query.access_token as string | undefined;
+        const refreshToken = req.query.refresh_token as string | undefined;
+        const expiresAt = req.query.expires_at as string | undefined;
 
-        if (!code) {
-          res.status(400).send('Missing authorization code');
-          server.close();
-          reject(new Error('Missing authorization code in callback'));
+        if (accessToken) {
+          // Primary flow — tokens provided directly by the hub login page
+          try {
+            const payload = decodeJwtPayload(accessToken);
+
+            res.send(
+              '<html><body><h2>Login successful!</h2><p>You can close this window.</p></body></html>'
+            );
+            server.close();
+
+            resolve({
+              session: {
+                access_token: accessToken,
+                refresh_token: refreshToken ?? '',
+                expires_at: expiresAt ? Number(expiresAt) : 0,
+              },
+              user: {
+                id: payload.sub ?? '',
+                email: payload.email ?? '',
+                name: payload.user_metadata?.full_name ?? payload.user_metadata?.name ?? '',
+                avatar: payload.user_metadata?.avatar_url ?? '',
+              },
+              hub: {
+                url: '',
+                machineId: '',
+              },
+            });
+          } catch (err) {
+            res.status(500).send('Failed to decode access token');
+            server.close();
+            reject(
+              new Error(
+                `Failed to decode access token: ${err instanceof Error ? err.message : String(err)}`
+              )
+            );
+          }
           return;
         }
 
-        try {
-          const supabase = createClient(supabaseUrl, supabaseAnonKey);
-          const { data, error } = await supabase.auth.exchangeCodeForSession(code);
-
-          if (error || !data.session) {
-            res.status(500).send('Failed to exchange code for session');
-            server.close();
-            reject(new Error(`Auth exchange failed: ${error?.message ?? 'no session'}`));
-            return;
-          }
-
-          res.send(
-            '<html><body><h2>Login successful!</h2><p>You can close this window.</p></body></html>'
-          );
-          server.close();
-
-          resolve({
-            session: {
-              access_token: data.session.access_token,
-              refresh_token: data.session.refresh_token,
-              expires_at: data.session.expires_at ?? 0,
-            },
-            user: {
-              id: data.user.id,
-              email: data.user.email ?? '',
-              name:
-                (data.user.user_metadata?.full_name as string) ??
-                (data.user.user_metadata?.name as string) ??
-                '',
-              avatar: (data.user.user_metadata?.avatar_url as string) ?? '',
-            },
-            hub: {
-              url: '',
-              machineId: '',
-            },
-          });
-        } catch (err) {
-          res.status(500).send('Auth error');
-          server.close();
-          reject(err);
-        }
+        // No recognized params
+        res.status(400).send('Missing authentication parameters');
+        server.close();
+        reject(new Error('Missing authentication parameters in callback'));
       });
 
       // Export port for the caller to build the OAuth URL


### PR DESCRIPTION
## Summary
- CLI now opens `{hub}/login?cli_port=X` instead of raw Supabase authorize URL
- Callback server accepts `access_token`, `refresh_token`, `expires_at` as query params
- Decodes JWT locally to extract user info (no Supabase SDK needed in auth flow)
- Removed `@supabase/supabase-js` dependency from callback server

## Depends on
- agentage/web — feat/auth-login-pages (hub must serve the login page)

## Test plan
- [x] 131 tests pass, verify clean
- [ ] Manual: `agentage login --hub https://dev.agentage.io` → browser → callback → CLI logged in