### PR TITLE
fix(run): allow empty prompt

### DIFF
--- a/src/commands/run.test.ts
+++ b/src/commands/run.test.ts
@@ -76,12 +76,30 @@ describe('run command', () => {
     expect(typeof mod.registerRun).toBe('function');
   });
 
-  it('errors when no prompt provided', async () => {
-    await program.parseAsync(['node', 'agentage', 'run', 'hello']);
+  it('runs with empty task when no prompt provided', async () => {
+    mockPost.mockResolvedValue({ runId: 'run-empty' });
 
-    expect(errorLogs.some((l) => l.includes('Prompt is required'))).toBe(true);
-    expect(process.exitCode).toBe(1);
-    process.exitCode = undefined;
+    const ws = createMockWs();
+    let wsCallback: (data: unknown) => void;
+    mockConnectWs.mockImplementation((cb) => {
+      wsCallback = cb;
+      setTimeout(() => {
+        ws.emit('open');
+        wsCallback({ type: 'run_state', run: { id: 'run-empty', state: 'completed' } });
+      }, 10);
+      return ws;
+    });
+
+    const parsePromise = program.parseAsync(['node', 'agentage', 'run', 'hello']);
+    await vi.advanceTimersByTimeAsync(50);
+    await vi.advanceTimersByTimeAsync(200);
+    await parsePromise;
+
+    expect(errorLogs.some((l) => l.includes('Prompt is required'))).toBe(false);
+    expect(mockPost).toHaveBeenCalledWith(
+      expect.stringContaining('/api/agents/hello/run'),
+      expect.objectContaining({ task: '' })
+    );
   });
 
   describe('local run', () => {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -75,11 +75,7 @@ export const registerRun = (program: Command): void => {
           project?: string;
         }
       ) => {
-        if (!prompt) {
-          console.error(chalk.red('Prompt is required. Usage: agentage run <agent> "<prompt>"'));
-          process.exitCode = 1;
-          return;
-        }
+        const task = prompt ?? '';
 
         if (isAgentPath(agent)) {
           if (opts.detach) {
@@ -91,7 +87,7 @@ export const registerRun = (program: Command): void => {
             process.exitCode = 1;
             return;
           }
-          await runStandalone(expandPath(agent), prompt, opts);
+          await runStandalone(expandPath(agent), task, opts);
           setTimeout(() => process.exit(process.exitCode ?? 0), 100);
           return;
         }
@@ -102,9 +98,9 @@ export const registerRun = (program: Command): void => {
         const project = resolveProject(opts.project, loadProjects());
 
         if (machineName) {
-          await runRemote(agentName, machineName, prompt, opts, project);
+          await runRemote(agentName, machineName, task, opts, project);
         } else {
-          await runLocal(agentName, prompt, opts, project);
+          await runLocal(agentName, task, opts, project);
         }
         // Let the event loop drain pending writes, then exit
         setTimeout(() => process.exit(process.exitCode ?? 0), 100);


### PR DESCRIPTION
## Summary
- **Removed the `Prompt is required` gate** in `agentage run` — an omitted prompt is now passed through as `task: ''` instead of erroring out.
- Agents that consume `--config` or `--context` instead of a task string (deterministic utility agents) now run without a placeholder prompt.
- Behavior for agents that *do* need a task is unchanged — they receive whatever the user typed.

## Context
Some agents are fully deterministic and draw their input from `--config '{...}'` or `--context path.json` rather than a task string. With the old gate, invocation required a dummy placeholder:

```
# before
agentage run my-agent "run"   # dummy required, or errored with "Prompt is required"
# after
agentage run my-agent          # just works; task: '' reaches the agent
```

The CLI spec described interactive mode when prompt is omitted; the implementation simply errored. This aligns reality with agents that genuinely need no prompt. A real interactive mode could be added separately for LLM-style agents.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test` — 438/438 (updated `run.test.ts`: `errors when no prompt provided` → `runs with empty task when no prompt provided`)
- [x] `npm run build`
- [ ] CI passes
- [ ] Post-merge smoke test: `agentage run <no-prompt-agent>` returns expected output without a dummy arg