### PR TITLE
fix: release gate pattern for squash merge

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,8 @@ jobs:
           echo "Commit message: $COMMIT_MSG"
 
           # Match squash merges from release/* branches or release prepare commits
-          if echo "$COMMIT_MSG" | grep -qE "(^Merge pull request .* from .*/release/|^chore: prepare release)"; then
+          # Match: merge commits from release/*, squash merges (PR title "Release v..."), or release prepare commits
+          if echo "$COMMIT_MSG" | grep -qE "(^Merge pull request .* from .*/release/|^Release v|^chore: prepare release)"; then
             echo "is-release=true" >> $GITHUB_OUTPUT
             echo "✅ Release commit detected — proceeding with publish"
           else


### PR DESCRIPTION
## Summary
- Fix release gate in publish.yml to match squash merge commit messages
- Squash merges use PR title as commit message (`Release vX.Y.Z`), not `Merge pull request...`
- Added `^Release v` pattern to the gate check

## Test plan
- [ ] Merge this PR (squash), then trigger release-prepare and verify full flow