### PR TITLE
feat: emit run_started WS so ctx.run children land in the hub

### DIFF
--- a/src/daemon/run-manager.test.ts
+++ b/src/daemon/run-manager.test.ts
@@ -407,6 +407,63 @@ describe('run-manager', () => {
     expect(sendInput(runId, 'text')).toBe(false);
   });
 
+  describe('onRunStarted', () => {
+    it('fires for top-level runs with no parentRunId', async () => {
+      const { startRun, onRunStarted } = await import('./run-manager.js');
+      const seen: Array<{ id: string; parentRunId?: string }> = [];
+      const unsub = onRunStarted((run) => {
+        seen.push({ id: run.id, parentRunId: run.parentRunId });
+      });
+
+      const agent = createMockAgent('top-level', [
+        { type: 'result', data: { type: 'result', success: true }, timestamp: Date.now() },
+      ]);
+      const runId = await startRun(agent, 't');
+
+      expect(seen.length).toBeGreaterThanOrEqual(1);
+      const self = seen.find((s) => s.id === runId);
+      expect(self).toBeDefined();
+      expect(self?.parentRunId).toBeUndefined();
+      unsub();
+    });
+
+    it('fires for ctx.run children with parentRunId and depth set', async () => {
+      const { startRun, onRunStarted } = await import('./run-manager.js');
+      const { setAgents } = await import('./routes.js');
+      const seen: Array<{ id: string; parentRunId?: string; depth?: number }> = [];
+      const unsub = onRunStarted((run) => {
+        seen.push({ id: run.id, parentRunId: run.parentRunId, depth: run.depth });
+      });
+
+      const child = createMockAgent('child-started', [
+        { type: 'result', data: { type: 'result', success: true }, timestamp: Date.now() },
+      ]);
+      setAgents([child]);
+
+      const parent = createParentAgent('parent-started', { childRef: 'child-started' });
+      const parentId = await startRun(parent, 't');
+      await new Promise((r) => setTimeout(r, 50));
+
+      const childEvent = seen.find((s) => s.parentRunId === parentId);
+      expect(childEvent).toBeDefined();
+      expect(childEvent?.depth).toBe(1);
+      unsub();
+    });
+
+    it('listener errors do not break startRun', async () => {
+      const { startRun, onRunStarted } = await import('./run-manager.js');
+      const unsub = onRunStarted(() => {
+        throw new Error('listener boom');
+      });
+
+      const agent = createMockAgent('tolerant', [
+        { type: 'result', data: { type: 'result', success: true }, timestamp: Date.now() },
+      ]);
+      await expect(startRun(agent, 't')).resolves.toBeDefined();
+      unsub();
+    });
+  });
+
   describe('ctx.run — daemon dispatch', () => {
     it('creates a linked child run when parent calls ctx.run', async () => {
       const { startRun, getRuns } = await import('./run-manager.js');

--- a/src/daemon/run-manager.ts
+++ b/src/daemon/run-manager.ts
@@ -43,6 +43,7 @@ interface AgentRuntimeLocal {
 
 type RunEventListener = (runId: string, event: RunEvent) => void;
 type RunStateListener = (run: Run) => void;
+type RunStartedListener = (run: Run) => void;
 
 interface TrackedRun {
   run: Run;
@@ -57,6 +58,7 @@ const RUN_CLEANUP_TTL_MS = 5 * 60_000; // Clean up terminal runs after 5 minutes
 const runs = new Map<string, TrackedRun>();
 const eventListeners = new Set<RunEventListener>();
 const stateListeners = new Set<RunStateListener>();
+const startedListeners = new Set<RunStartedListener>();
 
 export const onRunEvent = (listener: RunEventListener): (() => void) => {
   eventListeners.add(listener);
@@ -66,6 +68,11 @@ export const onRunEvent = (listener: RunEventListener): (() => void) => {
 export const onRunStateChange = (listener: RunStateListener): (() => void) => {
   stateListeners.add(listener);
   return () => stateListeners.delete(listener);
+};
+
+export const onRunStarted = (listener: RunStartedListener): (() => void) => {
+  startedListeners.add(listener);
+  return () => startedListeners.delete(listener);
 };
 
 const emitEvent = (runId: string, event: RunEvent): void => {
@@ -223,6 +230,16 @@ export const startRun = async (
   const outputSchema = (agent.manifest as { outputSchema?: JsonSchema }).outputSchema;
   const tracked: TrackedRun = { run, process, outputSchema, childRunIds: new Set() };
   runs.set(runId, tracked);
+
+  // Fire startedListeners BEFORE the first state change so subscribers (hub-ws)
+  // can register their event/state forwarders first.
+  for (const listener of startedListeners) {
+    try {
+      listener(run);
+    } catch (err) {
+      logError(`onRunStarted listener threw: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
 
   updateRunState(tracked, 'working', { startedAt: Date.now() });
 

--- a/src/hub/hub-ws.ts
+++ b/src/hub/hub-ws.ts
@@ -7,6 +7,7 @@ import {
   sendInput,
   onRunEvent,
   onRunStateChange,
+  onRunStarted,
 } from '../daemon/run-manager.js';
 
 interface WsExecuteRequest {
@@ -155,6 +156,51 @@ export const createHubWs = (
       });
 
       ws.on('message', handleMessage);
+
+      // Relay child runs created by ctx.run() — the daemon starts them
+      // internally (no `execute` from hub), so we register their lineage and
+      // forward their events/state using the daemon-generated runId.
+      const unsubStarted = onRunStarted((run) => {
+        if (!run.parentRunId) return; // only mirror ctx.run children
+        send({
+          type: 'run_started',
+          runId: run.id,
+          agentName: run.agentName,
+          input: run.input,
+          parentRunId: run.parentRunId,
+          depth: run.depth ?? 1,
+          createdAt: run.createdAt,
+        });
+
+        const TERMINAL_STATES = ['completed', 'failed', 'canceled'];
+        const unsubs: Array<() => void> = [];
+        const cleanupChildListeners = (): void => {
+          for (const fn of unsubs) fn();
+          unsubs.length = 0;
+        };
+        unsubs.push(
+          onRunEvent((eventRunId, event) => {
+            if (eventRunId === run.id) {
+              send({ type: 'run_event', runId: run.id, event });
+            }
+          })
+        );
+        unsubs.push(
+          onRunStateChange((child) => {
+            if (child.id !== run.id) return;
+            send({
+              type: 'run_state',
+              runId: run.id,
+              state: child.state,
+              error: child.error,
+              stats: child.stats,
+            });
+            if (TERMINAL_STATES.includes(child.state)) cleanupChildListeners();
+          })
+        );
+        eventUnsubscribers.push(cleanupChildListeners);
+      });
+      eventUnsubscribers.push(unsubStarted);
 
       ws.on('close', () => {
         connected = false;


### PR DESCRIPTION
## Summary
Closes the Phase 2 loop end-to-end. Pairs with **web#141** (run_started handler + \`runs.parent_run_id\` column) and **cli#126** (daemon dispatch + in-daemon child run creation).

Before this PR: ctx.run() children exist in the daemon's in-memory map but the hub never sees them. After: children appear in the dashboard with their lineage intact — parent link, children list, nested run tree.

## Changes

### \`run-manager.ts\`
- New \`onRunStarted(listener)\` API that fires **synchronously inside \`startRun\`**, BEFORE the first state change. This ordering is deliberate so subscribers (hub-ws) can register their event/state forwarders before any events flow.
- Listener errors are caught and logged — one misbehaving subscriber does not break run creation.
- Fires for every run (top-level and child); the filter for "child" is the caller's concern.

### \`hub-ws.ts\`
- Subscribes to \`onRunStarted\`. For runs with \`parentRunId\` (i.e. ctx.run() children that the hub did NOT initiate via \`execute\`):
  1. Sends \`run_started\` with lineage (runId, parentRunId, depth, agentName, input, createdAt) so the hub upserts a runs row.
  2. Registers \`run_event\` + \`run_state\` forwarders scoped to the child runId. Unsubscribes on terminal state to prevent listener accumulation.

## Tests (+3, total 467)
- \`onRunStarted\` fires for top-level runs with undefined \`parentRunId\`
- \`onRunStarted\` fires for ctx.run children with \`parentRunId\` set + \`depth = 1\`
- Listener errors do not break \`startRun\`

(The \`ensure-daemon.test.ts\` flake is pre-existing on master — 463/464 before this PR, 466/467 after; same failure mode.)

## Verify
\`npm run verify\` — 466/467 tests (+3 new), type-check, lint, format, build all clean.

## After merge
End-to-end test path unlocks:
1. Build an orchestrator agent that calls \`yield* ctx.run('pr-list', {...})\`.
2. Run it via the CLI.
3. Open dashboard → orchestrator run page → see the child run nested under "Lineage", click through to the child's own page with parent link back.

Phase 2 complete after this merge.

## Next
- **Phase 3 — combinators MVP** in agentkit: \`sequence\`, \`parallel\`, \`map\`. ~half a day, pure functions on top of \`ctx.run\`.
- **Follow-up S:** bump \`@agentage/core\` to 0.8.0 + remove local type mirrors (\`AgentRuntimeLocal\` etc.) from \`run-manager.ts\`. Waiting for core publish workflow to land the version.
- **Phase 7 dogfood:** build one real orchestrator (e.g. \`release-flow\` or \`daily-standup\`) so we prove the whole stack.