### PR TITLE
feat(daemon): collect CPU/memory/disk metrics in heartbeat

### DIFF
--- a/src/daemon/metrics.test.ts
+++ b/src/daemon/metrics.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { collectMachineMetrics } from './metrics.js';
+
+describe('collectMachineMetrics', () => {
+  it('returns cpu/memory in expected ranges', async () => {
+    const m = await collectMachineMetrics();
+
+    expect(m.cpuUsage).toBeGreaterThanOrEqual(0);
+    expect(m.cpuUsage).toBeLessThanOrEqual(100);
+
+    expect(m.memoryTotalMb).toBeGreaterThan(0);
+    expect(m.memoryUsedMb).toBeGreaterThanOrEqual(0);
+    expect(m.memoryUsedMb).toBeLessThanOrEqual(m.memoryTotalMb);
+  });
+
+  it('includes disk metrics when statfs is available', async () => {
+    const m = await collectMachineMetrics();
+
+    if (m.diskTotalMb !== undefined) {
+      expect(m.diskTotalMb).toBeGreaterThan(0);
+      expect(m.diskUsedMb).toBeGreaterThanOrEqual(0);
+      expect(m.diskUsedMb).toBeLessThanOrEqual(m.diskTotalMb);
+    }
+  });
+});

--- a/src/daemon/metrics.ts
+++ b/src/daemon/metrics.ts
@@ -1,0 +1,65 @@
+import { cpus, totalmem, freemem, homedir } from 'node:os';
+import { statfs } from 'node:fs/promises';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+export interface MachineMetrics {
+  cpuUsage: number;
+  memoryUsedMb: number;
+  memoryTotalMb: number;
+  diskUsedMb?: number;
+  diskTotalMb?: number;
+}
+
+const BYTES_PER_MB = 1024 * 1024;
+
+interface CpuSnapshot {
+  idle: number;
+  total: number;
+}
+
+const takeCpuSnapshot = (): CpuSnapshot => {
+  let idle = 0;
+  let total = 0;
+  for (const cpu of cpus()) {
+    for (const time of Object.values(cpu.times)) total += time;
+    idle += cpu.times.idle;
+  }
+  return { idle, total };
+};
+
+const sampleCpuUsage = async (windowMs = 200): Promise<number> => {
+  const a = takeCpuSnapshot();
+  await sleep(windowMs);
+  const b = takeCpuSnapshot();
+  const dTotal = b.total - a.total;
+  const dIdle = b.idle - a.idle;
+  if (dTotal <= 0) return 0;
+  const busy = 1 - dIdle / dTotal;
+  return Math.max(0, Math.min(100, busy * 100));
+};
+
+const collectDiskUsage = async (): Promise<Pick<MachineMetrics, 'diskUsedMb' | 'diskTotalMb'>> => {
+  try {
+    const stats = await statfs(homedir());
+    const totalBytes = Number(stats.blocks) * stats.bsize;
+    const freeBytes = Number(stats.bavail) * stats.bsize;
+    return {
+      diskUsedMb: Math.round((totalBytes - freeBytes) / BYTES_PER_MB),
+      diskTotalMb: Math.round(totalBytes / BYTES_PER_MB),
+    };
+  } catch {
+    return {};
+  }
+};
+
+export const collectMachineMetrics = async (): Promise<MachineMetrics> => {
+  const [cpuUsage, disk] = await Promise.all([sampleCpuUsage(), collectDiskUsage()]);
+  const totalMem = totalmem();
+  const freeMem = freemem();
+  return {
+    cpuUsage: Number(cpuUsage.toFixed(1)),
+    memoryUsedMb: Math.round((totalMem - freeMem) / BYTES_PER_MB),
+    memoryTotalMb: Math.round(totalMem / BYTES_PER_MB),
+    ...disk,
+  };
+};

