### PR TITLE
fix(daemon): make task optional when agent's inputSchema allows it

### DIFF
--- a/src/daemon/routes.test.ts
+++ b/src/daemon/routes.test.ts
@@ -168,11 +168,46 @@ describe('daemon routes', () => {
       expect(data.runId).toBe('run-new-123');
     });
 
-    it('returns 400 when task is missing', async () => {
-      const { status, data } = await request(server, 'POST', '/api/agents/hello/run', {});
+    it('accepts missing task when inputSchema does not list task as required', async () => {
+      setAgents([
+        {
+          manifest: {
+            name: 'no-task',
+            description: 'Needs no task',
+            path: '/test',
+            inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+          },
+          run: vi.fn(),
+        },
+      ] as Parameters<typeof setAgents>[0]);
+      mockStartRun.mockResolvedValue('run-empty-1');
+
+      const { status, data } = await request(server, 'POST', '/api/agents/no-task/run', {});
+
+      expect(status).toBe(200);
+      expect(data.runId).toBe('run-empty-1');
+    });
+
+    it('rejects missing task when inputSchema lists task as required', async () => {
+      setAgents([
+        {
+          manifest: {
+            name: 'needs-task',
+            description: 'Requires task',
+            path: '/test',
+            inputSchema: {
+              type: 'object',
+              properties: { task: { type: 'string' } },
+              required: ['task'],
+            },
+          },
+          run: vi.fn(),
+        },
+      ] as Parameters<typeof setAgents>[0]);
+
+      const { status } = await request(server, 'POST', '/api/agents/needs-task/run', {});
 
       expect(status).toBe(400);
-      expect(data.error).toContain('task');
     });
 
     it('returns 404 when agent not found', async () => {

--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -1,5 +1,5 @@
 import { type Router, Router as createRouter, json } from 'express';
-import { type Agent } from '@agentage/core';
+import { type Agent, type JsonSchema } from '@agentage/core';
 import { loadConfig } from './config.js';
 import { cancelRun, getRun, getRuns, sendInput, startRun } from './run-manager.js';
 import { getHubSync } from '../hub/hub-sync.js';
@@ -23,6 +23,16 @@ export const getAgents = (): Agent[] => agents;
 
 export const setRefreshHandler = (handler: () => Promise<Agent[]>): void => {
   refreshHandler = handler;
+};
+
+/**
+ * `task` is required iff the agent's inputSchema explicitly lists it under
+ * `required`. Agents are expected to declare their inputSchema; there is no
+ * legacy fallback.
+ */
+const isTaskRequired = (schema: JsonSchema | undefined): boolean => {
+  const required = (schema as { required?: unknown } | undefined)?.required;
+  return Array.isArray(required) && required.includes('task');
 };
 
 export const createRoutes = (): Router => {
@@ -106,18 +116,18 @@ export const createRoutes = (): Router => {
         project?: { name: string; path: string; branch?: string; remote?: string };
       };
 
-      if (!task) {
-        res.status(400).json({ error: 'Missing "task" in request body' });
-        return;
-      }
-
       const agent = agents.find((a) => a.manifest.name === name);
       if (!agent) {
         res.status(404).json({ error: `Agent "${name}" not found` });
         return;
       }
 
-      const runId = await startRun(agent, task, config, context, project);
+      if (!task && isTaskRequired(agent.manifest.inputSchema)) {
+        res.status(400).json({ error: 'Missing "task" in request body' });
+        return;
+      }
+
+      const runId = await startRun(agent, task ?? '', config, context, project);
       res.json({ runId });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -55,7 +55,30 @@ describe('server', () => {
         };
       },
     };
-    server.updateAgents([mockAgent]);
+    const noTaskAgent: Agent = {
+      manifest: {
+        name: 'no-task-agent',
+        description: 'Takes no task',
+        path: '/test',
+        inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+      },
+      async run() {
+        async function* gen(): AsyncIterable<RunEvent> {
+          yield {
+            type: 'result',
+            data: { type: 'result', success: true },
+            timestamp: Date.now(),
+          };
+        }
+        return {
+          runId: 'no-task',
+          events: gen(),
+          cancel: () => {},
+          sendInput: () => {},
+        };
+      },
+    };
+    server.updateAgents([mockAgent, noTaskAgent]);
     await server.start();
   });
 
@@ -94,6 +117,17 @@ describe('server', () => {
     expect(body.runId).toBeDefined();
   });
 
+  it('POST /api/agents/:name/run accepts missing task when inputSchema does not require it', async () => {
+    const res = await fetch(`http://localhost:${port}/api/agents/no-task-agent/run`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const body = (await res.json()) as { runId: string };
+    expect(res.status).toBe(200);
+    expect(body.runId).toBeDefined();
+  });
+
   it('GET /api/runs returns run list', async () => {
     // Wait for the run from previous test to register
     await new Promise((r) => setTimeout(r, 100));
@@ -124,15 +158,6 @@ describe('server', () => {
       body: JSON.stringify({ task: 'hello' }),
     });
     expect(res.status).toBe(404);
-  });
-
-  it('POST /api/agents/:name/run returns 400 without task', async () => {
-    const res = await fetch(`http://localhost:${port}/api/agents/test-agent/run`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({}),
-    });
-    expect(res.status).toBe(400);
   });
 
   it('GET /api/runs/:id returns 404 for unknown run', async () => {

--- a/src/e2e/daemon-lifecycle.test.ts
+++ b/src/e2e/daemon-lifecycle.test.ts
@@ -420,11 +420,6 @@ describe('E2E: daemon lifecycle', () => {
     expect(status).toBe(404);
   });
 
-  it('returns 400 for run without task', async () => {
-    const { status } = await api.post<unknown>('/api/agents/hello/run', {});
-    expect(status).toBe(400);
-  });
-
   it('returns 404 for unknown run ID', async () => {
     const { status } = await api.get<unknown>('/api/runs/nonexistent-id');
     expect(status).toBe(404);


### PR DESCRIPTION
## Summary

Observed: `agentage run pr-list` fails with
```
Error: Missing "task" in request body
  at post (.../cli/dist/utils/daemon-client.js:27)
  at runLocal (.../cli/dist/commands/run.js:118)
```

Root cause: the daemon's `POST /api/agents/:name/run` handler rejected any empty `task` before looking at the agent. But `pr-list` declares `inputSchema: { type: 'object', properties: {}, additionalProperties: false }` — it takes no task prompt and shouldn't have to lie about one.

## New rule

**The agent's `inputSchema` is the sole source of truth.** Task is required iff `schema.required` explicitly lists `'task'`. No legacy fallback — every agent is expected to declare an `inputSchema`.

## Changes

`src/daemon/routes.ts`
- New `isTaskRequired(schema)` helper — returns `true` only when `schema.required` is an array containing `'task'`.
- 404 agent-not-found moved above the task check so the schema is in hand.
- Pass `task ?? ''` to `startRun` for type stability.

Tests
- `src/daemon/routes.test.ts`: dropped the legacy "no inputSchema → 400" case; added "schema allows missing task → 200" and "`required:['task']` → 400".
- `src/daemon/server.test.ts`: added an integration case against a mocked agent with empty inputSchema; dropped the legacy 400-without-task case on the mock.
- `src/e2e/daemon-lifecycle.test.ts`: dropped the "hello without task → 400" e2e case — no longer a supported contract.

## Test plan
- [x] `npm run verify` — all tests pass
- [ ] Smoke: `agentage run pr-list` works locally (no `task` arg)
- [ ] Regression: `agentage run hello "say hi"` still works; agents with `required: ['task']` still 400 on empty body

## Note
The hub-side equivalent (web/backend's WS handler) likely has the same unconditional check — worth a follow-up in `agentage/web` if remote runs of empty-schema agents also fail.