### PR TITLE
feat: validate agent run inputs against inputSchema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,31 +12,32 @@
         "@agentage/core": "^0.6.0",
         "@agentage/platform": "^0.2.1",
         "@supabase/supabase-js": "2.103.0",
-        "chalk": "*",
-        "commander": "*",
-        "express": "*",
-        "gray-matter": "*",
-        "jiti": "*",
-        "open": "*",
-        "ws": "*"
+        "ajv": "8.18.0",
+        "chalk": "latest",
+        "commander": "latest",
+        "express": "latest",
+        "gray-matter": "latest",
+        "jiti": "latest",
+        "open": "latest",
+        "ws": "latest"
       },
       "bin": {
         "agentage": "dist/cli.js"
       },
       "devDependencies": {
-        "@anthropic-ai/sdk": "*",
-        "@types/express": "*",
-        "@types/node": "*",
-        "@types/ws": "*",
-        "@typescript-eslint/eslint-plugin": "*",
-        "@typescript-eslint/parser": "*",
-        "@vitest/coverage-v8": "*",
-        "eslint": "*",
-        "eslint-config-prettier": "*",
-        "eslint-plugin-prettier": "*",
+        "@anthropic-ai/sdk": "latest",
+        "@types/express": "latest",
+        "@types/node": "latest",
+        "@types/ws": "latest",
+        "@typescript-eslint/eslint-plugin": "latest",
+        "@typescript-eslint/parser": "latest",
+        "@vitest/coverage-v8": "latest",
+        "eslint": "latest",
+        "eslint-config-prettier": "latest",
+        "eslint-plugin-prettier": "latest",
         "prettier": "latest",
-        "typescript": "*",
-        "vitest": "*"
+        "typescript": "latest",
+        "vitest": "latest"
       },
       "engines": {
         "node": ">=22.0.0",
@@ -1334,16 +1335,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-      "dev": true,
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -1877,6 +1877,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
@@ -1899,6 +1916,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "11.2.0",
@@ -2078,7 +2102,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -2101,6 +2124,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2627,10 +2666,9 @@
       }
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -3420,6 +3458,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rolldown": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@agentage/core": "^0.6.0",
     "@agentage/platform": "^0.2.1",
     "@supabase/supabase-js": "2.103.0",
+    "ajv": "8.18.0",
     "chalk": "latest",
     "commander": "latest",
     "express": "latest",

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -3,13 +3,20 @@ import { resolve as resolvePath } from 'node:path';
 import { homedir } from 'node:os';
 import { type Command } from 'commander';
 import chalk from 'chalk';
-import { type Agent, type RunEvent, type RunInput } from '@agentage/core';
+import { type Agent, type AgentManifest, type RunEvent, type RunInput } from '@agentage/core';
 import { ensureDaemon } from '../utils/ensure-daemon.js';
 import { connectWs, get, post } from '../utils/daemon-client.js';
 import { renderEvent } from '../utils/render.js';
 import { loadProjects, resolveProject } from '../projects/projects.js';
 import { createMarkdownFactory } from '../discovery/markdown-factory.js';
 import { createCodeFactory } from '../discovery/code-factory.js';