--- a/src/hub/hub-client.ts
+++ b/src/hub/hub-client.ts
@@ -25,6 +25,13 @@ export interface HubClient {
       daemonVersion: string;
       agentsDefault?: string;
       projectsDefault?: string;
+      resources?: {
+        cpuUsage?: number;
+        memoryUsedMb?: number;
+        memoryTotalMb?: number;
+        diskUsedMb?: number;
+        diskTotalMb?: number;
+      };
     }
   ) => Promise<{
     pendingCommands: unknown[];

--- a/src/hub/hub-sync.test.ts
+++ b/src/hub/hub-sync.test.ts
@@ -44,6 +44,16 @@ vi.mock('../projects/projects.js', () => ({
   loadProjects: vi.fn(),
 }));
 
+vi.mock('../daemon/metrics.js', () => ({
+  collectMachineMetrics: vi.fn().mockResolvedValue({
+    cpuUsage: 12.3,
+    memoryUsedMb: 4096,
+    memoryTotalMb: 16384,
+    diskUsedMb: 100000,
+    diskTotalMb: 500000,
+  }),
+}));
+
 import { readAuth } from './auth.js';
 import { createHubClient } from './hub-client.js';
 import { createHubWs } from './hub-ws.js';
@@ -229,6 +239,13 @@ describe('hub-sync', () => {
         daemonVersion: '0.7.1',
         agentsDefault: '/tmp/agents',
         projectsDefault: '/tmp/projects',
+        resources: {
+          cpuUsage: 12.3,
+          memoryUsedMb: 4096,
+          memoryTotalMb: 16384,
+          diskUsedMb: 100000,
+          diskTotalMb: 500000,
+        },
       });
     });
 

--- a/src/hub/hub-sync.ts
+++ b/src/hub/hub-sync.ts
@@ -10,6 +10,7 @@ import { cancelRun, sendInput, getRuns } from '../daemon/run-manager.js';
 import { getScheduler } from '../daemon/scheduler.js';
 import { loadProjects } from '../projects/projects.js';
 
+import { collectMachineMetrics } from '../daemon/metrics.js';
 import { VERSION } from '../utils/version.js';
 import { refreshTokenIfNeeded } from './token-refresh.js';
 
@@ -100,6 +101,15 @@ export const createHubSync = (): HubSync => {
       .filter((r) => r.state === 'working' || r.state === 'submitted')
       .map((r) => r.id);
 
+    let resources: Awaited<ReturnType<typeof collectMachineMetrics>> | undefined;
+    try {
+      resources = await collectMachineMetrics();
+    } catch (err) {
+      logWarn(
+        `[hub-sync] metrics collection failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
     const response = await hubClient.heartbeat(auth.hub.machineId, {
       agents,
       projects,
@@ -107,6 +117,7 @@ export const createHubSync = (): HubSync => {
       daemonVersion: VERSION,
       agentsDefault: config.agents.default,
       projectsDefault: config.projects.default,
+      ...(resources && { resources }),
     });
 
     // Reconcile local cron registry against the authoritative bindings


### PR DESCRIPTION
## Summary
- New `src/daemon/metrics.ts` samples overall CPU busy % (200ms window, `os.cpus()` diff), memory via `os.totalmem`/`freemem`, disk via `fs.statfs(homedir())`.
- Daemon heartbeat now includes `resources: { cpuUsage, memoryUsedMb, memoryTotalMb, diskUsedMb, diskTotalMb }`. Failures in collection are caught and logged — heartbeat still fires.
- `hub-client.ts` wire type extended to match.

## Context
Part 2 of the CPU/memory/disk progress-bar feature:
1. agentkit#108 (merged) — contract
2. **cli (this PR)** — daemon sends metrics
3. web — persistence + UI

Fields are optional, so older backends strip unknown keys (Zod default behavior) — safe to land before the web PR.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` — 510+ tests pass, including new `metrics.test.ts` (range assertions on real host) and updated `hub-sync.test.ts` (mocked metrics in payload assertion)
- [x] Local smoke: `node -e "import('./dist/daemon/metrics.js').then(m => m.collectMachineMetrics()).then(console.log)"` returns sensible values on Linux