### PR TITLE
fix: auto-prepend https:// to --hub URL in login

### DIFF
--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -106,6 +106,24 @@ describe('login command', () => {
         })
       );
     });
+
+    it('auto-prepends https:// when protocol is missing', async () => {
+      await program.parseAsync([
+        'node',
+        'agentage',
+        'login',
+        '--hub',
+        'dev.agentage.io',
+        '--token',
+        'tk',
+      ]);
+
+      expect(mockSaveAuth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hub: expect.objectContaining({ url: 'https://dev.agentage.io' }),
+        })
+      );
+    });
   });
 
   describe('browser mode', () => {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -17,7 +17,7 @@ export const registerLogin = (program: Command): void => {
     .action(async (opts: { hub: string; token?: string }) => {
       await ensureDaemon();
 
-      const hubUrl = opts.hub;
+      const hubUrl = opts.hub.startsWith('http') ? opts.hub : `https://${opts.hub}`;
 
       if (opts.token) {
         // Direct token mode — for headless/CI


### PR DESCRIPTION
## Summary
- `agentage login --hub dev.agentage.io` was broken — bare domain passed as-is to `open()`, which didn't treat it as a URL
- Now auto-prepends `https://` when the `--hub` value has no protocol prefix
- Added test for the bare domain case

## Test plan
- [x] `npm run verify` — 251 tests, type-check, lint, build all pass
- [x] Manual test: `agentage login --hub dev.agentage.io` opens browser correctly