### PR TITLE
fix: CLI exits after all commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,4 +26,7 @@ registerLogout(program);
 registerLogs(program);
 registerDaemon(program);
 
-program.parse();
+program.parseAsync().then(() => {
+  // Force exit — forked daemon process can keep the event loop alive
+  setTimeout(() => process.exit(process.exitCode ?? 0), 100);
+});


### PR DESCRIPTION
Forces process.exit after command completes. Forked daemon keeps event loop alive.