### PR TITLE
ci(release): add PAT_TOKEN fallback so auto-merge fires today

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -114,7 +114,7 @@ jobs:
         if: steps.check_pr.outputs.skip != 'true' && steps.check_commits.outputs.has_commits == 'true'
         id: create_pr
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.bump.outputs.new_version }}"
           BRANCH_NAME="release/v${VERSION}"
@@ -170,7 +170,7 @@ jobs:
       - name: Auto-merge release PR
         if: steps.create_pr.outputs.pr_url && github.event.inputs.auto_merge == 'true'
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           echo "Auto-merge enabled — enabling GitHub auto-merge"
           gh pr merge "${{ steps.create_pr.outputs.pr_url }}" --auto --squash


### PR DESCRIPTION
## Summary

#124 wired `RELEASE_PAT` as the preferred token with `GITHUB_TOKEN` fallback. Since `RELEASE_PAT` is not yet configured, the fallback resolves to `GITHUB_TOKEN` — the same workflow-suppressing behavior we set out to fix. Auto-merge is still stuck.

Both repos already have an org-level `PAT_TOKEN` secret (created 2026-01-25). Wire it as the middle-tier fallback: `RELEASE_PAT || PAT_TOKEN || GITHUB_TOKEN`. Auto-merge starts working today with zero new secrets, and `RELEASE_PAT` remains the preferred slot for a release-scoped PAT later.

## Scope follow-up (nice-to-have, not blocking)

`PAT_TOKEN` may be broader than a release flow strictly needs. After this lands:

- Create a fine-grained PAT scoped to `contents:write` + `pull_requests:write`
- Add as org secret `RELEASE_PAT`
- Workflow picks it up automatically (first in the fallback chain) — no further code change

## Validation

Next release after merge: `gh workflow run release-prepare.yml -f bump_type=patch -f auto_merge=true` should

1. Push the release branch under `PAT_TOKEN` credentials
2. Fire `pr-validation.yml` automatically
3. Auto-merge when validation passes
4. Trigger `publish.yml` on merge

Paired PR in `agentage/agentkit` with the identical change.