### PR TITLE
chore: bump @agentage/core to 0.9; drop local type mirrors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@agentage/core": "^0.6.0",
+        "@agentage/core": "0.9.0",
         "@agentage/platform": "^0.2.1",
         "@supabase/supabase-js": "2.103.0",
         "ajv": "8.18.0",
@@ -45,13 +45,21 @@
       }
     },
     "node_modules/@agentage/core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@agentage/core/-/core-0.6.0.tgz",
-      "integrity": "sha512-0R2pNYlpFEWtg21ON74NEKTaDSi0riFeDRBMOq+5M3HepcvM9cQZtK42FiGcc8G6LddLhu5w6JQMTEcX5QnxIQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@agentage/core/-/core-0.9.0.tgz",
+      "integrity": "sha512-dV7nfltYlbJL6Fme4/pRQOQnC9jNpLHMAXSnlfer5PRksc8ST+mNSBew61rzlxoN87YNY4gl23arvGYBAWQY2g==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0",
         "npm": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "zod": ">=4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@agentage/platform": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prepublishOnly": "npm run verify"
   },
   "dependencies": {
-    "@agentage/core": "^0.6.0",
+    "@agentage/core": "0.9.0",
     "@agentage/platform": "^0.2.1",
     "@supabase/supabase-js": "2.103.0",
     "ajv": "8.18.0",

--- a/src/daemon/run-manager.ts
+++ b/src/daemon/run-manager.ts
@@ -2,6 +2,9 @@ import { randomUUID } from 'node:crypto';
 import {
   type Agent,
   type AgentProcess,
+  type AgentRuntime,
+  type CtxRunFn,
+  type CtxRunResult,
   type Run,
   type RunEvent,
   type RunInput,
@@ -18,27 +21,6 @@ declare module '@agentage/core' {
     parentRunId?: string;
     depth?: number;
   }
-}
-
-// Local mirrors of types added in @agentage/core@0.8.x (ctx.run primitive).
-// Switch to importing directly once the CLI bumps its core dependency.
-interface AgentRegistryLocal {
-  resolve(ref: string): Promise<Agent | null>;
-}
-interface CtxRunResultLocal<O = unknown> {
-  success: boolean;
-  output?: O;
-  error?: string;
-}
-type CtxRunFnLocal = <O = unknown>(
-  ref: string | Agent,
-  input: RunInput
-) => AsyncGenerator<RunEvent, CtxRunResultLocal<O>, void>;
-interface AgentRuntimeLocal {
-  registry?: AgentRegistryLocal;
-  parentRunId?: string;
-  depth?: number;
-  dispatch?: CtxRunFnLocal;
 }
 
 type RunEventListener = (runId: string, event: RunEvent) => void;
@@ -123,19 +105,19 @@ export const DAEMON_DEPTH_LIMIT = 50;
  * Build a daemon-side runtime that honours ctx.run() inside agent code.
  * - registry: resolves agent names against the daemon's discovered agents
  * - dispatch: creates a linked child run, streams its events to the parent
- *   iterator, and returns the final CtxRunResultLocal
+ *   iterator, and returns the final CtxRunResult
  */
-const buildRuntime = (parentRunId: string, parentDepth: number): AgentRuntimeLocal => {
+const buildRuntime = (parentRunId: string, parentDepth: number): AgentRuntime => {
   const registry = {
     async resolve(ref: string): Promise<Agent | null> {
       return getAgents().find((a) => a.manifest.name === ref) ?? null;
     },
   };
 
-  const dispatch: CtxRunFnLocal = async function* <O = unknown>(
+  const dispatch: CtxRunFn = async function* <O = unknown>(
     ref: string | Agent,
     input: RunInput
-  ): AsyncGenerator<RunEvent, CtxRunResultLocal<O>, void> {
+  ): AsyncGenerator<RunEvent, CtxRunResult<O>, void> {
     const nextDepth = parentDepth + 1;
     if (nextDepth > DAEMON_DEPTH_LIMIT) {
       return { success: false, error: `ctx.run depth limit exceeded (${DAEMON_DEPTH_LIMIT})` };
@@ -174,7 +156,7 @@ const buildRuntime = (parentRunId: string, parentDepth: number): AgentRuntimeLoc
     // events through the parent agent's generator so the author can observe
     // them if they iterate the yielded events).
     const childTracked = runs.get(childRunId);
-    let finalResult: CtxRunResultLocal<O> = { success: true };
+    let finalResult: CtxRunResult<O> = { success: true };
     if (childTracked) {
       for await (const event of childTracked.process.events) {
         yield event;
@@ -219,14 +201,7 @@ export const startRun = async (
 
   const runInput = { task, config, context, ...(project && { project }) };
   const runtime = buildRuntime(runId, depth);
-  // @agentage/core ^0.8 adds an optional second `runtime` arg; older versions
-  // simply ignore it at runtime (extra positional args are harmless for a
-  // regular function). Cast for type compatibility until the bump lands.
-  const runWithRuntime = agent.run as (
-    input: RunInput,
-    runtime?: AgentRuntimeLocal
-  ) => Promise<AgentProcess>;
-  const process = await runWithRuntime(runInput, runtime);
+  const process = await agent.run(runInput, runtime);
   const outputSchema = (agent.manifest as { outputSchema?: JsonSchema }).outputSchema;
   const tracked: TrackedRun = { run, process, outputSchema, childRunIds: new Set() };
   runs.set(runId, tracked);


### PR DESCRIPTION
## Summary
Cleanup PR. Core 0.9 is on npm with \`ctx.run\`/\`AgentRuntime\`/\`CtxRunFn\`/\`CtxRunResult\`/\`AgentRegistry\` properly exported, so the local mirrors we added in **cli#126** can go.

- Bump \`@agentage/core\` devDep to \`^0.9.0\`
- Import \`AgentRuntime\`, \`CtxRunFn\`, \`CtxRunResult\` directly from \`@agentage/core\`
- Drop \`AgentRegistryLocal\` / \`CtxRunResultLocal\` / \`CtxRunFnLocal\` / \`AgentRuntimeLocal\` interfaces (~15 LOC)
- Drop the \`runWithRuntime\` type cast — \`Agent.run\` natively accepts the optional runtime arg in 0.9

## No behavior change
Same 466 tests pass (\`ensure-daemon.test.ts\` flake is pre-existing on master).

\`npm run verify\` — type-check, lint, format, build, test all clean modulo the known flake.