### PR TITLE
feat: add AGENTAGE_PORT env var override

### DIFF
--- a/src/daemon/config.test.ts
+++ b/src/daemon/config.test.ts
@@ -88,4 +88,12 @@ describe('config', () => {
     expect(config.machine.name).toBeTruthy();
     expect(typeof config.machine.name).toBe('string');
   });
+
+  it('AGENTAGE_PORT overrides daemon port', async () => {
+    process.env['AGENTAGE_PORT'] = '5555';
+    const { loadConfig } = await import('./config.js');
+    const config = loadConfig();
+    expect(config.daemon.port).toBe(5555);
+    delete process.env['AGENTAGE_PORT'];
+  });
 });

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -72,13 +72,21 @@ const createDefaultConfig = (): DaemonConfig => {
 export const loadConfig = (): DaemonConfig => {
   const configPath = join(getConfigDir(), 'config.json');
 
+  let config: DaemonConfig;
+
   if (existsSync(configPath)) {
     const raw = readFileSync(configPath, 'utf-8');
-    return JSON.parse(raw) as DaemonConfig;
+    config = JSON.parse(raw) as DaemonConfig;
+  } else {
+    config = createDefaultConfig();
+    saveConfig(config);
   }
 
-  const config = createDefaultConfig();
-  saveConfig(config);
+  const portOverride = process.env['AGENTAGE_PORT'];
+  if (portOverride) {
+    config.daemon.port = parseInt(portOverride, 10);
+  }
+
   return config;
 };
 


### PR DESCRIPTION
## Summary
- Adds `AGENTAGE_PORT` env var support to override `daemon.port` from config
- Enables running multiple isolated daemon instances on different ports
- Needed for E2E testing — each `LocalMachine` gets its own port

## Changes
- `src/daemon/config.ts`: `loadConfig()` checks `AGENTAGE_PORT` env var after loading config, overrides `daemon.port` if set
- `src/daemon/config.test.ts`: test verifying the override works

## Test plan
- [x] `npm run verify` passes (132 tests, type-check, lint, format)
- [ ] Manual: `AGENTAGE_PORT=5555 agentage status` starts daemon on port 5555