### PR TITLE
fix(projects): return proper exit codes on error paths

### DIFF
--- a/src/commands/projects.test.ts
+++ b/src/commands/projects.test.ts
@@ -121,7 +121,7 @@ describe('projects command', () => {
       expect(mockExit).toHaveBeenCalledWith(0);
     });
 
-    it('handles errors when adding', async () => {
+    it('handles errors when adding with exit code 1', async () => {
       mockAddProject.mockImplementation(() => {
         throw new Error('Not a git repository');
       });
@@ -129,7 +129,7 @@ describe('projects command', () => {
       await program.parseAsync(['node', 'agentage', 'projects', 'add', '/tmp/bad']);
 
       expect(errorLogs.some((l) => l.includes('Not a git repository'))).toBe(true);
-      expect(mockExit).toHaveBeenCalledWith(0);
+      expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
@@ -144,13 +144,13 @@ describe('projects command', () => {
       expect(mockExit).toHaveBeenCalledWith(0);
     });
 
-    it('reports not found', async () => {
+    it('reports not found with exit code 1', async () => {
       mockRemoveProject.mockReturnValue(false);
 
       await program.parseAsync(['node', 'agentage', 'projects', 'remove', 'nonexistent']);
 
       expect(errorLogs.some((l) => l.includes('Project not found: nonexistent'))).toBe(true);
-      expect(mockExit).toHaveBeenCalledWith(0);
+      expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
@@ -217,13 +217,13 @@ describe('projects command', () => {
       expect(mockExit).toHaveBeenCalledWith(0);
     });
 
-    it('shows not found for unknown project', async () => {
+    it('shows not found for unknown project with exit code 1', async () => {
       mockLoadProjects.mockReturnValue([]);
 
       await program.parseAsync(['node', 'agentage', 'projects', 'info', 'nope']);
 
       expect(errorLogs.some((l) => l.includes('Project not found: nope'))).toBe(true);
-      expect(mockExit).toHaveBeenCalledWith(0);
+      expect(mockExit).toHaveBeenCalledWith(1);
     });
 
     it('shows project info with no worktrees', async () => {

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -122,23 +122,23 @@ const handleAdd = (path: string): void => {
   try {
     const project = addProject(absPath);
     console.log(chalk.green(`Added project: ${project.name} (${project.path})`));
+    process.exit(0);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(chalk.red(`Failed to add project: ${message}`));
-    process.exitCode = 1;
+    process.exit(1);
   }
-  process.exit(0);
 };
 
 const handleRemove = (name: string): void => {
   const removed = removeProject(name);
   if (removed) {
     console.log(chalk.green(`Removed project: ${name}`));
+    process.exit(0);
   } else {
     console.error(chalk.red(`Project not found: ${name}`));
-    process.exitCode = 1;
+    process.exit(1);
   }
-  process.exit(0);
 };
 
 const handleDiscover = (path?: string): void => {
@@ -165,9 +165,8 @@ const handleInfo = (name: string, jsonMode: boolean): void => {
 
   if (!project) {
     console.error(chalk.red(`Project not found: ${name}`));
-    process.exitCode = 1;
-    process.exit(0);
-    return;
+    process.exit(1);
+    return; // unreachable at runtime, needed so TS narrows `project` below
   }
 
   const worktrees = getWorktrees(project.path);


### PR DESCRIPTION
## Problem
\`handleAdd\`, \`handleRemove\`, and \`handleInfo\` each did:

\`\`\`typescript
process.exitCode = 1;
process.exit(0);  // ← this overrides exitCode, so shell sees 0
\`\`\`

So scripts piping \`agentage projects remove nope\` or \`agentage projects info nope\` saw success even when the project didn't exist. Discovered by the e2e test suite (PR 7) — the P13 test for 'info not-found' had to be softened to avoid this bug.

## Fix
- Call \`process.exit(1)\` directly on error branches, \`process.exit(0)\` on success branches
- \`handleInfo\` also needs a \`return;\` after \`process.exit(1)\` so tests mocking \`process.exit\` don't fall through and crash on \`getWorktrees(project.path)\` with \`project === undefined\`
- Updated 3 existing tests to assert exit code 1 on error paths

## Test plan
- [x] Build passes
- [x] Lint + format pass
- [x] All unit tests pass (the 3 updated assertions now expect exit 1)
- [x] Pre-existing \`ensure-daemon.test.ts\` flakiness unchanged (unrelated to this PR)