### PR TITLE
Release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.18.0] - 2026-04-17
+
+### New Features
+- Add support for configurable agents and projects directories with default and additional paths
+
 ## [0.17.1] - 2026-04-17
 
 ### New Features

--- a/changelog-content.md
+++ b/changelog-content.md
@@ -1,9 +1,2 @@
 ### New Features
-- Add schedules subcommands to CLI for managing scheduled agent tasks
-- Add cron scheduler module to daemon for automated agent execution
-
-### Bug Fixes
-- Fix project loading to automatically recover from ghost entries and sync missing remote projects
-
-### Improvements
-- Update core dependencies to latest versions
+- Add support for configurable agents and projects directories with default and additional paths

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentage/cli",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentage/cli",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "@agentage/core": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentage/cli",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Agentage CLI and daemon — control plane for AI agents",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release v0.18.0

This PR prepares the release of version 0.18.0.

### Changes
### New Features
- Add support for configurable agents and projects directories with default and additional paths

### Checklist
- [ ] Review the changelog
- [ ] Verify version numbers are correct
- [ ] Merge when ready to release

---

Once merged, this will automatically:
1. Create a git tag `v0.18.0`
2. Trigger the publish workflow
3. Publish to npm with provenance