### PR TITLE
Release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.17.0] - 2026-04-15
+
+### New Features
+- Add WebSocket event emission when runs start to ensure child runs appear in the hub
+- Add `ctx.run()` dispatch functionality with parent-child run linkage
+
+### Bug Fixes
+- Fix task parameter to be optional when agent's input schema allows it
+
 ## [0.16.0] - 2026-04-15
 
 ### New Features

--- a/changelog-content.md
+++ b/changelog-content.md
@@ -1,2 +1,6 @@
 ### New Features
-- Add validation of agent results against output schema defined in manifest
+- Add WebSocket event emission when runs start to ensure child runs appear in the hub
+- Add `ctx.run()` dispatch functionality with parent-child run linkage
+
+### Bug Fixes
+- Fix task parameter to be optional when agent's input schema allows it

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentage/cli",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentage/cli",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@agentage/core": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentage/cli",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Agentage CLI and daemon — control plane for AI agents",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release v0.17.0

This PR prepares the release of version 0.17.0.

### Changes
### New Features
- Add WebSocket event emission when runs start to ensure child runs appear in the hub
- Add `ctx.run()` dispatch functionality with parent-child run linkage

### Bug Fixes
- Fix task parameter to be optional when agent's input schema allows it

### Checklist
- [ ] Review the changelog
- [ ] Verify version numbers are correct
- [ ] Merge when ready to release

---

Once merged, this will automatically:
1. Create a git tag `v0.17.0`
2. Trigger the publish workflow
3. Publish to npm with provenance