### PR TITLE
feat(hub-sync): send agentsDefault + projectsDefault in heartbeat

### DIFF
--- a/src/hub/hub-client.ts
+++ b/src/hub/hub-client.ts
@@ -23,6 +23,8 @@ export interface HubClient {
       projects?: Array<{ name: string; path: string; discovered?: boolean; remote?: string }>;
       activeRunIds: string[];
       daemonVersion: string;
+      agentsDefault?: string;
+      projectsDefault?: string;
     }
   ) => Promise<{
     pendingCommands: unknown[];

--- a/src/hub/hub-sync.test.ts
+++ b/src/hub/hub-sync.test.ts
@@ -227,6 +227,8 @@ describe('hub-sync', () => {
         ],
         activeRunIds: ['run-1'],
         daemonVersion: '0.7.1',
+        agentsDefault: '/tmp/agents',
+        projectsDefault: '/tmp/projects',
       });
     });
 

--- a/src/hub/hub-sync.ts
+++ b/src/hub/hub-sync.ts
@@ -76,6 +76,8 @@ export const createHubSync = (): HubSync => {
   const sendHeartbeat = async (auth: AuthState): Promise<void> => {
     if (!hubClient) return;
 
+    const config = loadConfig();
+
     const agents = getAgents().map((a) => ({
       name: a.manifest.name,
       description: a.manifest.description,
@@ -103,6 +105,8 @@ export const createHubSync = (): HubSync => {
       projects,
       activeRunIds,
       daemonVersion: VERSION,
+      agentsDefault: config.agents.default,
+      projectsDefault: config.projects.default,
     });
 
     // Reconcile local cron registry against the authoritative bindings


### PR DESCRIPTION
## Summary

Last part of the cross-repo config-defaults work. Daemon now reports its configured install target (\`agents.default\`) and discovery root (\`projects.default\`) to the hub each heartbeat.

- **\`src/hub/hub-client.ts\`** — widened the inline heartbeat body type with two optional strings. **No \`@agentage/platform\` dep bump** — cli carries its own heartbeat shape locally, doesn't import \`platform.Heartbeat\`. Means this PR is independent of agentage/agentkit#107.
- **\`src/hub/hub-sync.ts\`** — \`loadConfig()\` is already called on the heartbeat path; added \`agentsDefault: config.agents.default\` and \`projectsDefault: config.projects.default\` to the payload.
- **\`src/hub/hub-sync.test.ts\`** — fixture assertion updated.

Pairs with:
- agentage/web#148 — Supabase columns + backend ingest + dashboard card
- agentage/agentkit#107 — \`Heartbeat\` type (informational; other consumers will pick up)

## Test plan
- [x] \`npm run verify\` — 512 tests pass
- [ ] After merge + release: upgrade daemon to new version, restart, inspect \`machines.agents_default\` / \`projects_default\` in Supabase
- [ ] Manual: dashboard machine detail page shows the two cards populated