### PR TITLE
fix(release): auth release push with RELEASE_PAT for auto-merge

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -114,13 +114,18 @@ jobs:
         if: steps.check_pr.outputs.skip != 'true' && steps.check_commits.outputs.has_commits == 'true'
         id: create_pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.bump.outputs.new_version }}"
           BRANCH_NAME="release/v${VERSION}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Re-auth origin so the push is authored by RELEASE_PAT, which fires
+          # downstream workflows. GITHUB_TOKEN pushes are suppressed by GitHub
+          # to prevent recursion, which stalls auto-merge on the release PR.
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
 
           git checkout -b "$BRANCH_NAME"
           git add -A
@@ -165,7 +170,7 @@ jobs:
       - name: Auto-merge release PR
         if: steps.create_pr.outputs.pr_url && github.event.inputs.auto_merge == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
         run: |
           echo "Auto-merge enabled — enabling GitHub auto-merge"
           gh pr merge "${{ steps.create_pr.outputs.pr_url }}" --auto --squash


### PR DESCRIPTION
## Summary

Every release PR currently needs a manual `gh pr merge <N> --squash` (confirmed on v0.14.0, 2026-04-09). Root cause: `GITHUB_TOKEN`-authored pushes are suppressed from triggering downstream workflows (GitHub prevents recursion), so `pr-validation.yml` never fires on the release branch, and `gh pr merge --auto` waits forever at `mergeStateStatus=CLEAN` for a state change.

## Fix

Re-auth `origin` with an org-scoped `RELEASE_PAT` before the release push + PR create. With a PAT, the push is authored by a real user and downstream workflows fire normally. Auto-merge then completes when validation passes.

Graceful fallback: `${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}`. If the secret is not set, the workflow behaves exactly as before — zero regression risk until the PAT lands.

## Required follow-up (org admin, one-time)

- [ ] Create PAT (classic with `repo` scope, OR fine-grained with `contents:write` + `pull_requests:write`)
- [ ] Add as org-level secret `RELEASE_PAT` for `agentage/cli` + `agentage/agentkit`

## Validation plan

After the PAT is configured, running `gh workflow run release-prepare.yml -f bump_type=patch -f auto_merge=true` should:

1. Open the release PR
2. Fire `pr-validation.yml` automatically (currently never fires on release PRs)
3. Auto-merge when validation passes
4. Trigger `publish.yml` on merge

Paired PR in `agentage/agentkit` with the same change.