### PR TITLE
feat: show discovery dirs in status, add --add-dir/--remove-dir

### DIFF
--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -13,17 +13,45 @@ vi.mock('../daemon/daemon.js', () => ({
   getDaemonPid: vi.fn(),
 }));
 
+vi.mock('../daemon/config.js', () => ({
+  loadConfig: vi.fn(),
+  saveConfig: vi.fn(),
+}));
+
 import { get } from '../utils/daemon-client.js';
 import { getDaemonPid } from '../daemon/daemon.js';
+import { loadConfig, saveConfig } from '../daemon/config.js';
 import { registerStatus } from './status.js';
 
 const mockGet = vi.mocked(get);
 const mockGetDaemonPid = vi.mocked(getDaemonPid);
+const mockLoadConfig = vi.mocked(loadConfig);
+const mockSaveConfig = vi.mocked(saveConfig);
 
 describe('status command', () => {
   let program: Command;
   let logs: string[];
   const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+  const defaultConfig = {
+    machine: { id: 'machine-123', name: 'test-host' },
+    daemon: { port: 4243 },
+    discovery: {
+      dirs: ['/home/user/.agentage/agents', '/home/user/.agentage/skills'],
+    },
+    sync: {
+      events: {
+        state: true,
+        result: true,
+        error: true,
+        input_required: true,
+        'output.llm.delta': true,
+        'output.llm.tool_call': true,
+        'output.llm.usage': true,
+        'output.progress': true,
+      },
+    },
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -31,6 +59,7 @@ describe('status command', () => {
     vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
       logs.push(args.map(String).join(' '));
     });
+    mockLoadConfig.mockReturnValue(structuredClone(defaultConfig));
 
     program = new Command();
     program.exitOverride();
@@ -119,5 +148,70 @@ describe('status command', () => {
     await program.parseAsync(['node', 'agentage', 'status']);
 
     expect(logs.some((l) => l.includes('45s'))).toBe(true);
+  });
+
+  it('displays discovery directories in status output', async () => {
+    mockGet.mockImplementation(async (path: string) => {
+      if (path === '/api/health') return baseHealth;
+      return [];
+    });
+    mockGetDaemonPid.mockReturnValue(42);
+
+    await program.parseAsync(['node', 'agentage', 'status']);
+
+    expect(logs.some((l) => l.includes('Discovery:'))).toBe(true);
+    expect(logs.some((l) => l.includes('/home/user/.agentage/agents'))).toBe(true);
+    expect(logs.some((l) => l.includes('/home/user/.agentage/skills'))).toBe(true);
+  });
+
+  it('--add-dir adds a new directory to config', async () => {
+    await program.parseAsync(['node', 'agentage', 'status', '--add-dir', '/tmp/new-agents']);
+
+    expect(mockSaveConfig).toHaveBeenCalledTimes(1);
+    const savedConfig = mockSaveConfig.mock.calls[0]![0];
+    expect(savedConfig.discovery.dirs).toContain('/tmp/new-agents');
+    expect(logs.some((l) => l.includes('Added discovery directory'))).toBe(true);
+    expect(mockExit).toHaveBeenCalledWith(0);
+  });
+
+  it('--add-dir with duplicate path does not add twice', async () => {
+    await program.parseAsync([
+      'node',
+      'agentage',
+      'status',
+      '--add-dir',
+      '/home/user/.agentage/agents',
+    ]);
+
+    expect(mockSaveConfig).not.toHaveBeenCalled();
+    expect(logs.some((l) => l.includes('already in discovery'))).toBe(true);
+    expect(mockExit).toHaveBeenCalledWith(0);
+  });
+
+  it('--remove-dir removes a directory from config', async () => {
+    await program.parseAsync([
+      'node',
+      'agentage',
+      'status',
+      '--remove-dir',
+      '/home/user/.agentage/agents',
+    ]);
+
+    expect(mockSaveConfig).toHaveBeenCalledTimes(1);
+    const savedConfig = mockSaveConfig.mock.calls[0]![0];
+    expect(savedConfig.discovery.dirs).not.toContain('/home/user/.agentage/agents');
+    expect(savedConfig.discovery.dirs).toContain('/home/user/.agentage/skills');
+    expect(logs.some((l) => l.includes('Removed discovery directory'))).toBe(true);
+    expect(mockExit).toHaveBeenCalledWith(0);
+  });
+
+  it('--remove-dir with non-existent path is graceful', async () => {
+    await program.parseAsync(['node', 'agentage', 'status', '--remove-dir', '/nonexistent/path']);
+
+    expect(mockSaveConfig).toHaveBeenCalledTimes(1);
+    const savedConfig = mockSaveConfig.mock.calls[0]![0];
+    expect(savedConfig.discovery.dirs).toHaveLength(2);
+    expect(logs.some((l) => l.includes('Removed discovery directory'))).toBe(true);
+    expect(mockExit).toHaveBeenCalledWith(0);
   });
 });

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,8 +1,10 @@
 import { type Command } from 'commander';
+import { resolve } from 'node:path';
 import chalk from 'chalk';
 import { ensureDaemon } from '../utils/ensure-daemon.js';
 import { get } from '../utils/daemon-client.js';
 import { getDaemonPid } from '../daemon/daemon.js';
+import { loadConfig, saveConfig } from '../daemon/config.js';
 
 interface HealthResponse {
   status: string;
@@ -18,7 +20,19 @@ export const registerStatus = (program: Command): void => {
   program
     .command('status')
     .description('Show daemon and connection status')
-    .action(async () => {
+    .option('--add-dir <path>', 'Add directory to agent discovery')
+    .option('--remove-dir <path>', 'Remove directory from agent discovery')
+    .action(async (opts: { addDir?: string; removeDir?: string }) => {
+      if (opts.addDir) {
+        handleAddDir(opts.addDir);
+        return;
+      }
+
+      if (opts.removeDir) {
+        handleRemoveDir(opts.removeDir);
+        return;
+      }
+
       await ensureDaemon();
       const health = await get<HealthResponse>('/api/health');
       const agents = await get<unknown[]>('/api/agents');
@@ -44,8 +58,43 @@ export const registerStatus = (program: Command): void => {
       console.log(`Machine:    ${health.machineId}`);
       console.log(`Agents:     ${agents.length} discovered`);
       console.log(`Runs:       ${activeRuns} active`);
+
+      const config = loadConfig();
+      const dirs = config.discovery.dirs;
+      if (dirs.length > 0) {
+        console.log(`Discovery:  ${dirs[0]}`);
+        for (const dir of dirs.slice(1)) {
+          console.log(`            ${dir}`);
+        }
+      } else {
+        console.log('Discovery:  (none)');
+      }
+
       process.exit(0);
     });
+};
+
+const handleAddDir = (path: string): void => {
+  const absolute = resolve(path);
+  const config = loadConfig();
+  if (config.discovery.dirs.includes(absolute)) {
+    console.log(chalk.yellow(`Directory already in discovery: ${absolute}`));
+    process.exit(0);
+    return;
+  }
+  config.discovery.dirs.push(absolute);
+  saveConfig(config);
+  console.log(chalk.green(`Added discovery directory: ${absolute}`));
+  process.exit(0);
+};
+
+const handleRemoveDir = (path: string): void => {
+  const absolute = resolve(path);
+  const config = loadConfig();
+  config.discovery.dirs = config.discovery.dirs.filter((d) => d !== absolute);
+  saveConfig(config);
+  console.log(chalk.green(`Removed discovery directory: ${absolute}`));
+  process.exit(0);
 };
 
 const formatUptime = (seconds: number): string => {


### PR DESCRIPTION
## Summary
- Display configured discovery directories in `agentage status` output after Agents/Runs
- Add `--add-dir <path>` flag to add a directory to `config.discovery.dirs` (deduplicates)
- Add `--remove-dir <path>` flag to remove a directory from `config.discovery.dirs`
- Both flags work without the daemon running (handled before health check)
- 5 new tests covering: display, add, add-duplicate, remove, remove-nonexistent

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npx vitest run src/commands/status.test.ts` — all 10 tests pass (5 existing + 5 new)
- [x] `npm run lint` passes
- [x] `npx prettier --check` passes