### PR TITLE
chore: release v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentage/cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentage/cli",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@agentage/core": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentage/cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Agentage CLI and daemon — control plane for AI agents",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## What's in v0.5.0

### Since v0.4.0
- **fix: all CLI commands now exit cleanly** — forked daemon process was keeping the event loop alive, causing `daemon restart`, `status`, `machines`, etc. to hang after completing

### Cumulative (v0.3.0 → v0.5.0)
- Login exits on success + daemon auto-connects on auth change (v0.4.0)
- Version read from package.json at runtime (v0.3.0)
- Hub login page flow instead of raw Supabase URL (v0.3.0)
- Optional chaining fix for legacy auth.json (v0.3.0)

Version bump triggers npm publish workflow.