### PR TITLE
feat(daemon): cron scheduler module — fire from heartbeat-pushed bindings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "ajv": "8.18.0",
         "chalk": "latest",
         "commander": "latest",
+        "croner": "*",
         "express": "latest",
         "gray-matter": "latest",
         "jiti": "latest",
@@ -1557,6 +1558,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/croner": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
+      "integrity": "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==",
+      "funding": [
+        {
+          "type": "other",
+          "url": "https://paypal.me/hexagonpp"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/hexagon"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ajv": "8.18.0",
     "chalk": "latest",
     "commander": "latest",
+    "croner": "*",
     "express": "latest",
     "gray-matter": "latest",
     "jiti": "latest",

--- a/src/daemon-entry.ts
+++ b/src/daemon-entry.ts
@@ -9,6 +9,8 @@ import { createCodeFactory } from './discovery/code-factory.js';
 import { getHubSync, resetHubSync } from './hub/hub-sync.js';
 import { readAuth } from './hub/auth.js';
 import { startWatcher } from './discovery/watcher.js';
+import { getScheduler, resetScheduler } from './daemon/scheduler.js';
+import { createHubClient } from './hub/hub-client.js';
 
 const main = async (): Promise<void> => {
   const config = loadConfig();
@@ -26,6 +28,16 @@ const main = async (): Promise<void> => {
 
   await server.start();
   logInfo(`Daemon ready on port ${config.daemon.port}`);
+
+  // Scheduler — fires schedules via the hub /fire endpoint. Initialised
+  // before hub-sync so the first heartbeat can reconcile immediately.
+  const scheduler = getScheduler(async (s) => {
+    const auth = readAuth();
+    if (!auth) return null;
+    const client = createHubClient(auth.hub.url, auth);
+    return client.fireSchedule(s.id, s.nextFireAt);
+  });
+  await scheduler.start();
 
   // Initialize hub sync (registers + heartbeat if auth.json exists)
   const hubSync = getHubSync();
@@ -65,6 +77,7 @@ const main = async (): Promise<void> => {
   const shutdown = async (): Promise<void> => {
     logInfo('Daemon shutting down...');
     stopWatcher();
+    resetScheduler();
     await hubSync.stop();
     await server.stop();
     removePidFile();

--- a/src/daemon/scheduler.test.ts
+++ b/src/daemon/scheduler.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createScheduler, type CachedSchedule, type FireCallback } from './scheduler.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'scheduler-test-'));
+  process.env.AGENTAGE_CONFIG_DIR = tmpDir;
+});
+
+afterEach(() => {
+  delete process.env.AGENTAGE_CONFIG_DIR;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const sample = (overrides: Partial<CachedSchedule> = {}): CachedSchedule => ({
+  id: 'sch-1',
+  agentName: 'echo',
+  cron: '0 9 * * *',
+  timezone: 'UTC',
+  nextFireAt: '2030-01-01T09:00:00.000Z',
+  missedFire: 'skip',
+  concurrency: 'skip',
+  ...overrides,
+});
+
+describe('scheduler.reconcile', () => {
+  it('registers new schedules', () => {
+    const scheduler = createScheduler(vi.fn());
+    scheduler.reconcile([sample({ id: 'a' }), sample({ id: 'b' })]);
+    const list = scheduler.list();
+    expect(list).toHaveLength(2);
+    expect(list.map((s) => s.id).sort()).toEqual(['a', 'b']);
+    scheduler.stop();
+  });
+
+  it('unregisters vanished schedules', () => {
+    const scheduler = createScheduler(vi.fn());
+    scheduler.reconcile([sample({ id: 'a' }), sample({ id: 'b' })]);
+    scheduler.reconcile([sample({ id: 'a' })]);
+    expect(scheduler.list().map((s) => s.id)).toEqual(['a']);
+    scheduler.stop();
+  });
+
+  it('re-registers when cron/tz/next_fire changes', () => {
+    const scheduler = createScheduler(vi.fn());
+    scheduler.reconcile([sample({ id: 'a', cron: '0 9 * * *' })]);
+    scheduler.reconcile([sample({ id: 'a', cron: '0 10 * * *' })]);
+    expect(scheduler.list()[0]!.cron).toBe('0 10 * * *');
+    scheduler.stop();
+  });
+
+  it('persists to cache file on reconcile', () => {
+    const scheduler = createScheduler(vi.fn());
+    scheduler.reconcile([sample()]);
+    const cachePath = scheduler.getCachePath();
+    expect(existsSync(cachePath)).toBe(true);
+    const parsed = JSON.parse(readFileSync(cachePath, 'utf-8')) as { schedules: CachedSchedule[] };
+    expect(parsed.schedules[0]!.id).toBe('sch-1');
+    scheduler.stop();
+  });
+});
+
+describe('scheduler.start', () => {
+  it('loads cached schedules from disk', async () => {
+    const cachePath = join(tmpDir, 'schedules.json');
+    writeFileSync(cachePath, JSON.stringify({ schedules: [sample({ id: 'persisted' })] }));
+    const scheduler = createScheduler(vi.fn());
+    await scheduler.start();
+    expect(scheduler.list().map((s) => s.id)).toEqual(['persisted']);
+    scheduler.stop();
+  });
+
+  it('does not crash on missing cache file', async () => {
+    const scheduler = createScheduler(vi.fn());
+    await scheduler.start();
+    expect(scheduler.list()).toEqual([]);
+    scheduler.stop();
+  });
+
+  it('does not crash on corrupt cache file', async () => {
+    const cachePath = join(tmpDir, 'schedules.json');
+    writeFileSync(cachePath, 'not-valid-json');
+    const scheduler = createScheduler(vi.fn());
+    await scheduler.start();
+    expect(scheduler.list()).toEqual([]);
+    scheduler.stop();
+  });
+
+  it('fires missed schedules immediately when missed_fire=run_once', async () => {
+    const fire = vi.fn<FireCallback>().mockResolvedValue({
+      acquired: true,
+      runId: 'run-1',
+      nextFireAt: '2030-01-02T09:00:00.000Z',
+    });
+    const cachePath = join(tmpDir, 'schedules.json');
+    writeFileSync(
+      cachePath,
+      JSON.stringify({
+        schedules: [
+          sample({
+            id: 'overdue',
+            nextFireAt: '2020-01-01T00:00:00.000Z', // in the past
+            missedFire: 'run_once',
+          }),
+        ],
+      })
+    );
+    const scheduler = createScheduler(fire);
+    await scheduler.start();
+    expect(fire).toHaveBeenCalledTimes(1);
+    scheduler.stop();
+  });
+
+  it('skips missed schedules when missed_fire=skip', async () => {
+    const fire = vi.fn<FireCallback>();
+    const cachePath = join(tmpDir, 'schedules.json');
+    writeFileSync(
+      cachePath,
+      JSON.stringify({
+        schedules: [
+          sample({
+            id: 'overdue',
+            nextFireAt: '2020-01-01T00:00:00.000Z',
+            missedFire: 'skip',
+          }),
+        ],
+      })
+    );
+    const scheduler = createScheduler(fire);
+    await scheduler.start();
+    expect(fire).not.toHaveBeenCalled();
+    scheduler.stop();
+  });
+});
+
+describe('scheduler stop', () => {
+  it('clears all jobs', () => {
+    const scheduler = createScheduler(vi.fn());
+    scheduler.reconcile([sample({ id: 'a' }), sample({ id: 'b' })]);
+    scheduler.stop();
+    expect(scheduler.list()).toEqual([]);
+  });
+});

--- a/src/daemon/scheduler.ts
+++ b/src/daemon/scheduler.ts
@@ -1,0 +1,203 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { Cron } from 'croner';
+import { getConfigDir } from './config.js';
+import { logInfo, logWarn } from './logger.js';
+
+export interface CachedSchedule {
+  id: string;
+  agentName: string;
+  cron: string;
+  timezone: string;
+  nextFireAt: string;
+  missedFire: 'skip' | 'run_once';
+  concurrency: 'skip' | 'queue';
+}
+
+export type FireCallback = (
+  schedule: CachedSchedule
+) => Promise<{ acquired: boolean; runId?: string; nextFireAt: string } | null>;
+
+interface RegisteredJob {
+  job: Cron;
+  schedule: CachedSchedule;
+  inFlight: boolean;
+}
+
+export interface Scheduler {
+  start: () => Promise<void>;
+  stop: () => void;
+  reconcile: (incoming: CachedSchedule[]) => void;
+  list: () => CachedSchedule[];
+  getCachePath: () => string;
+}
+
+const CACHE_FILE = 'schedules.json';
+
+const loadCache = (cachePath: string): CachedSchedule[] => {
+  if (!existsSync(cachePath)) return [];
+  try {
+    const raw = readFileSync(cachePath, 'utf-8');
+    const parsed = JSON.parse(raw) as { schedules?: CachedSchedule[] };
+    return Array.isArray(parsed.schedules) ? parsed.schedules : [];
+  } catch (err) {
+    logWarn(`Failed to read schedules cache: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+};
+
+const saveCache = (cachePath: string, schedules: CachedSchedule[]): void => {
+  try {
+    writeFileSync(cachePath, JSON.stringify({ schedules }, null, 2) + '\n', 'utf-8');
+  } catch (err) {
+    logWarn(`Failed to write schedules cache: ${err instanceof Error ? err.message : String(err)}`);
+  }
+};
+
+const sameSchedule = (a: CachedSchedule, b: CachedSchedule): boolean =>
+  a.cron === b.cron &&
+  a.timezone === b.timezone &&
+  a.nextFireAt === b.nextFireAt &&
+  a.missedFire === b.missedFire &&
+  a.concurrency === b.concurrency &&
+  a.agentName === b.agentName;
+
+export const createScheduler = (fire: FireCallback): Scheduler => {
+  const cachePath = join(getConfigDir(), CACHE_FILE);
+  const jobs = new Map<string, RegisteredJob>();
+
+  const fireOne = async (s: CachedSchedule): Promise<void> => {
+    const reg = jobs.get(s.id);
+    if (!reg) return;
+    if (reg.schedule.concurrency === 'skip' && reg.inFlight) {
+      logInfo(`[scheduler] skip ${s.id} — previous fire-call still in flight`);
+      return;
+    }
+    reg.inFlight = true;
+    try {
+      const result = await fire(reg.schedule);
+      if (!result) return;
+      if (result.acquired) {
+        logInfo(`[scheduler] fired ${s.id} → run ${result.runId ?? '?'}`);
+      } else {
+        logInfo(`[scheduler] skipped ${s.id} — CAS lost or schedule disabled`);
+      }
+      reg.schedule.nextFireAt = result.nextFireAt;
+      saveCache(
+        cachePath,
+        Array.from(jobs.values()).map((j) => j.schedule)
+      );
+    } catch (err) {
+      logWarn(
+        `[scheduler] fire ${s.id} failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+    } finally {
+      reg.inFlight = false;
+    }
+  };
+
+  const register = (s: CachedSchedule): void => {
+    try {
+      const job = new Cron(s.cron, { timezone: s.timezone }, () => {
+        void fireOne(s);
+      });
+      jobs.set(s.id, { job, schedule: { ...s }, inFlight: false });
+    } catch (err) {
+      logWarn(
+        `[scheduler] failed to register ${s.id}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  };
+
+  const unregister = (id: string): void => {
+    const reg = jobs.get(id);
+    if (reg) {
+      reg.job.stop();
+      jobs.delete(id);
+    }
+  };
+
+  return {
+    start: async () => {
+      const cached = loadCache(cachePath);
+      for (const s of cached) {
+        register(s);
+      }
+
+      // Missed-fire detection: schedule fired before daemon was running.
+      // Grace = one full interval to avoid replaying an overdue fire that
+      // would have happened within the next tick anyway.
+      const now = Date.now();
+      for (const s of cached) {
+        const next = new Date(s.nextFireAt).getTime();
+        if (next > now) continue;
+        if (s.missedFire === 'run_once') {
+          logInfo(`[scheduler] missed fire detected for ${s.id} (run_once) — firing now`);
+          await fireOne(s);
+        } else {
+          logInfo(`[scheduler] missed fire for ${s.id} — skipping per missed_fire=skip`);
+        }
+      }
+
+      logInfo(`[scheduler] started with ${jobs.size} schedule(s) from cache`);
+    },
+
+    stop: () => {
+      for (const reg of jobs.values()) {
+        reg.job.stop();
+      }
+      jobs.clear();
+    },
+
+    reconcile: (incoming) => {
+      const incomingIds = new Set(incoming.map((s) => s.id));
+
+      // Remove vanished
+      for (const id of jobs.keys()) {
+        if (!incomingIds.has(id)) {
+          unregister(id);
+          logInfo(`[scheduler] unregistered ${id}`);
+        }
+      }
+
+      // Add or update
+      for (const s of incoming) {
+        const existing = jobs.get(s.id);
+        if (!existing) {
+          register(s);
+          logInfo(`[scheduler] registered ${s.id} (${s.cron} ${s.timezone})`);
+        } else if (!sameSchedule(existing.schedule, s)) {
+          unregister(s.id);
+          register(s);
+          logInfo(`[scheduler] re-registered ${s.id} (cron/tz/next_fire changed)`);
+        }
+      }
+
+      saveCache(
+        cachePath,
+        Array.from(jobs.values()).map((j) => j.schedule)
+      );
+    },
+
+    list: () => Array.from(jobs.values()).map((j) => ({ ...j.schedule })),
+    getCachePath: () => cachePath,
+  };
+};
+
+// Module-level singleton — daemon-entry initialises once
+let _scheduler: Scheduler | null = null;
+
+export const getScheduler = (fire?: FireCallback): Scheduler => {
+  if (!_scheduler) {
+    if (!fire) throw new Error('Scheduler not initialised; pass fire callback on first call');
+    _scheduler = createScheduler(fire);
+  }
+  return _scheduler;
+};
+
+export const resetScheduler = (): void => {
+  if (_scheduler) {
+    _scheduler.stop();
+    _scheduler = null;
+  }
+};

--- a/src/hub/hub-client.ts
+++ b/src/hub/hub-client.ts
@@ -24,7 +24,23 @@ export interface HubClient {
       activeRunIds: string[];
       daemonVersion: string;
     }
-  ) => Promise<{ pendingCommands: unknown[]; latestCliVersion?: string }>;
+  ) => Promise<{
+    pendingCommands: unknown[];
+    latestCliVersion?: string;
+    schedules?: Array<{
+      id: string;
+      agentName: string;
+      cron: string;
+      timezone: string;
+      nextFireAt: string;
+      missedFire: 'skip' | 'run_once';
+      concurrency: 'skip' | 'queue';
+    }>;
+  }>;
+  fireSchedule: (
+    scheduleId: string,
+    expectedNextFireAt: string
+  ) => Promise<{ acquired: boolean; runId?: string; nextFireAt: string }>;
   deregister: (machineId: string) => Promise<void>;
   getMachines: () => Promise<unknown[]>;
   getAgents: (machineId?: string) => Promise<unknown[]>;
@@ -123,7 +139,14 @@ export const createHubClient = (hubUrl: string, auth: AuthState): HubClient => {
 
     heartbeat: async (machineId, body) => {
       const data = await request('POST', `/machines/${machineId}/heartbeat`, body);
-      return data as { pendingCommands: unknown[]; latestCliVersion?: string };
+      return data as Awaited<ReturnType<HubClient['heartbeat']>>;
+    },
+
+    fireSchedule: async (scheduleId, expectedNextFireAt) => {
+      const data = await request('POST', `/schedules/${scheduleId}/fire`, {
+        expectedNextFireAt,
+      });
+      return data as Awaited<ReturnType<HubClient['fireSchedule']>>;
     },
 
     deregister: async (machineId) => {

--- a/src/hub/hub-sync.ts
+++ b/src/hub/hub-sync.ts
@@ -7,6 +7,7 @@ import { createReconnector, type Reconnector } from './reconnection.js';
 import { logInfo, logWarn } from '../daemon/logger.js';
 import { getAgents } from '../daemon/routes.js';
 import { cancelRun, sendInput, getRuns } from '../daemon/run-manager.js';
+import { getScheduler } from '../daemon/scheduler.js';
 import { loadProjects } from '../projects/projects.js';
 
 import { VERSION } from '../utils/version.js';
@@ -103,6 +104,17 @@ export const createHubSync = (): HubSync => {
       activeRunIds,
       daemonVersion: VERSION,
     });
+
+    // Reconcile local cron registry against the authoritative bindings
+    if (response.schedules) {
+      try {
+        getScheduler().reconcile(response.schedules);
+      } catch (err) {
+        logWarn(
+          `[hub-sync] scheduler reconcile failed: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
 
     // Process pending commands from hub
     if (response.pendingCommands && Array.isArray(response.pendingCommands)) {


### PR DESCRIPTION
## Summary

Daemon side of the scheduler feature. Pairs with web PR #143 which extends the heartbeat response and adds a daemon-facing \`/fire\` endpoint.

End-to-end flow once both PRs land:
1. User creates schedule in dashboard (\`/schedules\`) → \`schedules\` row in DB.
2. Daemon heartbeat arrives → backend includes the active bindings for that machine in the response.
3. Daemon \`scheduler.reconcile()\` diffs and registers cron jobs via \`croner\`.
4. Cron fires → daemon calls \`POST /api/schedules/:id/fire { expectedNextFireAt }\` → backend does CAS-claim + dispatches the run.
5. Run lands on the same daemon via existing WS path.

## What's in

- **\`src/daemon/scheduler.ts\`** — croner registry + cache + reconcile + missed-fire on startup (run_once fires immediately, skip logs only) + skip-if-fire-call-in-flight concurrency.
- **\`src/hub/hub-client.ts\`** — heartbeat response type extended; \`fireSchedule()\` added.
- **\`src/hub/hub-sync.ts\`** — pipes \`response.schedules\` into \`scheduler.reconcile()\` after every heartbeat.
- **\`src/daemon-entry.ts\`** — scheduler init before hub-sync, teardown on SIGTERM/SIGINT.
- Local cache at \`~/.agentage/schedules.json\` so cron jobs register immediately on startup, before the first heartbeat lands.

## Decisions

1. **No backend run-tracking integration for concurrency.** Daemon's local \`inFlight\` flag is per-binding and reset on response. If a long-running run overlaps the next fire, backend's CAS still advances \`next_fire_at\` and a new run dispatches — same behaviour as the dashboard \`run-now\`. Hard concurrency belongs in the schedule.service when needed.
2. **Missed-fire \`run_once\` fires only on startup, not per-tick.** Avoids replay storms after long downtime; spec deferred catch-up policies to v2.
3. **Singleton scheduler.** Matches existing \`hub-sync\` pattern; tests reset between runs via \`resetScheduler()\`.

## Test plan

- [x] 10 new unit tests on \`scheduler.test.ts\` (reconcile add/remove/update, cache persist, start with cache present/missing/corrupt, missed_fire run_once vs skip, stop)
- [x] All existing 466 tests still pass — only pre-existing flake (\`ensure-daemon.test.ts\` worker-exit, reproduces on plain master) shows up
- [ ] Integration on real machine: dogfood against my mesh once #143 + this PR are merged

## Depends on

- agentage/web#143 (heartbeat returns schedules + /fire endpoint)