### PR TITLE
chore: release v0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentage/cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentage/cli",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@agentage/core": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentage/cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Agentage CLI and daemon — control plane for AI agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import { VERSION } from './utils/version.js';
 import { registerRun } from './commands/run.js';
 import { registerAgents } from './commands/agents.js';
 import { registerRuns } from './commands/runs.js';
@@ -13,7 +14,7 @@ import { registerDaemon } from './commands/daemon-cmd.js';
 
 const program = new Command();
 
-program.name('agentage').description('Agentage CLI — control plane for AI agents').version('0.2.0');
+program.name('agentage').description('Agentage CLI — control plane for AI agents').version(VERSION);
 
 registerRun(program);
 registerAgents(program);

--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -6,7 +6,8 @@ import { getHubSync } from '../hub/hub-sync.js';
 import { readAuth } from '../hub/auth.js';
 import { createHubClient } from '../hub/hub-client.js';
 
-const VERSION = '0.2.0';
+import { VERSION } from '../utils/version.js';
+
 const startTime = Date.now();
 
 let agents: Agent[] = [];

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -70,7 +70,7 @@ describe('server', () => {
     const body = (await res.json()) as Record<string, unknown>;
     expect(res.status).toBe(200);
     expect(body.status).toBe('ok');
-    expect(body.version).toBe('0.2.0');
+    expect(body.version).toBeDefined();
     expect(typeof body.uptime).toBe('number');
     expect(body.hubConnected).toBe(false);
   });

--- a/src/e2e/daemon-lifecycle.test.ts
+++ b/src/e2e/daemon-lifecycle.test.ts
@@ -176,7 +176,7 @@ describe('E2E: daemon lifecycle', () => {
     const { status, body } = await api.get<Record<string, unknown>>('/api/health');
     expect(status).toBe(200);
     expect(body.status).toBe('ok');
-    expect(body.version).toBe('0.2.0');
+    expect(body.version).toBeDefined();
     expect(typeof body.uptime).toBe('number');
     expect(body.machineId).toBeDefined();
     expect(body.hubConnected).toBe(false);

--- a/src/hub/hub-sync.ts
+++ b/src/hub/hub-sync.ts
@@ -8,8 +8,9 @@ import { logInfo, logWarn } from '../daemon/logger.js';
 import { getAgents } from '../daemon/routes.js';
 import { cancelRun, sendInput, getRuns } from '../daemon/run-manager.js';
 
+import { VERSION } from '../utils/version.js';
+
 const HEARTBEAT_INTERVAL_MS = 30_000;
-const DAEMON_VERSION = '0.2.0';
 
 export interface HubSync {
   start: () => Promise<void>;
@@ -34,7 +35,7 @@ export const createHubSync = (): HubSync => {
       name: config.machine.name,
       platform: platform(),
       arch: arch(),
-      daemonVersion: DAEMON_VERSION,
+      daemonVersion: VERSION,
     });
 
     // Save machineId in auth

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,0 +1,6 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../../package.json') as { version: string };
+
+export const VERSION = pkg.version;


### PR DESCRIPTION
## Summary
Version bump to 0.3.0 — triggers npm publish workflow on merge.

### What's new in 0.3.0
- Hub login page flow (`/login?cli_port=X`) instead of raw Supabase URL
- Optional chaining fix for legacy auth.json in health route
- Updated daemon/hub version constants

## Test plan
- [x] Merge triggers publish.yml → npm publish --provenance