+import {
+  mergeInputs,
+  parseInputJson,
+  validateInput,
+  type Input,
+  type JsonSchema,
+} from '../utils/schema-input.js';
 
 interface RunResponse {
   runId: string;
@@ -61,6 +68,7 @@ export const registerRun = (program: Command): void => {
     .option('-d, --detach', 'Run in background, print run ID')
     .option('--json', 'Output events as JSON lines')
     .option('--config <json>', 'Per-run config overrides (JSON)')
+    .option('--input <json>', 'Structured input matching the agent inputSchema (JSON object)')
     .option('--context <paths...>', 'Additional context files')
     .option('--project <name-or-path>', 'Project context (name, name:branch, or path)')
     .action(
@@ -71,6 +79,7 @@ export const registerRun = (program: Command): void => {
           detach?: boolean;
           json?: boolean;
           config?: string;
+          input?: string;
           context?: string[];
           project?: string;
         }
@@ -108,13 +117,60 @@ export const registerRun = (program: Command): void => {
     );
 };
 
+const parseJsonOption = (name: string, raw: string | undefined): Input | undefined => {
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error(`${name} must be a JSON object`);
+    }
+    return parsed as Input;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Invalid ${name}: ${message}`);
+  }
+};
+
+const resolveConfig = (
+  opts: { config?: string; input?: string },
+  inputSchema: JsonSchema | undefined
+): Input | undefined => {
+  const fromConfig = parseJsonOption('--config', opts.config);
+  const fromInput = opts.input ? parseInputJson(opts.input) : undefined;
+  const merged = mergeInputs(fromConfig, fromInput);
+  const hasAny = Object.keys(merged).length > 0;
+
+  if (!inputSchema) return hasAny ? merged : undefined;
+
+  const result = validateInput(inputSchema, merged);
+  if (!result.ok) {
+    const detail = result.errors.map((e) => `  • ${e}`).join('\n');
+    throw new Error(`Input does not match agent schema:\n${detail}`);
+  }
+  return Object.keys(result.value).length > 0 ? result.value : undefined;
+};
+
 const runLocal = async (
   agentName: string,
   prompt: string,
-  opts: { detach?: boolean; json?: boolean; config?: string; context?: string[] },
+  opts: { detach?: boolean; json?: boolean; config?: string; input?: string; context?: string[] },
   project?: { name: string; path: string; branch?: string; remote?: string }
 ): Promise<void> => {
-  const config = opts.config ? (JSON.parse(opts.config) as Record<string, unknown>) : undefined;
+  let manifest: AgentManifest | undefined;
+  try {
+    manifest = await get<AgentManifest>(`/api/agents/${agentName}`);
+  } catch {
+    // Older daemon may not expose this endpoint; skip schema validation
+  }
+
+  let config: Input | undefined;
+  try {
+    config = resolveConfig(opts, manifest?.inputSchema);
+  } catch (err) {
+    console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+    process.exitCode = 1;
+    return;
+  }
 
   const { runId } = await post<RunResponse>(`/api/agents/${agentName}/run`, {
     task: prompt,
@@ -284,7 +340,7 @@ const loadAgentFromPath = async (filePath: string): Promise<Agent | null> => {
 const runStandalone = async (
   filePath: string,
   prompt: string,
-  opts: { json?: boolean; config?: string; context?: string[] }
+  opts: { json?: boolean; config?: string; input?: string; context?: string[] }
 ): Promise<void> => {
   if (!existsSync(filePath)) {
     console.error(chalk.red(`Agent file not found: ${filePath}`));
@@ -312,7 +368,14 @@ const runStandalone = async (
     return;
   }
 
-  const config = opts.config ? (JSON.parse(opts.config) as Record<string, unknown>) : undefined;
+  let config: Input | undefined;
+  try {
+    config = resolveConfig(opts, agent.manifest.inputSchema as JsonSchema | undefined);
+  } catch (err) {
+    console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+    process.exitCode = 1;
+    return;
+  }
   const input: RunInput = { task: prompt, config, context: opts.context };
 
   let proc;

--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -54,6 +54,15 @@ export const createRoutes = (): Router => {
     res.json(getLastScanWarnings());
   });
 
+  router.get('/api/agents/:name', (req, res) => {
+    const agent = agents.find((a) => a.manifest.name === req.params.name);
+    if (!agent) {
+      res.status(404).json({ error: `Agent "${req.params.name}" not found` });
+      return;
+    }
+    res.json(agent.manifest);
+  });
+
   router.post('/api/agents/refresh', async (_req, res) => {
     try {
       if (refreshHandler) {

--- a/src/hub/hub-client.ts
+++ b/src/hub/hub-client.ts
@@ -12,7 +12,13 @@ export interface HubClient {
   heartbeat: (
     machineId: string,
     data: {
-      agents: Array<{ name: string; description?: string; version?: string; tags?: string[] }>;
+      agents: Array<{
+        name: string;
+        description?: string;
+        version?: string;
+        tags?: string[];
+        inputSchema?: Record<string, unknown>;
+      }>;
       projects?: Array<{ name: string; path: string; discovered?: boolean; remote?: string }>;
       activeRunIds: string[];
       daemonVersion: string;

--- a/src/hub/hub-sync.test.ts
+++ b/src/hub/hub-sync.test.ts
@@ -229,6 +229,31 @@ describe('hub-sync', () => {
       });
     });
 
+    it('includes inputSchema in agent payload when declared', async () => {
+      mockReadAuth.mockReturnValue(testAuth);
+      const schema = {
+        type: 'object',
+        properties: { prUrl: { type: 'string' } },
+        required: ['prUrl'],
+      };
+      mockGetAgents.mockReturnValue([
+        { manifest: { name: 'pr-reviewer', inputSchema: schema } },
+        { manifest: { name: 'pr-list' } },
+      ] as ReturnType<typeof getAgents>);
+      mockGetRuns.mockReturnValue([] as ReturnType<typeof getRuns>);
+      mockLoadProjects.mockReturnValue([]);
+
+      const sync = createHubSync();
+      await sync.start();
+      await sync.triggerHeartbeat();
+
+      const call = mockHubClient.heartbeat.mock.calls[0][1] as {
+        agents: Array<Record<string, unknown>>;
+      };
+      expect(call.agents[0]).toMatchObject({ name: 'pr-reviewer', inputSchema: schema });
+      expect(call.agents[1]).not.toHaveProperty('inputSchema');
+    });
+
     it('processes pending cancel commands', async () => {
       mockReadAuth.mockReturnValue(testAuth);
       mockHubClient.heartbeat.mockResolvedValue({

--- a/src/hub/hub-sync.ts
+++ b/src/hub/hub-sync.ts
@@ -80,6 +80,7 @@ export const createHubSync = (): HubSync => {
       description: a.manifest.description,
       version: a.manifest.version,
       tags: a.manifest.tags,
+      ...(a.manifest.inputSchema && { inputSchema: a.manifest.inputSchema }),
     }));
 
     const projects = loadProjects().map((p) => ({

--- a/src/utils/schema-input.test.ts
+++ b/src/utils/schema-input.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { mergeInputs, parseInputJson, validateInput } from './schema-input.js';
+
+describe('parseInputJson', () => {
+  it('parses an object', () => {
+    expect(parseInputJson('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('rejects a non-object', () => {
+    expect(() => parseInputJson('42')).toThrow(/must be a JSON object/);
+    expect(() => parseInputJson('[1,2]')).toThrow(/must be a JSON object/);
+    expect(() => parseInputJson('null')).toThrow(/must be a JSON object/);
+  });
+
+  it('rejects malformed JSON', () => {
+    expect(() => parseInputJson('{bad')).toThrow();
+  });
+});
+
+describe('mergeInputs', () => {
+  it('merges in order, later wins', () => {
+    expect(mergeInputs({ a: 1, b: 2 }, { b: 3 }, { c: 4 })).toEqual({ a: 1, b: 3, c: 4 });
+  });
+
+  it('skips undefined layers', () => {
+    expect(mergeInputs(undefined, { a: 1 }, undefined)).toEqual({ a: 1 });
+  });
+});
+
+describe('validateInput', () => {
+  const schema = {
+    type: 'object',
+    properties: {
+      prUrl: { type: 'string', format: 'uri' },
+      count: { type: 'number', default: 5 },
+      drafts: { type: 'boolean' },
+    },
+    required: ['prUrl'],
+    additionalProperties: false,
+  };
+
+  it('accepts valid input and applies defaults', () => {
+    const res = validateInput(schema, { prUrl: 'https://x' });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.value).toEqual({ prUrl: 'https://x', count: 5 });
+  });
+
+  it('coerces string to number when schema says number', () => {
+    const res = validateInput(schema, { prUrl: 'https://x', count: '7' });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.value.count).toBe(7);
+  });
+
+  it('rejects missing required field', () => {
+    const res = validateInput(schema, {});
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors.join(' ')).toMatch(/prUrl/);
+  });
+
+  it('rejects unknown property', () => {
+    const res = validateInput(schema, { prUrl: 'https://x', extra: 1 });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors.join(' ')).toMatch(/extra|additional/i);
+  });
+
+  it('returns error for malformed schema', () => {
+    const bad = { type: 'nope' } as Record<string, unknown>;
+    const res = validateInput(bad, {});
+    expect(res.ok).toBe(false);
+  });
+});

--- a/src/utils/schema-input.ts
+++ b/src/utils/schema-input.ts
@@ -1,0 +1,60 @@
+import { Ajv, type ErrorObject, type ValidateFunction } from 'ajv';
+
+export type JsonSchema = Record<string, unknown>;
+export type Input = Record<string, unknown>;
+
+export interface ValidationFailure {
+  ok: false;
+  errors: string[];
+}
+
+export interface ValidationSuccess {
+  ok: true;
+  value: Input;
+}
+
+export type ValidationResult = ValidationSuccess | ValidationFailure;
+
+const ajv = new Ajv({ allErrors: true, coerceTypes: true, useDefaults: true, strict: false });
+
+const compile = (schema: JsonSchema): ValidateFunction => ajv.compile(schema);
+
+const formatError = (err: ErrorObject): string => {
+  const path = err.instancePath || '/';
+  return `${path} ${err.message ?? 'is invalid'}`;
+};
+
+export const parseInputJson = (raw: string): Input => {
+  const parsed = JSON.parse(raw) as unknown;
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('--input must be a JSON object');
+  }
+  return parsed as Input;
+};
+
+export const mergeInputs = (...layers: Array<Input | undefined>): Input => {
+  const out: Input = {};
+  for (const layer of layers) {
+    if (!layer) continue;
+    for (const [k, v] of Object.entries(layer)) out[k] = v;
+  }
+  return out;
+};
+
+export const validateInput = (schema: JsonSchema, input: Input): ValidationResult => {
+  let validate: ValidateFunction;
+  try {
+    validate = compile(schema);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, errors: [`invalid inputSchema: ${message}`] };
+  }
+
+  const candidate: Input = { ...input };
+  const valid = validate(candidate);
+  if (!valid) {
+    const errors = (validate.errors ?? []).map(formatError);
+    return { ok: false, errors: errors.length ? errors : ['validation failed'] };
+  }
+  return { ok: true, value: candidate };
+};


### PR DESCRIPTION
## Summary
Part 1/2 of agent input-schema support. Paired follow-up in `web` will render schema-driven forms in the dashboard "New Run" dialog.

- New `agentage run --input <json>` flag — structured input, merged over `--config`.
- If the agent declares `inputSchema` (JSON Schema Draft 7), merged inputs are validated with **ajv** before dispatch; clear per-field errors on failure.
- Daemon exposes `GET /api/agents/:name` so CLI can fetch a single manifest.
- Daemon→hub **heartbeat now carries `inputSchema`** per agent, so the hub (and dashboard) can render per-agent forms without polling each daemon.
- No changes to agents themselves; agents without `inputSchema` keep today's behavior.

## Why this shape
- `inputSchema?: JsonSchema` already exists on `AgentManifest` in `@agentage/core` — this PR is the first consumer.
- Agents remain free to author schemas via Zod + `zod-to-json-schema` at registration; core stays dep-free.
- Heartbeat carries full schema (simple first). Optimize with a hash + lazy fetch later if payloads grow.

See spec note: `projects/work/specs/agent-input-schema.md` (vault).

## Files
- `src/utils/schema-input.ts` (+ test) — ajv helpers: `parseInputJson`, `mergeInputs`, `validateInput`
- `src/commands/run.ts` — `--input` flag; fetch manifest; validate + merge for local + standalone runs
- `src/daemon/routes.ts` — `GET /api/agents/:name`
- `src/hub/hub-client.ts` / `hub-sync.ts` (+ test) — include `inputSchema` in heartbeat agent payload

## Test plan
- [x] `npm run verify` — type-check + lint + format + build + test
- [x] 459 tests pass (10 new for schema-input, 1 new for heartbeat payload)
- [ ] Manual: run an agent with `inputSchema`, pass `--input '{"prUrl":"..."}'`, confirm validation error on missing required field
- [ ] Manual: run a schema-less agent — unchanged behavior