### PR TITLE
feat(run): standalone file-path mode for agent run

### DIFF
--- a/src/commands/run.test.ts
+++ b/src/commands/run.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Command } from 'commander';
 import { EventEmitter } from 'node:events';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { type WebSocket } from 'ws';
 
 vi.mock('../utils/ensure-daemon.js', () => ({
@@ -442,6 +445,71 @@ describe('run command', () => {
 
       expect(logs.some((l) => l.includes('"type":"output"'))).toBe(true);
       expect(mockRenderEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('standalone path run', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'agentage-run-test-'));
+      vi.useRealTimers();
+    });
+
+    const cleanup = (): void => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    };
+
+    it('runs a markdown agent from a direct path', async () => {
+      const agentPath = join(tmpDir, 'hello.agent.md');
+      writeFileSync(
+        agentPath,
+        `---\nname: hello\ndescription: test agent\n---\n\nYou are a helpful assistant.\n`
+      );
+
+      await program.parseAsync(['node', 'agentage', 'run', agentPath, 'do stuff']);
+
+      expect(mockRenderEvent).toHaveBeenCalled();
+      const eventTypes = mockRenderEvent.mock.calls.map((c) => c[0].data.type);
+      expect(eventTypes).toContain('output');
+      expect(eventTypes).toContain('result');
+      expect(process.exitCode === undefined || process.exitCode === 0).toBe(true);
+      cleanup();
+    });
+
+    it('exits 1 on missing file', async () => {
+      const missing = join(tmpDir, 'nope.agent.md');
+
+      await program.parseAsync(['node', 'agentage', 'run', missing, 'do stuff']);
+
+      expect(errorLogs.some((l) => l.includes('not found'))).toBe(true);
+      expect(process.exitCode).toBe(1);
+      process.exitCode = undefined;
+      cleanup();
+    });
+
+    it('exits 1 when file is not a recognized agent', async () => {
+      const bad = join(tmpDir, 'bad.md');
+      writeFileSync(bad, 'just a random markdown file');
+
+      await program.parseAsync(['node', 'agentage', 'run', bad, 'do stuff']);
+
+      expect(errorLogs.some((l) => l.includes('not a recognized agent'))).toBe(true);
+      expect(process.exitCode).toBe(1);
+      process.exitCode = undefined;
+      cleanup();
+    });
+
+    it('errors when --detach is used with a path', async () => {
+      const agentPath = join(tmpDir, 'hello.agent.md');
+      writeFileSync(agentPath, `---\nname: hello\n---\n\nsystem prompt\n`);
+
+      await program.parseAsync(['node', 'agentage', 'run', agentPath, 'do stuff', '-d']);
+
+      expect(errorLogs.some((l) => l.includes('--detach requires a daemon'))).toBe(true);
+      expect(process.exitCode).toBe(1);
+      process.exitCode = undefined;
+      cleanup();
     });
   });
 });

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,10 +1,15 @@
+import { existsSync } from 'node:fs';
+import { resolve as resolvePath } from 'node:path';
+import { homedir } from 'node:os';
 import { type Command } from 'commander';
 import chalk from 'chalk';
-import { type RunEvent } from '@agentage/core';
+import { type Agent, type RunEvent, type RunInput } from '@agentage/core';
 import { ensureDaemon } from '../utils/ensure-daemon.js';
 import { connectWs, get, post } from '../utils/daemon-client.js';
 import { renderEvent } from '../utils/render.js';
 import { loadProjects, resolveProject } from '../projects/projects.js';
