### PR TITLE
test: unit tests for agent DX quick wins (QW1-4)

### DIFF
--- a/src/commands/create.test.ts
+++ b/src/commands/create.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 const testDir = join(tmpdir(), `agentage-test-create-${Date.now()}`);
+const configDir = join(testDir, '.agentage');
 
 describe('create command', () => {
   beforeEach(() => {
@@ -82,5 +83,90 @@ describe('create command', () => {
     await cmd2.parseAsync(['node', 'test', 'existing', '--dir', testDir]);
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
+  });
+
+  // ─── QW-1: defaults to discovery dir ───────────────────────
+
+  it('defaults to first discovery dir when no --dir given', async () => {
+    // Set up config with discovery dirs
+    const agentsDir = join(configDir, 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+    process.env['AGENTAGE_CONFIG_DIR'] = configDir;
+    writeFileSync(
+      join(configDir, 'config.json'),
+      JSON.stringify({
+        machine: { id: 'test', name: 'test' },
+        daemon: { port: 4243 },
+        discovery: { dirs: [agentsDir] },
+        sync: { events: {} },
+      })
+    );
+
+    const { createCreateCommand } = await import('./create.js');
+    const cmd = createCreateCommand();
+    await cmd.parseAsync(['node', 'test', 'default-dir-agent']);
+
+    expect(existsSync(join(agentsDir, 'default-dir-agent.agent.ts'))).toBe(true);
+    delete process.env['AGENTAGE_CONFIG_DIR'];
+  });
+
+  // ─── QW-2: smart post-create message ───────────────────────
+
+  it('shows auto-discovered message when created in discovery dir', async () => {
+    const agentsDir = join(configDir, 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+    process.env['AGENTAGE_CONFIG_DIR'] = configDir;
+    writeFileSync(
+      join(configDir, 'config.json'),
+      JSON.stringify({
+        machine: { id: 'test', name: 'test' },
+        daemon: { port: 4243 },
+        discovery: { dirs: [agentsDir] },
+        sync: { events: {} },
+      })
+    );
+
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { createCreateCommand } = await import('./create.js');
+    const cmd = createCreateCommand();
+    await cmd.parseAsync(['node', 'test', 'auto-agent', '--dir', agentsDir]);
+
+    const output = spy.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('auto-discovered');
+    expect(output).toContain('agentage run auto-agent');
+    expect(output).not.toContain('cp ');
+
+    spy.mockRestore();
+    delete process.env['AGENTAGE_CONFIG_DIR'];
+  });
+
+  it('shows cp instructions when created outside discovery dir', async () => {
+    const agentsDir = join(configDir, 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+    process.env['AGENTAGE_CONFIG_DIR'] = configDir;
+    writeFileSync(
+      join(configDir, 'config.json'),
+      JSON.stringify({
+        machine: { id: 'test', name: 'test' },
+        daemon: { port: 4243 },
+        discovery: { dirs: [agentsDir] },
+        sync: { events: {} },
+      })
+    );
+
+    const otherDir = join(testDir, 'other');
+    mkdirSync(otherDir, { recursive: true });
+
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { createCreateCommand } = await import('./create.js');
+    const cmd = createCreateCommand();
+    await cmd.parseAsync(['node', 'test', 'other-agent', '--dir', otherDir]);
+
+    const output = spy.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('cp ');
+    expect(output).not.toContain('auto-discovered');
+
+    spy.mockRestore();
+    delete process.env['AGENTAGE_CONFIG_DIR'];
   });
 });

--- a/src/discovery/markdown-factory.test.ts
+++ b/src/discovery/markdown-factory.test.ts
@@ -95,4 +95,53 @@ describe('markdown-factory', () => {
     expect(agent).not.toBeNull();
     expect(agent!.manifest.name).toBe('my-skill');
   });
+
+  // ─── QW-4: markdown agent with model calls LLM ─────────────
+
+  it('agent with model yields error events when SDK missing', async () => {
+    const filePath = join(testDir, 'llm.agent.md');
+    writeFileSync(filePath, '---\nname: llm-test\nmodel: claude-sonnet-4-6\n---\nYou are a test.');
+
+    const { createMarkdownFactory } = await import('./markdown-factory.js');
+    const factory = createMarkdownFactory();
+    const agent = await factory(filePath);
+    expect(agent).not.toBeNull();
+    expect(agent!.manifest.config?.['model']).toBe('claude-sonnet-4-6');
+
+    const process = await agent!.run({ task: 'test prompt' });
+    const events = [];
+    for await (const event of process.events) {
+      events.push(event);
+    }
+
+    // Should get error (no SDK/API key) + result(false), NOT echo of system prompt
+    const errors = events.filter((e) => e.type === 'error');
+    const results = events.filter((e) => e.data.type === 'result');
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(results).toHaveLength(1);
+    expect((results[0].data as { success: boolean }).success).toBe(false);
+  });
+
+  it('agent without model still echoes text', async () => {
+    const filePath = join(testDir, 'echo.agent.md');
+    writeFileSync(filePath, '---\nname: echo-test\n---\nYou are an echo agent.');
+
+    const { createMarkdownFactory } = await import('./markdown-factory.js');
+    const factory = createMarkdownFactory();
+    const agent = await factory(filePath);
+    const process = await agent!.run({ task: 'hello' });
+    const events = [];
+    for await (const event of process.events) {
+      events.push(event);
+    }
+
+    // Should echo system prompt + task as before
+    const outputs = events.filter((e) => e.data.type === 'output');
+    expect(outputs.length).toBeGreaterThanOrEqual(1);
+    expect((outputs[0].data as { content: string }).content).toContain('You are an echo agent');
+
+    const results = events.filter((e) => e.data.type === 'result');
+    expect(results).toHaveLength(1);
+    expect((results[0].data as { success: boolean }).success).toBe(true);
+  });
 });

--- a/src/discovery/scanner.test.ts
+++ b/src/discovery/scanner.test.ts
@@ -87,4 +87,38 @@ describe('scanner', () => {
     const agents = await scanAgents([agentsDir], [factory]);
     expect(agents).toHaveLength(1);
   });
+
+  // ─── QW-3: scan warnings ──────────────────────────────────
+
+  it('collects factory errors as warnings', async () => {
+    const agentsDir = join(testDir, 'agents-warn');
+    mkdirSync(agentsDir, { recursive: true });
+    writeFileSync(join(agentsDir, 'broken.agent.md'), '---\nname: broken\n---\n');
+
+    const throwingFactory: AgentFactory = async (path) => {
+      if (path.endsWith('.agent.md')) throw new Error('Import failed: missing module');
+      return null;
+    };
+
+    const { scanAgents, getLastScanWarnings } = await import('./scanner.js');
+    await scanAgents([agentsDir], [throwingFactory]);
+
+    const warnings = getLastScanWarnings();
+    expect(warnings.length).toBeGreaterThanOrEqual(1);
+    expect(warnings[0].file).toContain('broken.agent.md');
+    expect(warnings[0].message).toContain('Import failed');
+  });
+
+  it('clears warnings on each scan', async () => {
+    const agentsDir = join(testDir, 'agents-clear');
+    mkdirSync(agentsDir, { recursive: true });
+
+    const okFactory: AgentFactory = async () => null;
+
+    const { scanAgents, getLastScanWarnings } = await import('./scanner.js');
+    await scanAgents([agentsDir], [okFactory]);
+
+    const warnings = getLastScanWarnings();
+    expect(warnings).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

Unit tests for the DX quick wins merged in #77.

**7 new tests (319 → 326):**
- QW1: `create` defaults to first discovery dir when no `--dir` given
- QW2: shows "auto-discovered" message in discovery dir, "cp" instructions otherwise
- QW3: scanner collects factory errors as `ScanWarning[]`, clears on each rescan
- QW4: markdown agent with `model` yields error events (no SDK), without `model` echoes text as before

## Test plan

- [x] `npm run verify` — 326 tests pass, type-check + lint + build clean