### PR TITLE
feat(cli): agentage schedules subcommands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "ajv": "8.18.0",
         "chalk": "latest",
         "commander": "latest",
+        "croner": "*",
         "express": "latest",
         "gray-matter": "latest",
         "jiti": "latest",
@@ -1565,6 +1566,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/croner": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
+      "integrity": "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==",
+      "funding": [
+        {
+          "type": "other",
+          "url": "https://paypal.me/hexagonpp"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/hexagon"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ajv": "8.18.0",
     "chalk": "latest",
     "commander": "latest",
+    "croner": "*",
     "express": "latest",
     "gray-matter": "latest",
     "jiti": "latest",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import { registerInit } from './commands/init.js';
 import { createCreateCommand } from './commands/create.js';
 import { registerUpdate } from './commands/update.js';
 import { registerProjects } from './commands/projects.js';
+import { registerSchedules } from './commands/schedules.js';
 import { checkForUpdateSafe, type UpdateCheckResult } from './utils/update-checker.js';
 
 const program = new Command();
@@ -43,6 +44,7 @@ registerInit(program);
 program.addCommand(createCreateCommand());
 registerUpdate(program);
 registerProjects(program);
+registerSchedules(program);
 
 program.parseAsync().then(async () => {
   // Show update notice if a newer version is available

--- a/src/commands/schedules.test.ts
+++ b/src/commands/schedules.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Command } from 'commander';
+
+vi.mock('../utils/ensure-daemon.js', () => ({
+  ensureDaemon: vi.fn(),
+}));
+
+vi.mock('../utils/daemon-client.js', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  request: vi.fn(),
+}));
+
+vi.mock('../daemon/config.js', () => ({
+  loadConfig: vi.fn(() => ({
+    machine: { id: '11111111-1111-1111-1111-111111111111', name: 'localdev' },
+    daemon: { port: 4243 },
+    discovery: { dirs: [] },
+    sync: { events: {} },
+  })),
+}));
+
+import { get, post, request } from '../utils/daemon-client.js';
+import { registerSchedules } from './schedules.js';
+
+const mockGet = vi.mocked(get);
+const mockPost = vi.mocked(post);
+const mockRequest = vi.mocked(request);
+
+const sampleSchedule = (overrides: Record<string, unknown> = {}) => ({
+  id: 'sch-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  name: 'morning brief',
+  agent_name: 'echo',
+  machine_id: '11111111-1111-1111-1111-111111111111',
+  cron: '0 9 * * *',
+  timezone: 'UTC',
+  enabled: true,
+  next_fire_at: '2030-01-01T09:00:00.000Z',
+  last_fired_at: null,
+  ...overrides,
+});
+
+describe('schedules command', () => {
+  let program: Command;
+  let logs: string[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logs = [];
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(' '));
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    program = new Command();
+    program.exitOverride();
+    registerSchedules(program);
+  });
+
+  describe('list (default)', () => {
+    it('prints empty message when no schedules', async () => {
+      mockGet.mockResolvedValue([]);
+      await program.parseAsync(['node', 'agentage', 'schedules']);
+      expect(mockGet).toHaveBeenCalledWith('/api/hub/schedules');
+      expect(logs.some((l) => l.includes('No schedules'))).toBe(true);
+    });
+
+    it('prints table with one schedule', async () => {
+      mockGet.mockResolvedValue([sampleSchedule()]);
+      await program.parseAsync(['node', 'agentage', 'schedules']);
+      expect(logs.some((l) => l.includes('NAME'))).toBe(true);
+      expect(logs.some((l) => l.includes('morning brief'))).toBe(true);
+      expect(logs.some((l) => l.includes('0 9 * * *'))).toBe(true);
+    });
+
+    it('passes --machine filter', async () => {
+      mockGet.mockResolvedValue([]);
+      await program.parseAsync(['node', 'agentage', 'schedules', '--machine', 'm-1']);
+      expect(mockGet).toHaveBeenCalledWith('/api/hub/schedules?machine=m-1');
+    });
+
+    it('passes --enabled filter', async () => {
+      mockGet.mockResolvedValue([]);
+      await program.parseAsync(['node', 'agentage', 'schedules', '--enabled']);
+      expect(mockGet).toHaveBeenCalledWith('/api/hub/schedules?enabled=true');
+    });
+
+    it('--json prints JSON', async () => {
+      const data = [sampleSchedule()];
+      mockGet.mockResolvedValue(data);
+      await program.parseAsync(['node', 'agentage', 'schedules', '--json']);
+      expect(JSON.parse(logs[0]!)).toEqual(data);
+    });
+  });
+
+  describe('add', () => {
+    it('expands preset name to full cron', async () => {
+      mockPost.mockResolvedValue(sampleSchedule());
+      await program.parseAsync(['node', 'agentage', 'schedules', 'add', 'echo', 'daily']);
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/hub/schedules',
+        expect.objectContaining({
+          agentName: 'echo',
+          cron: '0 9 * * *',
+          machineId: '11111111-1111-1111-1111-111111111111',
+        })
+      );
+    });
+
+    it('passes raw cron through', async () => {
+      mockPost.mockResolvedValue(sampleSchedule());
+      await program.parseAsync(['node', 'agentage', 'schedules', 'add', 'echo', '0 20 * * 1-5']);
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/hub/schedules',
+        expect.objectContaining({ cron: '0 20 * * 1-5' })
+      );
+    });
+
+    it('--task wraps as input.task', async () => {
+      mockPost.mockResolvedValue(sampleSchedule());
+      await program.parseAsync([
+        'node',
+        'agentage',
+        'schedules',
+        'add',
+        'echo',
+        'hourly',
+        '--task',
+        'morning brief',
+      ]);
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/hub/schedules',
+        expect.objectContaining({ input: { task: 'morning brief' } })
+      );
+    });
+  });
+
+  describe('enable / disable / remove', () => {
+    it('enable PATCHes enabled=true', async () => {
+      mockGet.mockResolvedValue([sampleSchedule({ enabled: false })]);
+      mockRequest.mockResolvedValue({});
+      await program.parseAsync(['node', 'agentage', 'schedules', 'enable', 'sch-aaaa']);
+      expect(mockRequest).toHaveBeenCalledWith(
+        'PATCH',
+        '/api/hub/schedules/sch-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        { enabled: true }
+      );
+    });
+
+    it('disable PATCHes enabled=false', async () => {
+      mockGet.mockResolvedValue([sampleSchedule()]);
+      mockRequest.mockResolvedValue({});
+      await program.parseAsync(['node', 'agentage', 'schedules', 'disable', 'sch-aaaa']);
+      expect(mockRequest).toHaveBeenCalledWith(
+        'PATCH',
+        '/api/hub/schedules/sch-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        { enabled: false }
+      );
+    });
+
+    it('remove DELETEs', async () => {
+      mockGet.mockResolvedValue([sampleSchedule()]);
+      mockRequest.mockResolvedValue({});
+      await program.parseAsync(['node', 'agentage', 'schedules', 'remove', 'sch-aaaa']);
+      expect(mockRequest).toHaveBeenCalledWith(
+        'DELETE',
+        '/api/hub/schedules/sch-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+      );
+    });
+
+    it('rejects ambiguous id prefix', async () => {
+      mockGet.mockResolvedValue([
+        sampleSchedule({ id: 'sch-aaaa-1' }),
+        sampleSchedule({ id: 'sch-aaaa-2' }),
+      ]);
+      await expect(
+        program.parseAsync(['node', 'agentage', 'schedules', 'enable', 'sch-aaaa'])
+      ).rejects.toThrow(/Ambiguous/);
+    });
+
+    it('rejects unknown id prefix', async () => {
+      mockGet.mockResolvedValue([sampleSchedule()]);
+      await expect(
+        program.parseAsync(['node', 'agentage', 'schedules', 'remove', 'nope-xxx'])
+      ).rejects.toThrow(/No schedule matches/);
+    });
+  });
+
+  describe('run-now', () => {
+    it('POSTs run-now and prints runId', async () => {
+      mockGet.mockResolvedValue([sampleSchedule()]);
+      mockPost.mockResolvedValue({ runId: 'run-12345678-...' });
+      await program.parseAsync(['node', 'agentage', 'schedules', 'run-now', 'sch-aaaa']);
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/hub/schedules/sch-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/run-now'
+      );
+      expect(logs.some((l) => l.includes('Fired'))).toBe(true);
+    });
+  });
+
+  describe('next', () => {
+    it('prints 5 future fire times', async () => {
+      mockGet.mockResolvedValue([sampleSchedule()]);
+      await program.parseAsync(['node', 'agentage', 'schedules', 'next', 'sch-aaaa']);
+      expect(logs).toHaveLength(5);
+      expect(new Date(logs[0]!).getTime()).toBeGreaterThan(Date.now());
+    });
+  });
+});

