### PR TITLE
feat: login exits cleanly, daemon auto-connects on auth

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -46,7 +46,7 @@ export const registerLogin = (program: Command): void => {
         saveConfig(config);
 
         console.log(chalk.green('Logged in with token.'));
-        return;
+        process.exit(0);
       }
 
       // Start callback server, then open browser to hub login page
@@ -91,10 +91,8 @@ export const registerLogin = (program: Command): void => {
         saveConfig(config);
 
         console.log(chalk.green(`✓ Logged in as ${authState.user.email}`));
-        console.log(
-          `Machine "${config.machine.name}" will register with hub on next daemon restart.`
-        );
-        console.log(chalk.dim('Run `agentage daemon restart` to connect now.'));
+        console.log(`Machine "${config.machine.name}" will connect to hub automatically.`);
+        process.exit(0);
       } catch (err) {
         console.error(
           chalk.red(`Login failed: ${err instanceof Error ? err.message : String(err)}`)

--- a/src/daemon-entry.ts
+++ b/src/daemon-entry.ts
@@ -1,11 +1,13 @@
-import { loadConfig } from './daemon/config.js';
+import { watch } from 'node:fs';
+import { loadConfig, getConfigDir } from './daemon/config.js';
 import { logError, logInfo } from './daemon/logger.js';
 import { writePidFile, removePidFile } from './daemon/daemon.js';
 import { createDaemonServer } from './daemon/server.js';
 import { scanAgents } from './discovery/scanner.js';
 import { createMarkdownFactory } from './discovery/markdown-factory.js';
 import { createCodeFactory } from './discovery/code-factory.js';
-import { getHubSync } from './hub/hub-sync.js';
+import { getHubSync, resetHubSync } from './hub/hub-sync.js';
+import { readAuth } from './hub/auth.js';
 
 const main = async (): Promise<void> => {
   const config = loadConfig();
@@ -27,6 +29,25 @@ const main = async (): Promise<void> => {
   // Initialize hub sync (registers + heartbeat if auth.json exists)
   const hubSync = getHubSync();
   await hubSync.start();
+
+  // Watch for auth.json changes — auto-connect when user logs in
+  let authWatchDebounce: ReturnType<typeof setTimeout> | null = null;
+
+  watch(getConfigDir(), (_event, filename) => {
+    if (filename !== 'auth.json') return;
+    if (authWatchDebounce) clearTimeout(authWatchDebounce);
+    authWatchDebounce = setTimeout(async () => {
+      const auth = readAuth();
+      const currentSync = getHubSync();
+      if (auth?.hub?.url && !currentSync.isConnected()) {
+        logInfo('Auth changed — connecting to hub...');
+        await currentSync.stop();
+        resetHubSync();
+        const newSync = getHubSync();
+        await newSync.start();
+      }
+    }, 500);
+  });
 
   const shutdown = async (): Promise<void> => {
     logInfo('Daemon shutting down...');


### PR DESCRIPTION
## Summary
- `agentage login` now exits after successful login instead of hanging
- Daemon watches `~/.agentage/auth.json` — auto-connects to hub when user logs in
- No more "run agentage daemon restart" step

## Test plan
- [x] 132 tests pass
- [ ] `agentage login` → browser → auth → CLI exits
- [ ] Daemon picks up auth.json and connects without restart