### PR TITLE
feat(daemon): include cpuCount + loadAvg in heartbeat

### DIFF
--- a/src/daemon/metrics.ts
+++ b/src/daemon/metrics.ts
@@ -1,13 +1,17 @@
-import { cpus, totalmem, freemem, homedir } from 'node:os';
+import { cpus, totalmem, freemem, homedir, loadavg, platform } from 'node:os';
 import { statfs } from 'node:fs/promises';
 import { setTimeout as sleep } from 'node:timers/promises';
 
 export interface MachineMetrics {
   cpuUsage: number;
+  cpuCount: number;
   memoryUsedMb: number;
   memoryTotalMb: number;
   diskUsedMb?: number;
   diskTotalMb?: number;
+  loadAvg1m?: number;
+  loadAvg5m?: number;
+  loadAvg15m?: number;
 }
 
 const BYTES_PER_MB = 1024 * 1024;
@@ -52,14 +56,27 @@ const collectDiskUsage = async (): Promise<Pick<MachineMetrics, 'diskUsedMb' | '
   }
 };
 
+const collectLoadAvg = (): Pick<MachineMetrics, 'loadAvg1m' | 'loadAvg5m' | 'loadAvg15m'> => {
+  // node returns [0, 0, 0] on Windows — omit to let UI hide the card.
+  if (platform() === 'win32') return {};
+  const [one, five, fifteen] = loadavg();
+  return {
+    loadAvg1m: Number(one.toFixed(2)),
+    loadAvg5m: Number(five.toFixed(2)),
+    loadAvg15m: Number(fifteen.toFixed(2)),
+  };
+};
+
 export const collectMachineMetrics = async (): Promise<MachineMetrics> => {
   const [cpuUsage, disk] = await Promise.all([sampleCpuUsage(), collectDiskUsage()]);
   const totalMem = totalmem();
   const freeMem = freemem();
   return {
     cpuUsage: Number(cpuUsage.toFixed(1)),
+    cpuCount: cpus().length,
     memoryUsedMb: Math.round((totalMem - freeMem) / BYTES_PER_MB),
     memoryTotalMb: Math.round(totalMem / BYTES_PER_MB),
     ...disk,
+    ...collectLoadAvg(),
   };
 };

--- a/src/hub/hub-client.ts
+++ b/src/hub/hub-client.ts
@@ -27,10 +27,14 @@ export interface HubClient {
       projectsDefault?: string;
       resources?: {
         cpuUsage?: number;
+        cpuCount?: number;
         memoryUsedMb?: number;
         memoryTotalMb?: number;
         diskUsedMb?: number;
         diskTotalMb?: number;
+        loadAvg1m?: number;
+        loadAvg5m?: number;
+        loadAvg15m?: number;
       };
     }
   ) => Promise<{

--- a/src/hub/hub-sync.test.ts
+++ b/src/hub/hub-sync.test.ts
@@ -47,10 +47,14 @@ vi.mock('../projects/projects.js', () => ({
 vi.mock('../daemon/metrics.js', () => ({
   collectMachineMetrics: vi.fn().mockResolvedValue({
     cpuUsage: 12.3,
+    cpuCount: 8,
     memoryUsedMb: 4096,
     memoryTotalMb: 16384,
     diskUsedMb: 100000,
     diskTotalMb: 500000,
+    loadAvg1m: 0.5,
+    loadAvg5m: 0.7,
+    loadAvg15m: 0.9,
   }),
 }));
 
@@ -241,10 +245,14 @@ describe('hub-sync', () => {
         projectsDefault: '/tmp/projects',
         resources: {
           cpuUsage: 12.3,
+          cpuCount: 8,
           memoryUsedMb: 4096,
           memoryTotalMb: 16384,
           diskUsedMb: 100000,
           diskTotalMb: 500000,
+          loadAvg1m: 0.5,
+          loadAvg5m: 0.7,
+          loadAvg15m: 0.9,
         },
       });
     });


### PR DESCRIPTION
## Summary
- `collectMachineMetrics()` now returns `cpuCount` (via `os.cpus().length`) and `loadAvg{1,5,15}m` (via `os.loadavg()`, Unix only — Windows omits).
- Heartbeat wire type extended; older backends just strip unknown fields.

## Test plan
- [x] `npm run type-check`, lint, build — green
- [x] `npm test` — metrics.test.ts + hub-sync.test.ts updated, all pass