### PR TITLE
feat: agent DX quick wins — create defaults, load warnings, markdown LLM

### DIFF
--- a/src/commands/agents.ts
+++ b/src/commands/agents.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import { type AgentManifest } from '@agentage/core';
 import { ensureDaemon } from '../utils/ensure-daemon.js';
 import { get, post } from '../utils/daemon-client.js';
+import { type ScanWarning } from '../discovery/scanner.js';
 
 interface HubAgent {
   name: string;
@@ -58,6 +59,19 @@ export const registerAgents = (program: Command): void => {
       }
 
       console.log(chalk.dim(`\n${agents.length} agents discovered`));
+
+      try {
+        const warnings = await get<ScanWarning[]>('/api/agents/warnings');
+        if (warnings.length > 0) {
+          console.log(chalk.yellow(`\n⚠ Failed to load ${warnings.length} agent(s):`));
+          for (const w of warnings) {
+            console.log(chalk.yellow(`  ${w.file}`));
+            console.log(chalk.dim(`    ${w.message}`));
+          }
+        }
+      } catch {
+        // Daemon may not support warnings endpoint yet
+      }
     });
 };
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { Command } from 'commander';
 import chalk from 'chalk';
+import { loadConfig } from '../daemon/config.js';
 
 const TEMPLATES: Record<string, { content: (name: string) => string; deps?: string[] }> = {
   simple: {
@@ -75,13 +76,22 @@ Respond concisely and cite sources when possible.\`,
 
 const KEBAB_CASE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
 
+const getDefaultAgentsDir = (): string => {
+  try {
+    const config = loadConfig();
+    return config.discovery.dirs[0] ?? join(process.env['HOME'] || '~', '.agentage', 'agents');
+  } catch {
+    return join(process.env['HOME'] || '~', '.agentage', 'agents');
+  }
+};
+
 export const createCreateCommand = (): Command => {
   const cmd = new Command('create')
     .description('Scaffold a new agent from a template')
     .argument('<name>', 'Agent name (kebab-case)')
     .option('-t, --template <template>', 'Template: simple, shell, claude, copilot, llm', 'simple')
-    .option('-d, --dir <dir>', 'Output directory', '.')
-    .action(async (name: string, options: { template: string; dir: string }) => {
+    .option('-d, --dir <dir>', 'Output directory (default: first discovery dir)')
+    .action(async (name: string, options: { template: string; dir?: string }) => {
       if (!KEBAB_CASE.test(name)) {
         console.error(chalk.red(`Invalid name "${name}". Use kebab-case (e.g. my-agent).`));
         process.exitCode = 1;
@@ -99,7 +109,7 @@ export const createCreateCommand = (): Command => {
         return;
       }
 
-      const dir = resolve(options.dir);
+      const dir = resolve(options.dir ?? getDefaultAgentsDir());
       const filePath = join(dir, `${name}.agent.ts`);
 
       if (existsSync(filePath)) {
@@ -118,9 +128,19 @@ export const createCreateCommand = (): Command => {
         );
       }
 
-      console.log(
-        chalk.dim(`\nTo use:\n  cp ${filePath} ~/.agentage/agents/\n  agentage agents --refresh`)
+      const config = loadConfig();
+      const isInDiscoveryDir = config.discovery.dirs.some((d) =>
+        dir.startsWith(d.replace(/^~/, process.env['HOME'] || '~'))
       );
+
+      if (isInDiscoveryDir) {
+        console.log(chalk.dim(`\nAgent will be auto-discovered by daemon.`));
+        console.log(chalk.dim(`Run: agentage run ${name} "your prompt"`));
+      } else {
+        console.log(
+          chalk.dim(`\nTo use:\n  cp ${filePath} ~/.agentage/agents/\n  agentage agents --refresh`)
+        );
+      }
     });
 
   return cmd;

--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -5,6 +5,7 @@ import { cancelRun, getRun, getRuns, sendInput, startRun } from './run-manager.j
 import { getHubSync } from '../hub/hub-sync.js';
 import { readAuth } from '../hub/auth.js';
 import { createHubClient } from '../hub/hub-client.js';
+import { getLastScanWarnings } from '../discovery/scanner.js';
 
 import { VERSION } from '../utils/version.js';
 
@@ -45,6 +46,10 @@ export const createRoutes = (): Router => {
 
   router.get('/api/agents', (_req, res) => {
     res.json(agents.map((a) => a.manifest));
+  });
+
+  router.get('/api/agents/warnings', (_req, res) => {
+    res.json(getLastScanWarnings());
   });
 
   router.post('/api/agents/refresh', async (_req, res) => {

--- a/src/discovery/markdown-factory.ts
+++ b/src/discovery/markdown-factory.ts
@@ -49,35 +49,63 @@ export const createMarkdownFactory =
       },
       async run(input: RunInput): Promise<AgentProcess> {
         const runId = randomUUID();
-        let canceled = false;
+        const controller = new AbortController();
 
         async function* generateEvents(): AsyncIterable<RunEvent> {
-          yield {
-            type: 'output',
-            data: { type: 'output', content: systemPrompt, format: 'text' },
-            timestamp: Date.now(),
-          };
-
-          if (!canceled) {
+          if (fm.model) {
+            try {
+              const { claude } = await import('@agentage/core');
+              yield* claude(input.task, {
+                signal: controller.signal,
+                systemPrompt,
+                model: fm.model,
+              });
+            } catch {
+              yield {
+                type: 'error',
+                data: {
+                  type: 'error',
+                  code: 'LLM_UNAVAILABLE',
+                  message:
+                    'Claude adapter not available. Install @anthropic-ai/claude-agent-sdk and set ANTHROPIC_API_KEY.',
+                  recoverable: false,
+                },
+                timestamp: Date.now(),
+              };
+              yield {
+                type: 'result',
+                data: { type: 'result', success: false, output: 'LLM adapter not available' },
+                timestamp: Date.now(),
+              };
+            }
+          } else {
             yield {
               type: 'output',
-              data: { type: 'output', content: `\nTask: ${input.task}`, format: 'text' },
+              data: { type: 'output', content: systemPrompt, format: 'text' },
+              timestamp: Date.now(),
+            };
+
+            if (!controller.signal.aborted) {
+              yield {
+                type: 'output',
+                data: { type: 'output', content: `\nTask: ${input.task}`, format: 'text' },
+                timestamp: Date.now(),
+              };
+            }
+
+            yield {
+              type: 'result',
+              data: { type: 'result', success: true, output: 'Agent execution complete' },
               timestamp: Date.now(),
             };
           }
-
-          yield {
-            type: 'result',
-            data: { type: 'result', success: true, output: 'Agent execution complete' },
-            timestamp: Date.now(),
-          };
         }
 
         return {
           runId,
           events: generateEvents(),
           cancel: () => {
-            canceled = true;
+            controller.abort();
           },
           sendInput: () => {
             // No-op for markdown agents

--- a/src/discovery/scanner.ts
+++ b/src/discovery/scanner.ts
@@ -3,6 +3,20 @@ import { join } from 'node:path';
 import { type Agent, type AgentFactory } from '@agentage/core';
 import { logDebug, logInfo, logWarn } from '../daemon/logger.js';
 
+export interface ScanWarning {
+  file: string;
+  message: string;
+}
+
+export interface ScanResult {
+  agents: Agent[];
+  warnings: ScanWarning[];
+}
+
+let lastWarnings: ScanWarning[] = [];
+
+export const getLastScanWarnings = (): ScanWarning[] => lastWarnings;
+
 const getAllFiles = (dir: string): string[] => {
   const results: string[] = [];
 
@@ -25,6 +39,7 @@ const getAllFiles = (dir: string): string[] => {
 
 export const scanAgents = async (dirs: string[], factories: AgentFactory[]): Promise<Agent[]> => {
   const agents: Agent[] = [];
+  const warnings: ScanWarning[] = [];
   const seen = new Set<string>();
 
   for (const dir of dirs) {
@@ -45,11 +60,13 @@ export const scanAgents = async (dirs: string[], factories: AgentFactory[]): Pro
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : String(err);
           logWarn(`Factory error on ${file}: ${message}`);
+          warnings.push({ file, message });
         }
       }
     }
   }
 
-  logInfo(`Scan complete: ${agents.length} agent(s) found`);
+  lastWarnings = warnings;
+  logInfo(`Scan complete: ${agents.length} agent(s) found, ${warnings.length} warning(s)`);
   return agents;
 };


### PR DESCRIPTION
## Summary

- `agentage create` defaults output to first discovery dir (eliminates manual `cp` + `--refresh`)
- Smart post-create message: detects if output dir is in discovery, shows `agentage run` instead of `cp` instructions
- Scanner collects agent load errors, exposed via `GET /api/agents/warnings`
- `agentage agents` prints load warnings after the agent table (no more silent failures)
- Markdown agents call `claude()` adapter when `model` is set in frontmatter (graceful fallback if SDK/key missing)

## Test plan

- [x] `npm run verify` — type-check + lint + 319 tests + build all pass
- [ ] `agentage create test-simple` → file created in `~/.agentage/agents/`, message says "auto-discovered"
- [ ] `agentage create test-cwd -d .` → file in cwd, message says "cp to..."
- [ ] Place a broken `.agent.ts` in discovery dir → `agentage agents` shows warning
- [ ] Create `.agent.md` with `model: claude-sonnet-4-6` → `agentage run` calls Claude