### PR TITLE
feat(config): agents/projects dirs with default + additional

### DIFF
--- a/src/commands/config-cmd.test.ts
+++ b/src/commands/config-cmd.test.ts
@@ -19,7 +19,8 @@ describe('config command', () => {
   const defaultConfig = {
     machine: { id: 'machine-123', name: 'test-host' },
     daemon: { port: 4243 },
-    discovery: { dirs: ['/home/user/.agentage/agents'] },
+    agents: { default: '/home/user/agents', additional: [] },
+    projects: { default: '/home/user/projects', additional: [] },
     sync: {
       events: {
         state: true,

--- a/src/commands/create.test.ts
+++ b/src/commands/create.test.ts
@@ -9,9 +9,12 @@ const configDir = join(testDir, '.agentage');
 describe('create command', () => {
   beforeEach(() => {
     mkdirSync(testDir, { recursive: true });
+    mkdirSync(configDir, { recursive: true });
+    process.env['AGENTAGE_CONFIG_DIR'] = configDir;
   });
 
   afterEach(() => {
+    delete process.env['AGENTAGE_CONFIG_DIR'];
     rmSync(testDir, { recursive: true, force: true });
   });
 
@@ -97,7 +100,8 @@ describe('create command', () => {
       JSON.stringify({
         machine: { id: 'test', name: 'test' },
         daemon: { port: 4243 },
-        discovery: { dirs: [agentsDir] },
+        agents: { default: agentsDir, additional: [] },
+        projects: { default: '/tmp/projects', additional: [] },
         sync: { events: {} },
       })
     );
@@ -121,7 +125,8 @@ describe('create command', () => {
       JSON.stringify({
         machine: { id: 'test', name: 'test' },
         daemon: { port: 4243 },
-        discovery: { dirs: [agentsDir] },
+        agents: { default: agentsDir, additional: [] },
+        projects: { default: '/tmp/projects', additional: [] },
         sync: { events: {} },
       })
     );
@@ -149,7 +154,8 @@ describe('create command', () => {
       JSON.stringify({
         machine: { id: 'test', name: 'test' },
         daemon: { port: 4243 },
-        discovery: { dirs: [agentsDir] },
+        agents: { default: agentsDir, additional: [] },
+        projects: { default: '/tmp/projects', additional: [] },
         sync: { events: {} },
       })
     );

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { Command } from 'commander';
 import chalk from 'chalk';
-import { loadConfig } from '../daemon/config.js';
+import { loadConfig, getAgentsDirs, getDefaultAgentsDir } from '../daemon/config.js';
 
 const TEMPLATES: Record<string, { content: (name: string) => string; deps?: string[] }> = {
   simple: {
@@ -76,12 +76,12 @@ Respond concisely and cite sources when possible.\`,
 
 const KEBAB_CASE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
 
-const getDefaultAgentsDir = (): string => {
+const resolveInstallDir = (): string => {
   try {
     const config = loadConfig();
-    return config.discovery.dirs[0] ?? join(process.env['HOME'] || '~', '.agentage', 'agents');
+    return config.agents.default;
   } catch {
-    return join(process.env['HOME'] || '~', '.agentage', 'agents');
+    return getDefaultAgentsDir();
   }
 };
 
@@ -90,7 +90,7 @@ export const createCreateCommand = (): Command => {
     .description('Scaffold a new agent from a template')
     .argument('<name>', 'Agent name (kebab-case)')
     .option('-t, --template <template>', 'Template: simple, shell, claude, copilot, llm', 'simple')
-    .option('-d, --dir <dir>', 'Output directory (default: first discovery dir)')
+    .option('-d, --dir <dir>', 'Output directory (default: agents.default)')
     .action(async (name: string, options: { template: string; dir?: string }) => {
       if (!KEBAB_CASE.test(name)) {
         console.error(chalk.red(`Invalid name "${name}". Use kebab-case (e.g. my-agent).`));
@@ -109,7 +109,7 @@ export const createCreateCommand = (): Command => {
         return;
       }
 
-      const dir = resolve(options.dir ?? getDefaultAgentsDir());
+      const dir = resolve(options.dir ?? resolveInstallDir());
       const filePath = join(dir, `${name}.agent.ts`);
 
       if (existsSync(filePath)) {
@@ -129,7 +129,7 @@ export const createCreateCommand = (): Command => {
       }
 
       const config = loadConfig();
-      const isInDiscoveryDir = config.discovery.dirs.some((d) =>
+      const isInDiscoveryDir = getAgentsDirs(config).some((d) =>
         dir.startsWith(d.replace(/^~/, process.env['HOME'] || '~'))
       );
 
@@ -138,7 +138,9 @@ export const createCreateCommand = (): Command => {
         console.log(chalk.dim(`Run: agentage run ${name} "your prompt"`));
       } else {
         console.log(
-          chalk.dim(`\nTo use:\n  cp ${filePath} ~/.agentage/agents/\n  agentage agents --refresh`)
+          chalk.dim(
+            `\nTo use:\n  cp ${filePath} ${config.agents.default}/\n  agentage agents --refresh`
+          )
         );
       }
     });

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -23,7 +23,8 @@ describe('init command', () => {
   const defaultConfig = {
     machine: { id: 'machine-123', name: 'test-host' },
     daemon: { port: 4243 },
-    discovery: { dirs: [] },
+    agents: { default: '/home/user/agents', additional: [] },
+    projects: { default: '/home/user/projects', additional: [] },
     sync: {
       events: {
         state: true,
@@ -61,12 +62,12 @@ describe('init command', () => {
     expect(logs.some((l) => l.includes('Machine name: my-pc'))).toBe(true);
   });
 
-  it('adds discovery dir with --dir', async () => {
+  it('adds agents dir with --dir', async () => {
     await program.parseAsync(['node', 'agentage', 'init', '--dir', '/tmp/agents']);
 
     const saved = mockSaveConfig.mock.calls[0]![0];
-    expect(saved.discovery.dirs).toContain('/tmp/agents');
-    expect(logs.some((l) => l.includes('Discovery dir:'))).toBe(true);
+    expect(saved.agents.additional).toContain('/tmp/agents');
+    expect(logs.some((l) => l.includes('Agents dir:'))).toBe(true);
   });
 
   it('sets hub URL with --hub', async () => {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,7 +10,7 @@ export const registerInit = (program: Command): void => {
     .description('Initialize agentage setup')
     .option('--hub <url>', 'Set hub URL')
     .option('--name <name>', 'Set machine name')
-    .option('--dir <path>', 'Add discovery directory')
+    .option('--dir <path>', 'Add to agents.additional')
     .option('--no-login', 'Skip login step')
     .action(async (opts: { hub?: string; name?: string; dir?: string; login: boolean }) => {
       const config = loadConfig();
@@ -22,13 +22,13 @@ export const registerInit = (program: Command): void => {
         steps.push(`Machine name: ${opts.name}`);
       }
 
-      // Step 2: Discovery dir
+      // Step 2: Additional agents dir
       if (opts.dir) {
         const absolute = resolve(opts.dir);
-        if (!config.discovery.dirs.includes(absolute)) {
-          config.discovery.dirs.push(absolute);
+        if (config.agents.default !== absolute && !config.agents.additional.includes(absolute)) {
+          config.agents.additional.push(absolute);
         }
-        steps.push(`Discovery dir: ${absolute}`);
+        steps.push(`Agents dir: ${absolute}`);
       }
 
       // Step 3: Hub URL

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -61,7 +61,8 @@ describe('login command', () => {
     mockLoadConfig.mockReturnValue({
       machine: { id: 'machine-1', name: 'test-pc' },
       daemon: { port: 4243 },
-      discovery: { dirs: [] },
+      agents: { default: '/tmp/agents', additional: [] },
+      projects: { default: '/tmp/projects', additional: [] },
       sync: { events: {} },
     } as unknown as ReturnType<typeof loadConfig>);
 

--- a/src/commands/schedules.test.ts
+++ b/src/commands/schedules.test.ts
@@ -15,7 +15,8 @@ vi.mock('../daemon/config.js', () => ({
   loadConfig: vi.fn(() => ({
     machine: { id: '11111111-1111-1111-1111-111111111111', name: 'localdev' },
     daemon: { port: 4243 },
-    discovery: { dirs: [] },
+    agents: { default: '/tmp/agents', additional: [] },
+    projects: { default: '/tmp/projects', additional: [] },
     sync: { events: {} },
   })),
 }));

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -49,8 +49,13 @@ describe('status command', () => {
   const defaultConfig = {
     machine: { id: 'machine-123', name: 'test-host' },
     daemon: { port: 4243 },
-    discovery: {
-      dirs: ['/home/user/.agentage/agents', '/home/user/.agentage/skills'],
+    agents: {
+      default: '/home/user/agents',
+      additional: ['/home/user/.agentage/skills'],
+    },
+    projects: {
+      default: '/home/user/projects',
+      additional: [],
     },
     sync: {
       events: {
@@ -236,7 +241,7 @@ describe('status command', () => {
     expect(logs.some((l) => l.includes('45s'))).toBe(true);
   });
 
-  it('displays discovery directories in status output', async () => {
+  it('displays agent dirs in status output', async () => {
     mockGet.mockImplementation(async (path: string) => {
       if (path === '/api/health') return baseHealth;
       return [];
@@ -245,18 +250,18 @@ describe('status command', () => {
 
     await program.parseAsync(['node', 'agentage', 'status']);
 
-    expect(logs.some((l) => l.includes('Discovery:'))).toBe(true);
-    expect(logs.some((l) => l.includes('/home/user/.agentage/agents'))).toBe(true);
+    expect(logs.some((l) => l.includes('/home/user/agents'))).toBe(true);
     expect(logs.some((l) => l.includes('/home/user/.agentage/skills'))).toBe(true);
+    expect(logs.some((l) => l.includes('/home/user/projects'))).toBe(true);
   });
 
-  it('--add-dir adds a new directory to config', async () => {
+  it('--add-dir adds a new directory to agents.additional', async () => {
     await program.parseAsync(['node', 'agentage', 'status', '--add-dir', '/tmp/new-agents']);
 
     expect(mockSaveConfig).toHaveBeenCalledTimes(1);
     const savedConfig = mockSaveConfig.mock.calls[0]![0];
-    expect(savedConfig.discovery.dirs).toContain('/tmp/new-agents');
-    expect(logs.some((l) => l.includes('Added discovery directory'))).toBe(true);
+    expect(savedConfig.agents.additional).toContain('/tmp/new-agents');
+    expect(logs.some((l) => l.includes('Added agents directory'))).toBe(true);
     expect(mockExit).toHaveBeenCalledWith(0);
   });
 
@@ -266,29 +271,60 @@ describe('status command', () => {
       'agentage',
       'status',
       '--add-dir',
-      '/home/user/.agentage/agents',
+      '/home/user/.agentage/skills',
     ]);
 
     expect(mockSaveConfig).not.toHaveBeenCalled();
-    expect(logs.some((l) => l.includes('already in discovery'))).toBe(true);
+    expect(logs.some((l) => l.includes('already configured'))).toBe(true);
     expect(mockExit).toHaveBeenCalledWith(0);
   });
 
-  it('--remove-dir removes a directory from config', async () => {
+  it('--add-dir rejects path matching agents.default as duplicate', async () => {
+    await program.parseAsync(['node', 'agentage', 'status', '--add-dir', '/home/user/agents']);
+
+    expect(mockSaveConfig).not.toHaveBeenCalled();
+    expect(logs.some((l) => l.includes('already configured'))).toBe(true);
+  });
+
+  it('--remove-dir removes from agents.additional', async () => {
     await program.parseAsync([
       'node',
       'agentage',
       'status',
       '--remove-dir',
-      '/home/user/.agentage/agents',
+      '/home/user/.agentage/skills',
     ]);
 
     expect(mockSaveConfig).toHaveBeenCalledTimes(1);
     const savedConfig = mockSaveConfig.mock.calls[0]![0];
-    expect(savedConfig.discovery.dirs).not.toContain('/home/user/.agentage/agents');
-    expect(savedConfig.discovery.dirs).toContain('/home/user/.agentage/skills');
-    expect(logs.some((l) => l.includes('Removed discovery directory'))).toBe(true);
+    expect(savedConfig.agents.additional).not.toContain('/home/user/.agentage/skills');
+    expect(savedConfig.agents.default).toBe('/home/user/agents');
+    expect(logs.some((l) => l.includes('Removed agents directory'))).toBe(true);
     expect(mockExit).toHaveBeenCalledWith(0);
+  });
+
+  it('--remove-dir refuses to remove agents.default', async () => {
+    const mockExitErr = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    const errLogs: string[] = [];
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errLogs.push(args.map(String).join(' '));
+    });
+
+    await program.parseAsync(['node', 'agentage', 'status', '--remove-dir', '/home/user/agents']);
+
+    expect(mockSaveConfig).not.toHaveBeenCalled();
+    expect(errLogs.some((l) => l.includes('Cannot remove default'))).toBe(true);
+    expect(mockExitErr).toHaveBeenCalledWith(1);
+  });
+
+  it('--set-default swaps default and demotes old default to additional', async () => {
+    await program.parseAsync(['node', 'agentage', 'status', '--set-default', '/tmp/new-default']);
+
+    expect(mockSaveConfig).toHaveBeenCalledTimes(1);
+    const savedConfig = mockSaveConfig.mock.calls[0]![0];
+    expect(savedConfig.agents.default).toBe('/tmp/new-default');
+    expect(savedConfig.agents.additional).toContain('/home/user/agents');
+    expect(logs.some((l) => l.includes('Set agents default'))).toBe(true);
   });
 
   it('outputs JSON with --json', async () => {
@@ -314,7 +350,10 @@ describe('status command', () => {
     expect(parsed.hub.url).toBe('https://agentage.io');
     expect(parsed.agents).toBe(2);
     expect(parsed.runs).toBe(3);
-    expect(parsed.discoveryDirs).toHaveLength(2);
+    expect(parsed.agentsDefault).toBe('/home/user/agents');
+    expect(parsed.agentsAdditional).toEqual(['/home/user/.agentage/skills']);
+    expect(parsed.projectsDefault).toBe('/home/user/projects');
+    expect(parsed.projectsAdditional).toEqual([]);
     expect(mockExit).toHaveBeenCalledWith(0);
   });
 
@@ -323,8 +362,8 @@ describe('status command', () => {
 
     expect(mockSaveConfig).toHaveBeenCalledTimes(1);
     const savedConfig = mockSaveConfig.mock.calls[0]![0];
-    expect(savedConfig.discovery.dirs).toHaveLength(2);
-    expect(logs.some((l) => l.includes('Removed discovery directory'))).toBe(true);
+    expect(savedConfig.agents.additional).toHaveLength(1);
+    expect(logs.some((l) => l.includes('Removed agents directory'))).toBe(true);
     expect(mockExit).toHaveBeenCalledWith(0);
   });
 });

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -23,125 +23,169 @@ export const registerStatus = (program: Command): void => {
   program
     .command('status')
     .description('Show daemon and connection status')
-    .option('--add-dir <path>', 'Add directory to agent discovery')
-    .option('--remove-dir <path>', 'Remove directory from agent discovery')
+    .option('--add-dir <path>', 'Add directory to agents.additional')
+    .option('--remove-dir <path>', 'Remove directory from agents.additional')
+    .option('--set-default <path>', 'Set agents.default (install target)')
     .option('--json', 'JSON output')
-    .action(async (opts: { addDir?: string; removeDir?: string; json?: boolean }) => {
-      if (opts.addDir) {
-        handleAddDir(opts.addDir);
-        return;
-      }
+    .action(
+      async (opts: {
+        addDir?: string;
+        removeDir?: string;
+        setDefault?: string;
+        json?: boolean;
+      }) => {
+        if (opts.addDir) {
+          handleAddDir(opts.addDir);
+          return;
+        }
 
-      if (opts.removeDir) {
-        handleRemoveDir(opts.removeDir);
-        return;
-      }
+        if (opts.removeDir) {
+          handleRemoveDir(opts.removeDir);
+          return;
+        }
 
-      await ensureDaemon();
-      const [health, agents, runs, updateCheck] = await Promise.all([
-        get<HealthResponse>('/api/health'),
-        get<unknown[]>('/api/agents'),
-        get<unknown[]>('/api/runs'),
-        checkForUpdateSafe(),
-      ]);
-      const pid = getDaemonPid();
-      const config = loadConfig();
-      const dirs = config.discovery.dirs;
+        if (opts.setDefault) {
+          handleSetDefault(opts.setDefault);
+          return;
+        }
 
-      const projects = loadProjects();
+        await ensureDaemon();
+        const [health, agents, runs, updateCheck] = await Promise.all([
+          get<HealthResponse>('/api/health'),
+          get<unknown[]>('/api/agents'),
+          get<unknown[]>('/api/runs'),
+          checkForUpdateSafe(),
+        ]);
+        const pid = getDaemonPid();
+        const config = loadConfig();
 
-      if (opts.json) {
+        const projects = loadProjects();
+
+        if (opts.json) {
+          console.log(
+            JSON.stringify(
+              {
+                daemon: { status: 'running', pid, port: config.daemon.port },
+                version: {
+                  current: health.version,
+                  latest: updateCheck?.latestVersion ?? null,
+                  updateAvailable: updateCheck?.updateAvailable ?? false,
+                },
+                uptime: health.uptime,
+                hub: {
+                  connected: health.hubConnected,
+                  connecting: health.hubConnecting,
+                  url: health.hubUrl,
+                  userEmail: health.userEmail,
+                },
+                machine: health.machineId,
+                agents: agents.length,
+                projects: projects.length,
+                runs: runs.length,
+                agentsDefault: config.agents.default,
+                agentsAdditional: config.agents.additional,
+                projectsDefault: config.projects.default,
+                projectsAdditional: config.projects.additional,
+              },
+              null,
+              2
+            )
+          );
+          process.exit(0);
+          return;
+        }
+
+        const uptime = formatUptime(health.uptime);
+        const activeRuns = runs.length;
+
         console.log(
-          JSON.stringify(
-            {
-              daemon: { status: 'running', pid, port: config.daemon.port },
-              version: {
-                current: health.version,
-                latest: updateCheck?.latestVersion ?? null,
-                updateAvailable: updateCheck?.updateAvailable ?? false,
-              },
-              uptime: health.uptime,
-              hub: {
-                connected: health.hubConnected,
-                connecting: health.hubConnecting,
-                url: health.hubUrl,
-                userEmail: health.userEmail,
-              },
-              machine: health.machineId,
-              agents: agents.length,
-              projects: projects.length,
-              runs: runs.length,
-              discoveryDirs: dirs,
-            },
-            null,
-            2
-          )
+          `Daemon:     ${chalk.green('running')} (PID ${pid}, port ${config.daemon.port})`
         );
-        process.exit(0);
-        return;
-      }
+        const versionLine = updateCheck?.updateAvailable
+          ? `${health.version} ${chalk.yellow(`→ ${updateCheck.latestVersion} available`)} ${chalk.dim('(run `agentage update`)')}`
+          : health.version;
+        console.log(`Version:    ${versionLine}`);
+        console.log(`Uptime:     ${uptime}`);
 
-      const uptime = formatUptime(health.uptime);
-      const activeRuns = runs.length;
+        if (health.hubConnected) {
+          console.log(`Hub:        ${chalk.green('connected')} (${health.hubUrl})`);
+          console.log(`User:       ${health.userEmail}`);
+        } else if (health.hubConnecting) {
+          console.log(`Hub:        ${chalk.cyan('connecting')} (${health.hubUrl})`);
+          console.log(`User:       ${health.userEmail}`);
+        } else if (health.hubUrl) {
+          console.log(`Hub:        ${chalk.yellow('disconnected')} (${health.hubUrl})`);
+          console.log(`User:       ${health.userEmail}`);
+        } else {
+          console.log(`Hub:        ${chalk.yellow('not connected (standalone mode)')}`);
+        }
 
-      console.log(`Daemon:     ${chalk.green('running')} (PID ${pid}, port 4243)`);
-      const versionLine = updateCheck?.updateAvailable
-        ? `${health.version} ${chalk.yellow(`→ ${updateCheck.latestVersion} available`)} ${chalk.dim('(run `agentage update`)')}`
-        : health.version;
-      console.log(`Version:    ${versionLine}`);
-      console.log(`Uptime:     ${uptime}`);
+        console.log(`Machine:    ${health.machineId}`);
+        console.log(`Agents:     ${agents.length} discovered`);
+        console.log(`Projects:   ${projects.length} registered`);
+        console.log(`Runs:       ${activeRuns} active`);
 
-      if (health.hubConnected) {
-        console.log(`Hub:        ${chalk.green('connected')} (${health.hubUrl})`);
-        console.log(`User:       ${health.userEmail}`);
-      } else if (health.hubConnecting) {
-        console.log(`Hub:        ${chalk.cyan('connecting')} (${health.hubUrl})`);
-        console.log(`User:       ${health.userEmail}`);
-      } else if (health.hubUrl) {
-        console.log(`Hub:        ${chalk.yellow('disconnected')} (${health.hubUrl})`);
-        console.log(`User:       ${health.userEmail}`);
-      } else {
-        console.log(`Hub:        ${chalk.yellow('not connected (standalone mode)')}`);
-      }
-
-      console.log(`Machine:    ${health.machineId}`);
-      console.log(`Agents:     ${agents.length} discovered`);
-      console.log(`Projects:   ${projects.length} registered`);
-      console.log(`Runs:       ${activeRuns} active`);
-
-      if (dirs.length > 0) {
-        console.log(`Discovery:  ${dirs[0]}`);
-        for (const dir of dirs.slice(1)) {
+        console.log(`Agents:     ${config.agents.default} ${chalk.dim('(default)')}`);
+        for (const dir of config.agents.additional) {
           console.log(`            ${dir}`);
         }
-      } else {
-        console.log('Discovery:  (none)');
-      }
+        console.log(`Projects:   ${config.projects.default} ${chalk.dim('(default)')}`);
+        for (const dir of config.projects.additional) {
+          console.log(`            ${dir}`);
+        }
 
-      process.exit(0);
-    });
+        process.exit(0);
+      }
+    );
 };
 
 const handleAddDir = (path: string): void => {
   const absolute = resolve(path);
   const config = loadConfig();
-  if (config.discovery.dirs.includes(absolute)) {
-    console.log(chalk.yellow(`Directory already in discovery: ${absolute}`));
+  if (config.agents.default === absolute || config.agents.additional.includes(absolute)) {
+    console.log(chalk.yellow(`Directory already configured: ${absolute}`));
     process.exit(0);
     return;
   }
-  config.discovery.dirs.push(absolute);
+  config.agents.additional.push(absolute);
   saveConfig(config);
-  console.log(chalk.green(`Added discovery directory: ${absolute}`));
+  console.log(chalk.green(`Added agents directory: ${absolute}`));
   process.exit(0);
 };
 
 const handleRemoveDir = (path: string): void => {
   const absolute = resolve(path);
   const config = loadConfig();
-  config.discovery.dirs = config.discovery.dirs.filter((d) => d !== absolute);
+  if (config.agents.default === absolute) {
+    console.error(
+      chalk.red(`Cannot remove default directory. Use --set-default to change it first.`)
+    );
+    process.exit(1);
+    return;
+  }
+  config.agents.additional = config.agents.additional.filter((d) => d !== absolute);
   saveConfig(config);
-  console.log(chalk.green(`Removed discovery directory: ${absolute}`));
+  console.log(chalk.green(`Removed agents directory: ${absolute}`));
+  process.exit(0);
+};
+
+const handleSetDefault = (path: string): void => {
+  const absolute = resolve(path);
+  const config = loadConfig();
+  const previousDefault = config.agents.default;
+  if (previousDefault === absolute) {
+    console.log(chalk.yellow(`Already the default: ${absolute}`));
+    process.exit(0);
+    return;
+  }
+  config.agents.additional = config.agents.additional.filter((d) => d !== absolute);
+  if (previousDefault && !config.agents.additional.includes(previousDefault)) {
+    config.agents.additional.unshift(previousDefault);
+  }
+  config.agents.default = absolute;
+  saveConfig(config);
+  console.log(chalk.green(`Set agents default: ${absolute}`));
+  console.log(chalk.dim(`Previous default moved to additional: ${previousDefault}`));
   process.exit(0);
 };
 

--- a/src/commands/whoami.test.ts
+++ b/src/commands/whoami.test.ts
@@ -23,7 +23,8 @@ describe('whoami command', () => {
   const defaultConfig = {
     machine: { id: 'machine-123', name: 'test-host' },
     daemon: { port: 4243 },
-    discovery: { dirs: [] },
+    agents: { default: '/tmp/agents', additional: [] },
+    projects: { default: '/tmp/projects', additional: [] },
     hub: { url: 'https://agentage.io' },
     sync: {
       events: {

--- a/src/daemon-entry.ts
+++ b/src/daemon-entry.ts
@@ -1,5 +1,5 @@
 import { watch } from 'node:fs';
-import { loadConfig, getConfigDir } from './daemon/config.js';
+import { loadConfig, getConfigDir, getAgentsDirs } from './daemon/config.js';
 import { logError, logInfo } from './daemon/logger.js';
 import { writePidFile, removePidFile } from './daemon/daemon.js';
 import { createDaemonServer } from './daemon/server.js';
@@ -22,7 +22,7 @@ const main = async (): Promise<void> => {
   server.setFactories(factories);
 
   // Initial agent discovery
-  const agents = await scanAgents(config.discovery.dirs, factories);
+  const agents = await scanAgents(getAgentsDirs(config), factories);
   server.updateAgents(agents);
   logInfo(`Discovered ${agents.length} agent(s)`);
 
@@ -44,10 +44,10 @@ const main = async (): Promise<void> => {
   await hubSync.start();
 
   // Watch discovery dirs for agent file changes
-  const stopWatcher = startWatcher(config.discovery.dirs, async () => {
+  const stopWatcher = startWatcher(getAgentsDirs(config), async () => {
     try {
       const freshConfig = loadConfig();
-      const updatedAgents = await scanAgents(freshConfig.discovery.dirs, factories);
+      const updatedAgents = await scanAgents(getAgentsDirs(freshConfig), factories);
       server.updateAgents(updatedAgents);
       logInfo(`Watcher rescan: discovered ${updatedAgents.length} agent(s)`);
     } catch (err) {

--- a/src/daemon/config.test.ts
+++ b/src/daemon/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
 
 const testDir = join(tmpdir(), `agentage-test-config-${Date.now()}`);
 
@@ -13,6 +13,8 @@ describe('config', () => {
 
   afterEach(() => {
     delete process.env['AGENTAGE_CONFIG_DIR'];
+    delete process.env['AGENTAGE_AGENTS_DIR'];
+    delete process.env['AGENTAGE_PROJECTS_DIR'];
     rmSync(testDir, { recursive: true, force: true });
   });
 
@@ -24,7 +26,10 @@ describe('config', () => {
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
     );
     expect(config.daemon.port).toBe(4243);
-    expect(config.discovery.dirs).toHaveLength(2);
+    expect(config.agents.default).toBe(join(homedir(), 'agents'));
+    expect(config.agents.additional).toEqual([]);
+    expect(config.projects.default).toBe(join(homedir(), 'projects'));
+    expect(config.projects.additional).toEqual([]);
     expect(existsSync(join(testDir, 'config.json'))).toBe(true);
   });
 
@@ -41,19 +46,20 @@ describe('config', () => {
     const config = loadConfig();
     const originalId = config.machine.id;
 
-    // Load again — should return same config
     const config2 = loadConfig();
     expect(config2.machine.id).toBe(originalId);
   });
 
-  it('default discovery dirs include agents and skills', async () => {
+  it('default agents dir is homedir()/agents', async () => {
     const { loadConfig } = await import('./config.js');
     const config = loadConfig();
+    expect(config.agents.default).toBe(join(homedir(), 'agents'));
+  });
 
-    const agentsDir = config.discovery.dirs.find((d) => d.endsWith('/agents'));
-    const skillsDir = config.discovery.dirs.find((d) => d.endsWith('/skills'));
-    expect(agentsDir).toBeDefined();
-    expect(skillsDir).toBeDefined();
+  it('default projects dir is homedir()/projects', async () => {
+    const { loadConfig } = await import('./config.js');
+    const config = loadConfig();
+    expect(config.projects.default).toBe(join(homedir(), 'projects'));
   });
 
   it('respects AGENTAGE_CONFIG_DIR', async () => {
@@ -95,5 +101,43 @@ describe('config', () => {
     const config = loadConfig();
     expect(config.daemon.port).toBe(5555);
     delete process.env['AGENTAGE_PORT'];
+  });
+
+  it('AGENTAGE_AGENTS_DIR overrides agents.default (in-memory, not persisted)', async () => {
+    process.env['AGENTAGE_AGENTS_DIR'] = '/tmp/custom-agents';
+    const { loadConfig } = await import('./config.js');
+    const config = loadConfig();
+    expect(config.agents.default).toBe('/tmp/custom-agents');
+
+    const raw = readFileSync(join(testDir, 'config.json'), 'utf-8');
+    const saved = JSON.parse(raw);
+    expect(saved.agents.default).toBe(join(homedir(), 'agents'));
+  });
+
+  it('AGENTAGE_PROJECTS_DIR overrides projects.default (in-memory, not persisted)', async () => {
+    process.env['AGENTAGE_PROJECTS_DIR'] = '/tmp/custom-projects';
+    const { loadConfig } = await import('./config.js');
+    const config = loadConfig();
+    expect(config.projects.default).toBe('/tmp/custom-projects');
+
+    const raw = readFileSync(join(testDir, 'config.json'), 'utf-8');
+    const saved = JSON.parse(raw);
+    expect(saved.projects.default).toBe(join(homedir(), 'projects'));
+  });
+
+  it('getAgentsDirs returns [default, ...additional] deduped', async () => {
+    const { loadConfig, getAgentsDirs } = await import('./config.js');
+    const config = loadConfig();
+    config.agents.default = '/a';
+    config.agents.additional = ['/b', '/a', '/c'];
+    expect(getAgentsDirs(config)).toEqual(['/a', '/b', '/c']);
+  });
+
+  it('getProjectsDirs returns [default, ...additional] deduped', async () => {
+    const { loadConfig, getProjectsDirs } = await import('./config.js');
+    const config = loadConfig();
+    config.projects.default = '/a';
+    config.projects.additional = ['/b', '/a'];
+    expect(getProjectsDirs(config)).toEqual(['/a', '/b']);
   });
 });

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { hostname } from 'node:os';
+import { homedir, hostname } from 'node:os';
 import { join } from 'node:path';
 
 export interface SyncEvents {
@@ -14,6 +14,11 @@ export interface SyncEvents {
   'output.progress': boolean;
 }
 
+export interface DirConfig {
+  default: string;
+  additional: string[];
+}
+
 export interface DaemonConfig {
   machine: {
     id: string;
@@ -25,12 +30,8 @@ export interface DaemonConfig {
   hub?: {
     url: string;
   };
-  projects?: {
-    roots: string[];
-  };
-  discovery: {
-    dirs: string[];
-  };
+  agents: DirConfig;
+  projects: DirConfig;
   sync: {
     events: SyncEvents;
   };
@@ -44,33 +45,48 @@ export const getConfigDir = (): string => {
   return dir;
 };
 
-const createDefaultConfig = (): DaemonConfig => {
-  const configDir = getConfigDir();
-  return {
-    machine: {
-      id: randomUUID(),
-      name: hostname(),
-    },
-    daemon: {
-      port: 4243,
-    },
-    discovery: {
-      dirs: [join(configDir, 'agents'), join(configDir, 'skills')],
-    },
-    sync: {
-      events: {
-        state: true,
-        result: true,
-        error: true,
-        input_required: true,
-        'output.llm.delta': true,
-        'output.llm.tool_call': true,
-        'output.llm.usage': true,
-        'output.progress': true,
-      },
-    },
-  };
+export const getDefaultAgentsDir = (): string => join(homedir(), 'agents');
+export const getDefaultProjectsDir = (): string => join(homedir(), 'projects');
+
+export const getAgentsDirs = (config: DaemonConfig): string[] => {
+  const all = [config.agents.default, ...config.agents.additional];
+  return Array.from(new Set(all));
 };
+
+export const getProjectsDirs = (config: DaemonConfig): string[] => {
+  const all = [config.projects.default, ...config.projects.additional];
+  return Array.from(new Set(all));
+};
+
+const createDefaultConfig = (): DaemonConfig => ({
+  machine: {
+    id: randomUUID(),
+    name: hostname(),
+  },
+  daemon: {
+    port: 4243,
+  },
+  agents: {
+    default: getDefaultAgentsDir(),
+    additional: [],
+  },
+  projects: {
+    default: getDefaultProjectsDir(),
+    additional: [],
+  },
+  sync: {
+    events: {
+      state: true,
+      result: true,
+      error: true,
+      input_required: true,
+      'output.llm.delta': true,
+      'output.llm.tool_call': true,
+      'output.llm.usage': true,
+      'output.progress': true,
+    },
+  },
+});
 
 export const loadConfig = (): DaemonConfig => {
   const configPath = join(getConfigDir(), 'config.json');
@@ -88,6 +104,16 @@ export const loadConfig = (): DaemonConfig => {
   const portOverride = process.env['AGENTAGE_PORT'];
   if (portOverride) {
     config.daemon.port = parseInt(portOverride, 10);
+  }
+
+  const agentsOverride = process.env['AGENTAGE_AGENTS_DIR'];
+  if (agentsOverride) {
+    config.agents.default = agentsOverride;
+  }
+
+  const projectsOverride = process.env['AGENTAGE_PROJECTS_DIR'];
+  if (projectsOverride) {
+    config.projects.default = projectsOverride;
   }
 
   return config;

--- a/src/daemon/routes.test.ts
+++ b/src/daemon/routes.test.ts
@@ -80,7 +80,8 @@ describe('daemon routes', () => {
     mockLoadConfig.mockReturnValue({
       machine: { id: 'machine-1', name: 'test-pc' },
       daemon: { port: 4243 },
-      discovery: { dirs: [] },
+      agents: { default: '/tmp/agents', additional: [] },
+      projects: { default: '/tmp/projects', additional: [] },
       sync: { events: {} },
     } as unknown as ReturnType<typeof loadConfig>);
 

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -23,7 +23,8 @@ describe('server', () => {
       JSON.stringify({
         machine: { id: randomUUID(), name: 'test' },
         daemon: { port },
-        discovery: { dirs: [] },
+        agents: { default: '/tmp/agents', additional: [] },
+        projects: { default: '/tmp/projects', additional: [] },
         sync: { events: {} },
       })
     );

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -1,7 +1,7 @@
 import { createServer, type Server } from 'node:http';
 import express from 'express';
 import { type Agent, type AgentFactory } from '@agentage/core';
-import { loadConfig } from './config.js';
+import { loadConfig, getAgentsDirs } from './config.js';
 import { logInfo } from './logger.js';
 import { createRoutes, setAgents, setRefreshHandler } from './routes.js';
 import { setupWebSocket } from './websocket.js';
@@ -29,7 +29,7 @@ export const createDaemonServer = (): DaemonServer => {
   // Wire up refresh to actually rescan
   setRefreshHandler(async () => {
     const config = loadConfig();
-    const agents = await scanAgents(config.discovery.dirs, factories);
+    const agents = await scanAgents(getAgentsDirs(config), factories);
     setAgents(agents);
     logInfo(`Refresh: discovered ${agents.length} agent(s)`);
     return agents;

--- a/src/daemon/websocket.test.ts
+++ b/src/daemon/websocket.test.ts
@@ -19,7 +19,8 @@ describe('websocket', () => {
       JSON.stringify({
         machine: { id: randomUUID(), name: 'test' },
         daemon: { port: 4243 },
-        discovery: { dirs: [] },
+        agents: { default: '/tmp/agents', additional: [] },
+        projects: { default: '/tmp/projects', additional: [] },
         sync: { events: {} },
       })
     );

--- a/src/e2e/daemon-lifecycle.test.ts
+++ b/src/e2e/daemon-lifecycle.test.ts
@@ -31,7 +31,8 @@ const writeTestConfig = (): void => {
     JSON.stringify({
       machine: { id: randomUUID(), name: 'e2e-test-machine' },
       daemon: { port },
-      discovery: { dirs: [agentsDir, skillsDir] },
+      agents: { default: agentsDir, additional: [skillsDir] },
+      projects: { default: join(tmpdir(), 'projects'), additional: [] },
       sync: {
         events: {
           state: true,
@@ -169,7 +170,7 @@ describe('E2E: daemon lifecycle', () => {
     const config = JSON.parse(readFileSync(join(testDir, 'config.json'), 'utf-8'));
     expect(config.machine.id).toBeDefined();
     expect(config.daemon.port).toBe(port);
-    expect(config.discovery.dirs).toContain(agentsDir);
+    expect(config.agents.default).toBe(agentsDir);
   });
 
   it('Scenario 1: daemon is running and healthy', async () => {

--- a/src/hub/hub-sync.test.ts
+++ b/src/hub/hub-sync.test.ts
@@ -75,7 +75,8 @@ const testAuth = {
 const testConfig = {
   machine: { id: 'machine-1', name: 'test-pc' },
   daemon: { port: 4243 },
-  discovery: { dirs: [] },
+  agents: { default: '/tmp/agents', additional: [] },
+  projects: { default: '/tmp/projects', additional: [] },
 };
 
 describe('hub-sync', () => {

--- a/src/utils/daemon-client.test.ts
+++ b/src/utils/daemon-client.test.ts
@@ -20,7 +20,8 @@ describe('daemon-client', () => {
       JSON.stringify({
         machine: { id: randomUUID(), name: 'test' },
         daemon: { port },
-        discovery: { dirs: [] },
+        agents: { default: '/tmp/agents', additional: [] },
+        projects: { default: '/tmp/projects', additional: [] },
         sync: { events: {} },
       })
     );


### PR DESCRIPTION
## Summary

- Reshape `~/.agentage/config.json`: `agents.{default,additional}` and `projects.{default,additional}` replace `discovery.dirs[]`. `default` is the install target; `additional` is scan-only.
- Env overlay: `AGENTAGE_AGENTS_DIR` / `AGENTAGE_PROJECTS_DIR` override `default` in-memory (mirrors `AGENTAGE_PORT`). Built-in defaults: `homedir()/agents`, `homedir()/projects`.
- `agentage status` gets `--set-default <path>` (swaps default, demotes old to additional). `--add-dir` now appends to `agents.additional`; `--remove-dir` refuses the default.
- `agentage create` installs to `agents.default` (override with `--dir`). `agentage init --dir` appends to `agents.additional`.
- No migrator — fresh configs get the new shape. Existing users delete or replace their `config.json`.

Follow-ups (separate PRs): discovery-scanner ignore-dirs, recursive projects walk, heartbeat + Supabase + dashboard card.

## Test plan
- [x] `npm run verify` — type-check, lint, format, build, 503 tests pass
- [ ] Manual: delete `~/.agentage/config.json`, run `agentage status` — confirm new shape written with `homedir()/agents` + `homedir()/projects`
- [ ] Manual: `AGENTAGE_AGENTS_DIR=/tmp/x agentage status --json` — confirm `agentsDefault` is `/tmp/x`, on-disk file unchanged
- [ ] Manual: `agentage status --set-default /opt/foo` then `agentage status` — confirm swap + demotion
- [ ] Manual: `agentage create hello` — confirm file lands in `agents.default`