### PR TITLE
ci: fall back to direct squash when auto-merge rejects clean-status PR

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -171,10 +171,24 @@ jobs:
         if: steps.create_pr.outputs.pr_url && github.event.inputs.auto_merge == 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.create_pr.outputs.pr_url }}
         run: |
           echo "Auto-merge enabled — enabling GitHub auto-merge"
-          gh pr merge "${{ steps.create_pr.outputs.pr_url }}" --auto --squash
-          echo "Auto-merge enabled. PR will merge when all checks pass."
+          # `--auto` waits for required checks. When the PR has no required checks,
+          # GitHub rejects it with `GraphQL: Pull request is in clean status
+          # (enablePullRequestAutoMerge)` — in that case the PR is already mergeable
+          # so fall back to an immediate squash-merge.
+          if ! OUTPUT=$(gh pr merge "$PR_URL" --auto --squash 2>&1); then
+            echo "$OUTPUT"
+            if echo "$OUTPUT" | grep -q "clean status"; then
+              echo "Auto-merge rejected (clean status) — merging directly"
+              gh pr merge "$PR_URL" --squash
+            else
+              exit 1
+            fi
+          else
+            echo "Auto-merge enabled. PR will merge when all checks pass."
+          fi
 
       - name: Summary
         if: always()


### PR DESCRIPTION
## Summary

- `gh pr merge --auto --squash` in the release-prepare workflow fails with `GraphQL: Pull request is in clean status (enablePullRequestAutoMerge)` when the generated release PR has no required checks
- Fall back to an immediate `gh pr merge --squash` on that specific error (the PR is already mergeable)
- Other auto-merge failures still exit non-zero so they remain visible

## Context

Hit twice on 2026-04-23 during the machine-metrics feature shipments (release PRs #149 here, and #111 in agentkit) — both required a manual `gh pr merge --squash` follow-up.

## Test plan
- [ ] Trigger release-prepare manually with `auto_merge=true` on a commit that produces a version bump
- [ ] Verify the Auto-merge step succeeds and the PR squash-merges even though there are no required checks