--- a/src/commands/schedules.ts
+++ b/src/commands/schedules.ts
@@ -1,0 +1,209 @@
+import { type Command } from 'commander';
+import chalk from 'chalk';
+import { Cron } from 'croner';
+import { ensureDaemon } from '../utils/ensure-daemon.js';
+import { get, post, request } from '../utils/daemon-client.js';
+import { loadConfig } from '../daemon/config.js';
+
+interface ScheduleRow {
+  id: string;
+  name: string;
+  agent_name: string;
+  machine_id: string;
+  cron: string | null;
+  timezone: string;
+  enabled: boolean;
+  next_fire_at: string;
+  last_fired_at: string | null;
+}
+
+const COMMON_PRESETS: Record<string, string> = {
+  hourly: '0 * * * *',
+  daily: '0 9 * * *',
+  weekdays: '0 9 * * 1-5',
+  weekly: '0 9 * * 1',
+};
+
+const truncate = (s: string, n: number): string => (s.length <= n ? s : `${s.slice(0, n - 1)}…`);
+
+const formatTime = (iso: string | null): string => {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString();
+};
+
+const printList = (schedules: ScheduleRow[]): void => {
+  if (schedules.length === 0) {
+    console.log(chalk.gray('No schedules.'));
+    return;
+  }
+  const idW = 10;
+  const nameW = Math.max(8, ...schedules.map((s) => Math.min(s.name.length, 30))) + 2;
+  const cronW = Math.max(8, ...schedules.map((s) => (s.cron ?? '').length)) + 2;
+  console.log(
+    chalk.bold('ID'.padEnd(idW)) +
+      chalk.bold('NAME'.padEnd(nameW)) +
+      chalk.bold('CRON'.padEnd(cronW)) +
+      chalk.bold('TZ'.padEnd(20)) +
+      chalk.bold('ENABLED'.padEnd(10)) +
+      chalk.bold('NEXT FIRE')
+  );
+  for (const s of schedules) {
+    const enabled = s.enabled ? chalk.green('yes') : chalk.gray('no');
+    console.log(
+      s.id.slice(0, 8).padEnd(idW) +
+        truncate(s.name, nameW - 2).padEnd(nameW) +
+        (s.cron ?? '—').padEnd(cronW) +
+        s.timezone.padEnd(20) +
+        enabled.padEnd(10 + (enabled.length - 'no'.length)) +
+        formatTime(s.next_fire_at)
+    );
+  }
+  console.log(chalk.dim(`\n${schedules.length} schedule(s)`));
+};
+
+const findById = async (idPrefix: string): Promise<ScheduleRow> => {
+  const all = await get<ScheduleRow[]>('/api/hub/schedules');
+  const matches = all.filter((s) => s.id.startsWith(idPrefix));
+  if (matches.length === 0) {
+    throw new Error(`No schedule matches id prefix "${idPrefix}"`);
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Ambiguous id prefix "${idPrefix}" — matches ${matches.length}: ${matches.map((m) => m.id.slice(0, 12)).join(', ')}`
+    );
+  }
+  return matches[0]!;
+};
+
+export const registerSchedules = (program: Command): void => {
+  const root = program.command('schedules').description('Manage scheduled agent runs');
+
+  root
+    .command('list', { isDefault: true })
+    .description('List your schedules')
+    .option('--machine <name>', 'Filter to one machine')
+    .option('--enabled', 'Show only enabled schedules')
+    .option('--disabled', 'Show only disabled schedules')
+    .option('--json', 'JSON output')
+    .action(
+      async (opts: { machine?: string; enabled?: boolean; disabled?: boolean; json?: boolean }) => {
+        await ensureDaemon();
+        const params = new URLSearchParams();
+        if (opts.machine) params.set('machine', opts.machine);
+        if (opts.enabled) params.set('enabled', 'true');
+        if (opts.disabled) params.set('enabled', 'false');
+        const qs = params.toString();
+        const schedules = await get<ScheduleRow[]>(`/api/hub/schedules${qs ? `?${qs}` : ''}`);
+        if (opts.json) {
+          console.log(JSON.stringify(schedules, null, 2));
+          return;
+        }
+        printList(schedules);
+      }
+    );
+
+  root
+    .command('add <agent> <cron>')
+    .description(
+      'Create a schedule on the current machine. Use a preset (hourly|daily|weekdays|weekly) or 5-field cron.'
+    )
+    .option('--machine <id>', 'Override target machine ID (default: this daemon)')
+    .option('--timezone <tz>', 'IANA timezone (default: machine TZ)')
+    .option('--name <name>', 'Schedule name')
+    .option('--task <task>', 'Task text passed to the agent as input.task')
+    .option('--json', 'JSON output')
+    .action(
+      async (
+        agentName: string,
+        cron: string,
+        opts: { machine?: string; timezone?: string; name?: string; task?: string; json?: boolean }
+      ) => {
+        await ensureDaemon();
+        const cronExpr = COMMON_PRESETS[cron] ?? cron;
+        const config = loadConfig();
+        const machineId = opts.machine ?? config.machine.id;
+        const body: Record<string, unknown> = {
+          machineId,
+          agentName,
+          cron: cronExpr,
+          timezone: opts.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
+        };
+        if (opts.name) body.name = opts.name;
+        if (opts.task) body.input = { task: opts.task };
+        const created = await post<ScheduleRow>('/api/hub/schedules', body);
+        if (opts.json) {
+          console.log(JSON.stringify(created, null, 2));
+          return;
+        }
+        console.log(chalk.green(`Created schedule ${created.id.slice(0, 8)}: ${created.name}`));
+        console.log(chalk.dim(`Next fire: ${formatTime(created.next_fire_at)}`));
+      }
+    );
+
+  root
+    .command('enable <id>')
+    .description('Enable a schedule (id prefix accepted)')
+    .action(async (idPrefix: string) => {
+      await ensureDaemon();
+      const s = await findById(idPrefix);
+      await request<unknown>('PATCH', `/api/hub/schedules/${s.id}`, { enabled: true });
+      console.log(chalk.green(`Enabled ${s.id.slice(0, 8)}: ${s.name}`));
+    });
+
+  root
+    .command('disable <id>')
+    .description('Disable a schedule (id prefix accepted)')
+    .action(async (idPrefix: string) => {
+      await ensureDaemon();
+      const s = await findById(idPrefix);
+      await request<unknown>('PATCH', `/api/hub/schedules/${s.id}`, { enabled: false });
+      console.log(chalk.yellow(`Disabled ${s.id.slice(0, 8)}: ${s.name}`));
+    });
+
+  root
+    .command('remove <id>')
+    .alias('rm')
+    .description('Delete a schedule (id prefix accepted)')
+    .action(async (idPrefix: string) => {
+      await ensureDaemon();
+      const s = await findById(idPrefix);
+      await request<unknown>('DELETE', `/api/hub/schedules/${s.id}`);
+      console.log(chalk.red(`Deleted ${s.id.slice(0, 8)}: ${s.name}`));
+    });
+
+  root
+    .command('run-now <id>')
+    .description('Fire a schedule once (outside its cadence)')
+    .action(async (idPrefix: string) => {
+      await ensureDaemon();
+      const s = await findById(idPrefix);
+      const result = await post<{ runId: string }>(`/api/hub/schedules/${s.id}/run-now`);
+      console.log(chalk.green(`Fired ${s.id.slice(0, 8)} → run ${result.runId.slice(0, 8)}`));
+    });
+
+  root
+    .command('next <id>')
+    .description('Print the next 5 fire times (computed locally from cron + tz)')
+    .action(async (idPrefix: string) => {
+      await ensureDaemon();
+      const s = await findById(idPrefix);
+      if (!s.cron) {
+        console.error(chalk.red('Schedule has no cron expression'));
+        process.exitCode = 1;
+        return;
+      }
+      try {
+        const c = new Cron(s.cron, { timezone: s.timezone });
+        let prev: Date | null = c.nextRun();
+        for (let i = 0; i < 5 && prev; i += 1) {
+          console.log(prev.toLocaleString(undefined, { timeZone: s.timezone }));
+          prev = c.nextRun(prev);
+        }
+      } catch (err) {
+        console.error(
+          chalk.red(`Invalid cron: ${err instanceof Error ? err.message : String(err)}`)
+        );
+        process.exitCode = 1;
+      }
+    });
+};

--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -260,5 +260,56 @@ export const createRoutes = (): Router => {
     }
   });
 
+  // Schedule proxy routes — CLI subcommands hit these, daemon forwards to hub
+  const withHubClient = async (
+    res: Parameters<Parameters<typeof router.get>[1]>[1],
+    fn: (client: ReturnType<typeof createHubClient>) => Promise<unknown>
+  ): Promise<void> => {
+    const auth = readAuth();
+    if (!auth) {
+      res.status(401).json({ error: 'Not logged in' });
+      return;
+    }
+    try {
+      const result = await fn(createHubClient(auth.hub.url, auth));
+      res.json(result ?? { ok: true });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(502).json({ error: message });
+    }
+  };
+
+  router.get('/api/hub/schedules', async (req, res) => {
+    await withHubClient(res, (client) =>
+      client.getSchedules({
+        machineId: req.query.machine as string | undefined,
+        enabled: req.query.enabled === undefined ? undefined : req.query.enabled === 'true',
+      })
+    );
+  });
+
+  router.post('/api/hub/schedules', async (req, res) => {
+    await withHubClient(res, (client) =>
+      client.createSchedule(req.body as Parameters<typeof client.createSchedule>[0])
+    );
+  });
+
+  router.patch('/api/hub/schedules/:id', async (req, res) => {
+    await withHubClient(res, (client) =>
+      client.updateSchedule(req.params.id, req.body as Record<string, unknown>)
+    );
+  });
+
+  router.delete('/api/hub/schedules/:id', async (req, res) => {
+    await withHubClient(res, async (client) => {
+      await client.deleteSchedule(req.params.id);
+      return { ok: true };
+    });
+  });
+
+  router.post('/api/hub/schedules/:id/run-now', async (req, res) => {
+    await withHubClient(res, (client) => client.runScheduleNow(req.params.id));
+  });
+
   return router;
 };

--- a/src/hub/hub-client.ts
+++ b/src/hub/hub-client.ts
@@ -33,6 +33,18 @@ export interface HubClient {
   sendRunInput: (runId: string, text: string) => Promise<void>;
   getRun: (runId: string) => Promise<unknown>;
   getRunEvents: (runId: string, after?: string) => Promise<unknown[]>;
+  getSchedules: (filters?: { machineId?: string; enabled?: boolean }) => Promise<unknown[]>;
+  createSchedule: (input: {
+    machineId: string;
+    agentName: string;
+    cron: string;
+    timezone?: string;
+    name?: string;
+    input?: Record<string, unknown>;
+  }) => Promise<unknown>;
+  updateSchedule: (id: string, patch: Record<string, unknown>) => Promise<unknown>;
+  deleteSchedule: (id: string) => Promise<void>;
+  runScheduleNow: (id: string) => Promise<{ runId: string }>;
 }
 
 const refreshAccessToken = async (hubUrl: string, auth: AuthState): Promise<boolean> => {
@@ -163,6 +175,28 @@ export const createHubClient = (hubUrl: string, auth: AuthState): HubClient => {
       const path = after ? `/runs/${runId}/events?after=${after}` : `/runs/${runId}/events`;
       const data = await request('GET', path);
       return data as unknown[];
+    },
+
+    getSchedules: async (filters) => {
+      const params = new URLSearchParams();
+      if (filters?.machineId) params.set('machine', filters.machineId);
+      if (filters?.enabled !== undefined) params.set('enabled', String(filters.enabled));
+      const qs = params.toString();
+      const data = await request('GET', `/schedules${qs ? `?${qs}` : ''}`);
+      return data as unknown[];
+    },
+
+    createSchedule: async (input) => request('POST', '/schedules', input),
+
+    updateSchedule: async (id, patch) => request('PATCH', `/schedules/${id}`, patch),
+
+    deleteSchedule: async (id) => {
+      await request('DELETE', `/schedules/${id}`);
+    },
+
+    runScheduleNow: async (id) => {
+      const data = await request('POST', `/schedules/${id}/run-now`);
+      return data as { runId: string };
     },
   };
 };

--- a/src/utils/daemon-client.ts
+++ b/src/utils/daemon-client.ts
@@ -20,10 +20,13 @@ export const get = async <T>(path: string): Promise<T> => {
   return response.json() as Promise<T>;
 };
 
-export const post = async <T>(path: string, body?: unknown): Promise<T> => {
+export const post = async <T>(path: string, body?: unknown): Promise<T> =>
+  request<T>('POST', path, body);
+
+export const request = async <T>(method: string, path: string, body?: unknown): Promise<T> => {
   const response = await fetch(`${getBaseUrl()}${path}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method,
+    headers: body ? { 'Content-Type': 'application/json' } : undefined,
     body: body ? JSON.stringify(body) : undefined,
   });
   if (!response.ok) {


### PR DESCRIPTION
## Summary

Slice 3 of scheduler — CLI parity with the dashboard. Closes the v1 trio (backend #140, dashboard #142, daemon #131, this).

\`\`\`
agentage schedules                                   # list (default subcommand)
agentage schedules --machine <id> --enabled --json   # filters
agentage schedules add <agent> <cron|preset>         # create on this machine
agentage schedules enable|disable <id>               # toggle (id-prefix ok)
agentage schedules remove|rm <id>                    # delete
agentage schedules run-now <id>                      # fire once outside cadence
agentage schedules next <id>                         # next 5 fires, computed locally
\`\`\`

Presets: \`hourly\`, \`daily\` (9 AM), \`weekdays\` (9 AM Mon–Fri), \`weekly\` (9 AM Mon).

## Changes

- **\`src/hub/hub-client.ts\`** — 5 new schedule methods (get/create/update/delete/run-now). Independent of the \`fireSchedule\` method added in #131; merged on master cleanly.
- **\`src/daemon/routes.ts\`** — 5 \`/api/hub/schedules*\` proxy routes following the existing pattern (\`/api/hub/runs\`, \`/api/hub/agents\`). Shared auth + error handler via \`withHubClient\` helper.
- **\`src/utils/daemon-client.ts\`** — extracts generic \`request()\` for PATCH/DELETE; \`post()\` now thin wrapper.
- **\`src/commands/schedules.ts\`** — commander definitions, id-prefix resolution (rejects ambiguous + no-match), preset expansion, JSON mode.

## Decisions

- **Id-prefix matching** matches the existing CLI ergonomics (e.g. \`agentage runs\` shows truncated 8-char IDs). User pastes the short prefix; we resolve.
- **Default machine = current daemon's** (from \`loadConfig().machine.id\`). Override with \`--machine\` for cross-machine schedule creation.
- **No \`edit\` subcommand v1** — per spec; user edits via dashboard or \`disable\` + new \`add\`. Add later if ergonomics demand.

## Test plan

- [x] 13 new unit tests on \`schedules.test.ts\` (filters, presets, --task, PATCH/DELETE wiring, ambiguous-id rejection, run-now, next-fires).
- [x] Full verify: 481/482 (one pre-existing flake in \`ensure-daemon.test.ts\` worker-exit, reproduces on plain master).
- [ ] Manual: \`agentage schedules add echo daily --task "morning brief"\` against dev hub once cli is published / built locally.