### PR TITLE
fix(hub-sync): include discovered and remote in heartbeat payload

### DIFF
--- a/src/hub/hub-client.ts
+++ b/src/hub/hub-client.ts
@@ -13,7 +13,7 @@ export interface HubClient {
     machineId: string,
     data: {
       agents: Array<{ name: string; description?: string; version?: string; tags?: string[] }>;
-      projects?: Array<{ name: string; path: string }>;
+      projects?: Array<{ name: string; path: string; discovered?: boolean; remote?: string }>;
       activeRunIds: string[];
       daemonVersion: string;
     }

--- a/src/hub/hub-sync.test.ts
+++ b/src/hub/hub-sync.test.ts
@@ -201,7 +201,12 @@ describe('hub-sync', () => {
       ] as ReturnType<typeof getRuns>);
       mockLoadProjects.mockReturnValue([
         { name: 'proj-a', path: '/home/user/proj-a', discovered: false },
-        { name: 'proj-b', path: '/home/user/proj-b', discovered: true },
+        {
+          name: 'proj-b',
+          path: '/home/user/proj-b',
+          discovered: true,
+          remote: 'https://github.com/example/proj-b.git',
+        },
       ]);
 
       const sync = createHubSync();
@@ -211,8 +216,13 @@ describe('hub-sync', () => {
       expect(mockHubClient.heartbeat).toHaveBeenCalledWith('machine-1', {
         agents: [{ name: 'hello', description: 'Hi', version: '1.0', tags: ['chat'] }],
         projects: [
-          { name: 'proj-a', path: '/home/user/proj-a' },
-          { name: 'proj-b', path: '/home/user/proj-b' },
+          { name: 'proj-a', path: '/home/user/proj-a', discovered: false },
+          {
+            name: 'proj-b',
+            path: '/home/user/proj-b',
+            discovered: true,
+            remote: 'https://github.com/example/proj-b.git',
+          },
         ],
         activeRunIds: ['run-1'],
         daemonVersion: '0.7.1',

--- a/src/hub/hub-sync.ts
+++ b/src/hub/hub-sync.ts
@@ -82,7 +82,12 @@ export const createHubSync = (): HubSync => {
       tags: a.manifest.tags,
     }));
 
-    const projects = loadProjects().map((p) => ({ name: p.name, path: p.path }));
+    const projects = loadProjects().map((p) => ({
+      name: p.name,
+      path: p.path,
+      discovered: p.discovered,
+      ...(p.remote && { remote: p.remote }),
+    }));
 
     const activeRunIds = getRuns()
       .filter((r) => r.state === 'working' || r.state === 'submitted')


### PR DESCRIPTION
## Problem
Discovered by the e2e connected test suite (agentage/e2e#30 — PS2).

The heartbeat was stripping \`discovered\` and \`remote\` when mapping projects to the payload:

\`\`\`typescript
const projects = loadProjects().map((p) => ({ name: p.name, path: p.path }));
//                                  ^^^^ drops discovered + remote
\`\`\`

So the hub always saw every project with \`discovered: true\` (backend default) regardless of whether the user discovered it or added it manually, and the origin URL was never persisted.

## Impact
- Dashboard projects list filter "discovered vs manual" is broken — all manually-added projects show as discovered
- Dashboard projects REMOTE column (agentage/web#128) would stay empty even though CLI captures the URL
- E2E PS2 test fails: \`expect(manual!.discovered).toBe(false)\` — received \`true\`

## Fix
Pass \`discovered\` unconditionally, \`remote\` when set:

\`\`\`typescript
const projects = loadProjects().map((p) => ({
  name: p.name,
  path: p.path,
  discovered: p.discovered,
  ...(p.remote && { remote: p.remote }),
}));
\`\`\`

Also updated \`hub-client.ts\` type and tightened the \`hub-sync.test.ts\` heartbeat assertion to verify both fields round-trip.

## Depends on
Backend needs to accept \`discovered\`/\`remote\` in the heartbeat schema. agentage/web#126 already accepts \`discovered\`. agentage/web#128 adds \`remote\`. Both need to be live before this PR ships to production — but this PR is backward compatible (extra fields are ignored if backend doesn't know them).

## Test plan
- [x] Build + lint + format pass
- [x] Existing hub-sync heartbeat test tightened to assert \`discovered\` + \`remote\` flow through
- [x] All unit tests pass