### PR TITLE
feat: validate agent result.output against manifest.outputSchema

### DIFF
--- a/src/daemon/run-manager.test.ts
+++ b/src/daemon/run-manager.test.ts
@@ -17,8 +17,12 @@ describe('run-manager', () => {
     rmSync(testDir, { recursive: true, force: true });
   });
 
-  const createMockAgent = (name: string, events: RunEvent[]): Agent => ({
-    manifest: { name, path: '/test', description: `Test agent ${name}` },
+  const createMockAgent = (
+    name: string,
+    events: RunEvent[],
+    extra?: Record<string, unknown>
+  ): Agent => ({
+    manifest: { name, path: '/test', description: `Test agent ${name}`, ...extra },
     async run() {
       const canceled = { value: false };
 
@@ -142,6 +146,95 @@ describe('run-manager', () => {
 
     const run = getRun(runId);
     expect(run?.state).toBe('failed');
+  });
+
+  it('marks run failed when result.output mismatches outputSchema', async () => {
+    const { startRun, getRun } = await import('./run-manager.js');
+    const outputSchema = {
+      type: 'object',
+      properties: { verdict: { type: 'string', enum: ['approve', 'reject'] } },
+      required: ['verdict'],
+      additionalProperties: false,
+    };
+    const agent = createMockAgent(
+      'schema-fail',
+      [
+        {
+          type: 'result',
+          data: { type: 'result', success: true, output: { verdict: 'maybe' } },
+          timestamp: Date.now(),
+        },
+      ],
+      { outputSchema }
+    );
+
+    const runId = await startRun(agent, 't');
+    await new Promise((r) => setTimeout(r, 100));
+
+    const run = getRun(runId);
+    expect(run?.state).toBe('failed');
+    expect(run?.error).toMatch(/outputSchema/);
+  });
+
+  it('marks run completed when output matches schema', async () => {
+    const { startRun, getRun } = await import('./run-manager.js');
+    const outputSchema = {
+      type: 'object',
+      properties: { verdict: { type: 'string', enum: ['approve', 'reject'] } },
+      required: ['verdict'],
+    };
+    const agent = createMockAgent(
+      'schema-ok',
+      [
+        {
+          type: 'result',
+          data: { type: 'result', success: true, output: { verdict: 'approve' } },
+          timestamp: Date.now(),
+        },
+      ],
+      { outputSchema }
+    );
+
+    const runId = await startRun(agent, 't');
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(getRun(runId)?.state).toBe('completed');
+  });
+
+  it('skips output validation when outputSchema is absent', async () => {
+    const { startRun, getRun } = await import('./run-manager.js');
+    const agent = createMockAgent('no-schema', [
+      {
+        type: 'result',
+        data: { type: 'result', success: true, output: { anything: 'goes' } },
+        timestamp: Date.now(),
+      },
+    ]);
+
+    const runId = await startRun(agent, 't');
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(getRun(runId)?.state).toBe('completed');
+  });
+
+  it('skips output validation when result has no output', async () => {
+    const { startRun, getRun } = await import('./run-manager.js');
+    const outputSchema = {
+      type: 'object',
+      required: ['verdict'],
+      properties: { verdict: { type: 'string' } },
+    };
+    const agent = createMockAgent(
+      'no-output',
+      [{ type: 'result', data: { type: 'result', success: true }, timestamp: Date.now() }],
+      { outputSchema }
+    );
+
+    const runId = await startRun(agent, 't');
+    await new Promise((r) => setTimeout(r, 100));
+
+    // success=true with no output is allowed (back-compat).
+    expect(getRun(runId)?.state).toBe('completed');
   });
 
   it('handles non-recoverable error event', async () => {

--- a/src/daemon/run-manager.ts
+++ b/src/daemon/run-manager.ts
@@ -7,6 +7,7 @@ import {
   canTransition,
 } from '@agentage/core';
 import { logError, logInfo } from './logger.js';
+import { validateOutput, type JsonSchema } from '../utils/schema-input.js';
 
 type RunEventListener = (runId: string, event: RunEvent) => void;
 type RunStateListener = (run: Run) => void;
@@ -14,6 +15,7 @@ type RunStateListener = (run: Run) => void;
 interface TrackedRun {
   run: Run;
   process: AgentProcess;
+  outputSchema?: JsonSchema;
 }
 
 const TERMINAL_STATES: Run['state'][] = ['completed', 'failed', 'canceled'];
@@ -90,7 +92,8 @@ export const startRun = async (
 
   const runInput = { task, config, context, ...(project && { project }) };
   const process = await agent.run(runInput);
-  const tracked: TrackedRun = { run, process };
+  const outputSchema = (agent.manifest as { outputSchema?: JsonSchema }).outputSchema;
+  const tracked: TrackedRun = { run, process, outputSchema };
   runs.set(runId, tracked);
 
   updateRunState(tracked, 'working', { startedAt: Date.now() });
@@ -114,9 +117,23 @@ const consumeEvents = async (tracked: TrackedRun): Promise<void> => {
     }
 
     if (event.data.type === 'result') {
-      updateRunState(tracked, event.data.success ? 'completed' : 'failed', {
+      let success = event.data.success;
+      let errorMessage = success ? undefined : 'Agent returned unsuccessful result';
+
+      if (success && tracked.outputSchema && event.data.output !== undefined) {
+        const validation = validateOutput(tracked.outputSchema, event.data.output);
+        if (!validation.ok) {
+          success = false;
+          errorMessage = `Output does not match agent outputSchema:\n${validation.errors
+            .map((e) => `  • ${e}`)
+            .join('\n')}`;
+          logError(`Run ${tracked.run.id}: ${errorMessage}`);
+        }
+      }
+
+      updateRunState(tracked, success ? 'completed' : 'failed', {
         endedAt: Date.now(),
-        error: event.data.success ? undefined : 'Agent returned unsuccessful result',
+        error: errorMessage,
       });
     }
 

--- a/src/hub/hub-client.ts
+++ b/src/hub/hub-client.ts
@@ -18,6 +18,7 @@ export interface HubClient {
         version?: string;
         tags?: string[];
         inputSchema?: Record<string, unknown>;
+        outputSchema?: Record<string, unknown>;
       }>;
       projects?: Array<{ name: string; path: string; discovered?: boolean; remote?: string }>;
       activeRunIds: string[];

--- a/src/hub/hub-sync.test.ts
+++ b/src/hub/hub-sync.test.ts
@@ -254,6 +254,31 @@ describe('hub-sync', () => {
       expect(call.agents[1]).not.toHaveProperty('inputSchema');
     });
 
+    it('includes outputSchema in agent payload when declared', async () => {
+      mockReadAuth.mockReturnValue(testAuth);
+      const outputSchema = {
+        type: 'object',
+        properties: { verdict: { type: 'string' } },
+        required: ['verdict'],
+      };
+      mockGetAgents.mockReturnValue([
+        { manifest: { name: 'pr-reviewer', outputSchema } },
+        { manifest: { name: 'pr-list' } },
+      ] as ReturnType<typeof getAgents>);
+      mockGetRuns.mockReturnValue([] as ReturnType<typeof getRuns>);
+      mockLoadProjects.mockReturnValue([]);
+
+      const sync = createHubSync();
+      await sync.start();
+      await sync.triggerHeartbeat();
+
+      const call = mockHubClient.heartbeat.mock.calls[0][1] as {
+        agents: Array<Record<string, unknown>>;
+      };
+      expect(call.agents[0]).toMatchObject({ name: 'pr-reviewer', outputSchema });
+      expect(call.agents[1]).not.toHaveProperty('outputSchema');
+    });
+
     it('processes pending cancel commands', async () => {
       mockReadAuth.mockReturnValue(testAuth);
       mockHubClient.heartbeat.mockResolvedValue({

--- a/src/hub/hub-sync.ts
+++ b/src/hub/hub-sync.ts
@@ -81,6 +81,9 @@ export const createHubSync = (): HubSync => {
       version: a.manifest.version,
       tags: a.manifest.tags,
       ...(a.manifest.inputSchema && { inputSchema: a.manifest.inputSchema }),
+      ...((a.manifest as { outputSchema?: Record<string, unknown> }).outputSchema && {
+        outputSchema: (a.manifest as { outputSchema?: Record<string, unknown> }).outputSchema,
+      }),
     }));
 
     const projects = loadProjects().map((p) => ({

--- a/src/utils/schema-input.test.ts
+++ b/src/utils/schema-input.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mergeInputs, parseInputJson, validateInput } from './schema-input.js';
+import { mergeInputs, parseInputJson, validateInput, validateOutput } from './schema-input.js';
 
 describe('parseInputJson', () => {
   it('parses an object', () => {
@@ -66,6 +66,57 @@ describe('validateInput', () => {
   it('returns error for malformed schema', () => {
     const bad = { type: 'nope' } as Record<string, unknown>;
     const res = validateInput(bad, {});
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('validateOutput', () => {
+  const schema = {
+    type: 'object',
+    properties: {
+      verdict: { type: 'string', enum: ['approve', 'reject'] },
+      score: { type: 'number' },
+    },
+    required: ['verdict'],
+    additionalProperties: false,
+  };
+
+  it('accepts a well-shaped output', () => {
+    const res = validateOutput(schema, { verdict: 'approve', score: 0.9 });
+    expect(res.ok).toBe(true);
+  });
+
+  it('rejects missing required field', () => {
+    const res = validateOutput(schema, { score: 1 });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors.join(' ')).toMatch(/verdict/);
+  });
+
+  it('rejects wrong enum value', () => {
+    const res = validateOutput(schema, { verdict: 'maybe' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors.join(' ')).toMatch(/enum|allowed/i);
+  });
+
+  it('rejects unknown property', () => {
+    const res = validateOutput(schema, { verdict: 'approve', extra: 1 });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors.join(' ')).toMatch(/extra|additional/i);
+  });
+
+  it('does NOT coerce types (integrity-preserving)', () => {
+    // validateInput coerces "7" -> 7; validateOutput must not.
+    const res = validateOutput(schema, { verdict: 'approve', score: '7' });
+    expect(res.ok).toBe(false);
+  });
+
+  it('accepts non-object outputs when schema permits', () => {
+    const res = validateOutput({ type: 'array', items: { type: 'string' } }, ['a', 'b']);
+    expect(res.ok).toBe(true);
+  });
+
+  it('returns error for malformed schema', () => {
+    const res = validateOutput({ type: 'nope' } as Record<string, unknown>, {});
     expect(res.ok).toBe(false);
   });
 });

--- a/src/utils/schema-input.ts
+++ b/src/utils/schema-input.ts
@@ -17,7 +17,12 @@ export type ValidationResult = ValidationSuccess | ValidationFailure;
 
 const ajv = new Ajv({ allErrors: true, coerceTypes: true, useDefaults: true, strict: false });
 
+// Separate, stricter instance for validating agent outputs — don't mutate
+// or coerce the agent's actual result payload.
+const ajvOutput = new Ajv({ allErrors: true, strict: false });
+
 const compile = (schema: JsonSchema): ValidateFunction => ajv.compile(schema);
+const compileOutput = (schema: JsonSchema): ValidateFunction => ajvOutput.compile(schema);
 
 const formatError = (err: ErrorObject): string => {
   const path = err.instancePath || '/';
@@ -39,6 +44,31 @@ export const mergeInputs = (...layers: Array<Input | undefined>): Input => {
     for (const [k, v] of Object.entries(layer)) out[k] = v;
   }
   return out;
+};
+
+export interface OutputValidationFailure {
+  ok: false;
+  errors: string[];
+}
+export interface OutputValidationSuccess {
+  ok: true;
+}
+export type OutputValidationResult = OutputValidationSuccess | OutputValidationFailure;
+
+export const validateOutput = (schema: JsonSchema, output: unknown): OutputValidationResult => {
+  let validate: ValidateFunction;
+  try {
+    validate = compileOutput(schema);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, errors: [`invalid outputSchema: ${message}`] };
+  }
+  const valid = validate(output);
+  if (!valid) {
+    const errors = (validate.errors ?? []).map(formatError);
+    return { ok: false, errors: errors.length ? errors : ['output validation failed'] };
+  }
+  return { ok: true };
 };
 
 export const validateInput = (schema: JsonSchema, input: Input): ValidationResult => {


### PR DESCRIPTION
## Summary
Phase 1 finish on the CLI side. Pairs with **agentkit#95** (merged — `outputSchema` added to manifest + `defineAgent` Zod helper).

- **Daemon validates `result.output`** against `manifest.outputSchema` before marking a run completed. On mismatch: run is marked `failed` with per-field error details in `run.error`.
- **Heartbeat** now carries `outputSchema` per agent (mirror of the inputSchema path from #120). Hub + dashboard can surface output contracts.
- **New `validateOutput` helper** in \`utils/schema-input\` — separate ajv instance with NO coercion / NO defaults (preserves the agent's actual payload).
- `GET /api/agents/:name` already exposes the full manifest, so clients automatically see \`outputSchema\` — no route change needed.

## Back-compat
- Agents without \`outputSchema\` → validation skipped, current behavior unchanged.
- \`success: true\` with no \`output\` → allowed (existing agents often omit).
- Only \`success: true && output defined && outputSchema declared\` triggers validation.

## Files
- \`src/utils/schema-input.ts\` (+ test) — \`validateOutput\`, separate ajv instance
- \`src/daemon/run-manager.ts\` (+ test) — capture \`outputSchema\` on startRun; validate on result event
- \`src/hub/hub-client.ts\` / \`hub-sync.ts\` (+ test) — heartbeat \`outputSchema\` propagation

## Test coverage (+12, total 461)
- \`validateOutput\`: happy path, missing required, wrong enum, unknown property, no-coercion (vs \`validateInput\`), non-object outputs, malformed schema
- \`run-manager\`: outputSchema mismatch → failed with \`error\` message; match → completed; no schema → passthrough; no output → allowed
- \`hub-sync\`: outputSchema propagated + omitted when absent

## Verify
- \`npm run verify\` — 461/461 tests, type-check, lint, format, build all clean

## Note on type access
\`@agentage/core\` released the \`outputSchema\` field in v0.7.0 (agentkit#96 release PR merged). This CLI still pulls \`^0.6.0\`; \`outputSchema\` is read via a narrow \`(manifest as { outputSchema?: ... })\` cast for now. Upgrade to \`^0.7.0\` in a follow-up once the publish workflow confirms the new version is live on npm.

## Next
Phase 1 web PR: migration \`agents.output_schema jsonb\`, persist from heartbeat, surface on agent detail page.