### PR TITLE
feat(projects): capture git origin URL on discover/add

### DIFF
--- a/src/commands/projects.test.ts
+++ b/src/commands/projects.test.ts
@@ -250,6 +250,23 @@ describe('projects command', () => {
       expect(parsed.worktrees[0].branch).toBe('main');
       expect(mockExit).toHaveBeenCalledWith(0);
     });
+
+    it('shows remote URL when set', async () => {
+      mockLoadProjects.mockReturnValue([
+        {
+          name: 'cli',
+          path: '/home/user/cli',
+          discovered: true,
+          remote: 'git@github.com:agentage/cli.git',
+        },
+      ]);
+      mockGetWorktrees.mockReturnValue([]);
+
+      await program.parseAsync(['node', 'agentage', 'projects', 'info', 'cli']);
+
+      expect(logs.some((l) => l.includes('git@github.com:agentage/cli.git'))).toBe(true);
+      expect(mockExit).toHaveBeenCalledWith(0);
+    });
   });
 
   describe('prune', () => {

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -84,25 +84,33 @@ const listProjects = (jsonMode: boolean): void => {
     return;
   }
 
+  const hasAnyRemote = enriched.some((p) => p.remote);
   const nameWidth = Math.max(12, ...enriched.map((p) => p.name.length)) + 2;
   const pathWidth = Math.max(12, ...enriched.map((p) => p.path.length)) + 2;
   const sourceWidth = 14;
+  const remoteWidth = hasAnyRemote
+    ? Math.max(8, ...enriched.map((p) => (p.remote ?? '').length)) + 2
+    : 0;
 
-  console.log(
-    chalk.bold('NAME'.padEnd(nameWidth)) +
-      chalk.bold('PATH'.padEnd(pathWidth)) +
-      chalk.bold('SOURCE'.padEnd(sourceWidth)) +
-      chalk.bold('WORKTREES')
-  );
+  const headerParts = [
+    chalk.bold('NAME'.padEnd(nameWidth)),
+    chalk.bold('PATH'.padEnd(pathWidth)),
+    chalk.bold('SOURCE'.padEnd(sourceWidth)),
+  ];
+  if (hasAnyRemote) headerParts.push(chalk.bold('REMOTE'.padEnd(remoteWidth)));
+  headerParts.push(chalk.bold('WORKTREES'));
+  console.log(headerParts.join(''));
 
   for (const p of enriched) {
     const source = p.discovered ? 'discovered' : 'manual';
-    console.log(
-      p.name.padEnd(nameWidth) +
-        chalk.gray(p.path.padEnd(pathWidth)) +
-        source.padEnd(sourceWidth) +
-        String(p.worktrees)
-    );
+    const rowParts = [
+      p.name.padEnd(nameWidth),
+      chalk.gray(p.path.padEnd(pathWidth)),
+      source.padEnd(sourceWidth),
+    ];
+    if (hasAnyRemote) rowParts.push(chalk.cyan((p.remote ?? '').padEnd(remoteWidth)));
+    rowParts.push(String(p.worktrees));
+    console.log(rowParts.join(''));
   }
 
   console.log(chalk.dim(`\n${enriched.length} projects`));
@@ -144,7 +152,8 @@ const handleDiscover = (path?: string): void => {
   } else {
     console.log(chalk.green(`Discovered ${newProjects.length} new project(s):`));
     for (const p of newProjects) {
-      console.log(`  ${p.name} ${chalk.gray(p.path)}`);
+      const remoteSuffix = p.remote ? ` ${chalk.cyan(p.remote)}` : '';
+      console.log(`  ${p.name} ${chalk.gray(p.path)}${remoteSuffix}`);
     }
   }
   process.exit(0);
@@ -172,6 +181,7 @@ const handleInfo = (name: string, jsonMode: boolean): void => {
   console.log(`Name:       ${project.name}`);
   console.log(`Path:       ${project.path}`);
   console.log(`Source:     ${project.discovered ? 'discovered' : 'manual'}`);
+  console.log(`Remote:     ${project.remote ? chalk.cyan(project.remote) : chalk.gray('none')}`);
 
   if (worktrees.length > 0) {
     console.log(`Worktrees:`);

--- a/src/projects/projects.test.ts
+++ b/src/projects/projects.test.ts
@@ -146,6 +146,23 @@ describe('addProject', () => {
     expect(project).toEqual(existing[0]);
     expect(mockWriteFileSync).not.toHaveBeenCalled();
   });
+
+  it('captures origin remote URL when present', () => {
+    mockExistsSync.mockImplementation((p) => {
+      if (String(p).endsWith('projects.json')) return false;
+      if (String(p).endsWith('package.json')) return false;
+      return false;
+    });
+    mockExecSync.mockImplementation((cmd) => {
+      if (String(cmd).includes('git remote get-url origin')) {
+        return 'https://github.com/agentage/cli.git\n';
+      }
+      throw new Error('not expected');
+    });
+
+    const project = addProject('/projects/cli');
+    expect(project.remote).toBe('https://github.com/agentage/cli.git');
+  });
 });
 
 describe('removeProject', () => {
@@ -237,6 +254,68 @@ describe('discoverProjects', () => {
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe('manual');
     expect(result[0].discovered).toBe(false);
+  });
+
+  it('captures origin remote URL on newly-discovered projects', () => {
+    mockExistsSync.mockImplementation((p) => {
+      const s = String(p);
+      if (s.endsWith('projects.json')) return false;
+      if (s === '/root/cli/.git') return true;
+      return false;
+    });
+    mockReaddirSync.mockReturnValue([{ name: 'cli', isDirectory: () => true } as never]);
+    mockStatSync.mockReturnValue({ isDirectory: () => true } as never);
+    mockExecSync.mockImplementation((cmd) => {
+      if (String(cmd).includes('git remote get-url origin')) {
+        return 'git@github.com:agentage/cli.git\n';
+      }
+      throw new Error('not expected');
+    });
+
+    const result = discoverProjects('/root');
+    expect(result).toHaveLength(1);
+    expect(result[0].remote).toBe('git@github.com:agentage/cli.git');
+  });
+
+  it('omits remote when origin is not configured', () => {
+    mockExistsSync.mockImplementation((p) => {
+      const s = String(p);
+      if (s.endsWith('projects.json')) return false;
+      if (s === '/root/local/.git') return true;
+      return false;
+    });
+    mockReaddirSync.mockReturnValue([{ name: 'local', isDirectory: () => true } as never]);
+    mockStatSync.mockReturnValue({ isDirectory: () => true } as never);
+    mockExecSync.mockImplementation(() => {
+      throw new Error('fatal: No such remote');
+    });
+
+    const result = discoverProjects('/root');
+    expect(result).toHaveLength(1);
+    expect(result[0].remote).toBeUndefined();
+  });
+
+  it('backfills remote on existing entries that are missing it', () => {
+    const existing: Project[] = [{ name: 'cli', path: '/root/cli', discovered: true }];
+    mockExistsSync.mockImplementation((p) => {
+      const s = String(p);
+      if (s.endsWith('projects.json')) return true;
+      if (s === '/root/cli/.git') return true;
+      return false;
+    });
+    mockReadFileSync.mockReturnValue(JSON.stringify(existing));
+    mockReaddirSync.mockReturnValue([{ name: 'cli', isDirectory: () => true } as never]);
+    mockStatSync.mockReturnValue({ isDirectory: () => true } as never);
+    mockExecSync.mockImplementation((cmd) => {
+      if (String(cmd).includes('git remote get-url origin')) {
+        return 'https://github.com/agentage/cli.git\n';
+      }
+      throw new Error('not expected');
+    });
+
+    const result = discoverProjects('/root');
+    expect(result).toHaveLength(1);
+    expect(result[0].remote).toBe('https://github.com/agentage/cli.git');
   });
 });
 

--- a/src/projects/projects.ts
+++ b/src/projects/projects.ts
@@ -15,6 +15,8 @@ export interface Project {
   name: string;
   path: string;
   discovered: boolean;
+  /** Git remote origin URL (if the project is a git repo with an origin). */
+  remote?: string;
 }
 
 export interface Worktree {
@@ -52,8 +54,23 @@ const isValidProject = (value: unknown): value is Project => {
   return (
     typeof candidate.name === 'string' &&
     typeof candidate.path === 'string' &&
-    typeof candidate.discovered === 'boolean'
+    typeof candidate.discovered === 'boolean' &&
+    (candidate.remote === undefined || typeof candidate.remote === 'string')
   );
+};
+
+/** Reads the origin remote URL of a git repo. Returns undefined if not a repo or no origin. */
+const getOriginUrl = (projectPath: string): string | undefined => {
+  try {
+    const url = execSync('git remote get-url origin', {
+      cwd: projectPath,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim();
+    return url || undefined;
+  } catch {
+    return undefined;
+  }
 };
 
 export const loadProjects = (): Project[] => {
@@ -90,8 +107,8 @@ export const addProject = (projectPath: string): Project => {
   if (existing) return existing;
 
   const name = deriveNameFromDir(absPath);
-  const discovered = false;
-  const project: Project = { name, path: absPath, discovered };
+  const remote = getOriginUrl(absPath);
+  const project: Project = { name, path: absPath, discovered: false, ...(remote && { remote }) };
   projects.push(project);
   saveProjects(projects);
   return project;
@@ -120,10 +137,19 @@ export const discoverProjects = (rootDir: string): Project[] => {
     if (!existsSync(gitPath)) continue;
     if (!statSync(gitPath).isDirectory()) continue;
 
-    if (projects.some((p) => p.path === dirPath)) continue;
+    const existing = projects.find((p) => p.path === dirPath);
+    if (existing) {
+      // Backfill remote on previously-discovered entries that predate remote capture.
+      if (!existing.remote) {
+        const remote = getOriginUrl(dirPath);
+        if (remote) existing.remote = remote;
+      }
+      continue;
+    }
 
     const name = deriveNameFromDir(dirPath);
-    projects.push({ name, path: dirPath, discovered: true });
+    const remote = getOriginUrl(dirPath);
+    projects.push({ name, path: dirPath, discovered: true, ...(remote && { remote }) });
   }
 
   saveProjects(projects);


### PR DESCRIPTION
## Problem
\`agentage projects discover\` was finding local git repos but **not capturing the \`origin\` remote URL**. So the CLI knew the name and path but had no link to the external repo (GitHub / GitLab). The dashboard and hub couldn't show where a project came from.

## Fix
- Add optional \`remote?: string\` field to the \`Project\` interface
- New helper \`getOriginUrl(path)\` runs \`git remote get-url origin\` with error handling (returns \`undefined\` if not a repo or no origin configured)
- \`addProject\` and \`discoverProjects\` now populate \`remote\` when discovered
- \`discoverProjects\` also **backfills** \`remote\` on existing entries missing it — so running discover again on projects already in the list enriches them without duplication
- Schema validation accepts the new optional field
- \`agentage projects\` list adds a REMOTE column when any project has one
- \`agentage projects info\` adds a Remote line

## Test plan
- [x] Build + lint + format pass
- [x] All 434 tests pass (429 baseline + 5 new)
- [x] New tests cover: capture on new discovery, omit when no origin, backfill on existing, addProject with remote, info display

## Not in this PR
- Backend DB column + heartbeat payload change — separate PR once the CLI data is flowing and we want to persist it to the hub