+import { createMarkdownFactory } from '../discovery/markdown-factory.js';
+import { createCodeFactory } from '../discovery/code-factory.js';
 
 interface RunResponse {
   runId: string;
@@ -24,6 +29,17 @@ interface WsRunStateMessage {
 type WsMessage = WsRunEventMessage | WsRunStateMessage;
 
 const TERMINAL_STATES = ['completed', 'failed', 'canceled'];
+
+const isAgentPath = (input: string): boolean => {
+  if (input.includes('/')) return true;
+  if (/\.(agent\.md|agent\.ts|agent\.js|md|ts|js)$/.test(input)) return true;
+  return false;
+};
+
+const expandPath = (input: string): string => {
+  if (input.startsWith('~')) return resolvePath(homedir(), input.slice(1).replace(/^\/+/, ''));
+  return resolvePath(input);
+};
 
 const parseAgentTarget = (input: string): { agentName: string; machineName?: string } => {
   const atIndex = input.lastIndexOf('@');
@@ -59,13 +75,28 @@ export const registerRun = (program: Command): void => {
           project?: string;
         }
       ) => {
-        await ensureDaemon();
-
         if (!prompt) {
           console.error(chalk.red('Prompt is required. Usage: agentage run <agent> "<prompt>"'));
           process.exitCode = 1;
           return;
         }
+
+        if (isAgentPath(agent)) {
+          if (opts.detach) {
+            console.error(
+              chalk.red(
+                '--detach requires a daemon. Omit --detach for standalone file runs, or register this agent in a discovery dir.'
+              )
+            );
+            process.exitCode = 1;
+            return;
+          }
+          await runStandalone(expandPath(agent), prompt, opts);
+          setTimeout(() => process.exit(process.exitCode ?? 0), 100);
+          return;
+        }
+
+        await ensureDaemon();
 
         const { agentName, machineName } = parseAgentTarget(agent);
         const project = resolveProject(opts.project, loadProjects());
@@ -241,5 +272,90 @@ const pollRemoteRun = async (runId: string, jsonMode: boolean): Promise<void> =>
     const done = await poll();
     if (done) break;
     await new Promise((r) => setTimeout(r, pollInterval));
+  }
+};
+
+const loadAgentFromPath = async (filePath: string): Promise<Agent | null> => {
+  const markdownFactory = createMarkdownFactory();
+  const codeFactory = createCodeFactory();
+  const md = await markdownFactory(filePath);
+  if (md) return md;
+  const code = await codeFactory(filePath);
+  if (code) return code;
+  return null;
+};
+
+const runStandalone = async (
+  filePath: string,
+  prompt: string,
+  opts: { json?: boolean; config?: string; context?: string[] }
+): Promise<void> => {
+  if (!existsSync(filePath)) {
+    console.error(chalk.red(`Agent file not found: ${filePath}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  let agent: Agent | null;
+  try {
+    agent = await loadAgentFromPath(filePath);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(chalk.red(`Failed to load agent: ${message}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!agent) {
+    console.error(
+      chalk.red(
+        `File is not a recognized agent: ${filePath} (expected .agent.md, .agent.ts, .agent.js, or SKILL.md)`
+      )
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const config = opts.config ? (JSON.parse(opts.config) as Record<string, unknown>) : undefined;
+  const input: RunInput = { task: prompt, config, context: opts.context };
+
+  let proc;
+  try {
+    proc = await agent.run(input);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(chalk.red(`Agent execution failed: ${message}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  const onSigint = (): void => {
+    proc.cancel();
+  };
+  process.on('SIGINT', onSigint);
+
+  try {
+    for await (const event of proc.events as AsyncIterable<RunEvent>) {
+      if (opts.json) {
+        console.log(JSON.stringify(event));
+      } else {
+        renderEvent(event);
+      }
+      if (event.data.type === 'error') {
+        process.exitCode = 1;
+      }
+      if (event.data.type === 'result' && event.data.success === false) {
+        process.exitCode = 1;
+      }
+      if (event.data.type === 'state' && event.data.state === 'failed') {
+        process.exitCode = 1;
+      }
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(chalk.red(`Agent execution error: ${message}`));
+    process.exitCode = 1;
+  } finally {
+    process.off('SIGINT', onSigint);
   }
 };


### PR DESCRIPTION
## Summary

Extends `agentage run` with a **standalone file-path mode**: run a `.agent.md` / `.agent.ts` / `.agent.js` file directly without needing the daemon or a discovery-dir registration. Use cases: PR reviews, fresh clones, CI smoke tests, local iteration before registering an agent.

Implements the plan at `projects/inbox/agent-run-standalone-plan.md`. The existing named-agent flow (`agentage run hello \"...\"`) is untouched.

## Changes

- `src/commands/run.ts`
  - Path detection: if the arg contains `/` or ends in `.agent.md`/`.agent.ts`/`.agent.js`/`.md`/`.ts`/`.js`, dispatch to `runStandalone()` instead of the daemon flow.
  - `runStandalone()` loads the agent via `createMarkdownFactory` / `createCodeFactory`, iterates `proc.events`, and renders via the existing `renderEvent` (or JSON lines with `--json`).
  - Sets exit code 1 on `error` events, failed `result`, or `failed` state.
  - `--detach` is rejected in path mode with a clear error — detach requires a persistent daemon.
  - `~` expansion for paths.

- `src/commands/run.test.ts` — 4 new tests
  - Runs a markdown agent from a direct path (happy path).
  - Exits 1 on missing file.
  - Exits 1 when file is not a recognized agent.
  - Errors when `--detach` is used with a path.

## Trade-offs (documented in plan)

- Standalone runs are **not persisted** (no daemon = no run history, no hub sync). This is intentional — matches the \"local-only, no login required\" UX.
- `.agent.ts` first-load has `jiti` compile cost; acceptable for standalone.

## Test plan

- [x] `npm run verify` — type-check + lint + format + build + 438 tests passing
- [x] Smoke test against a real markdown agent: `node dist/cli.js run /tmp/smoke.agent.md \"do the thing\"` streams output correctly without daemon
- [x] Missing-file path returns exit 1 with clear error