### PR TITLE
fix: drain stdout before exit in run command (v0.7.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentage/cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentage/cli",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@agentage/core": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentage/cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Agentage CLI and daemon — control plane for AI agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -66,7 +66,8 @@ export const registerRun = (program: Command): void => {
         } else {
           await runLocal(agentName, prompt, opts);
         }
-        process.exit(process.exitCode ?? 0);
+        // Let the event loop drain pending writes, then exit
+        setTimeout(() => process.exit(process.exitCode ?? 0), 100);
       }
     );
 };


### PR DESCRIPTION
Fixes empty stdout in E2E tests. setTimeout(100ms) lets event loop drain before process.exit.