### PR TITLE
feat(daemon): expose machine metrics via GET /api/metrics

### DIFF
--- a/src/daemon/routes.test.ts
+++ b/src/daemon/routes.test.ts
@@ -6,6 +6,10 @@ vi.mock('./config.js', () => ({
   loadConfig: vi.fn(),
 }));
 
+vi.mock('./metrics.js', () => ({
+  collectMachineMetrics: vi.fn(),
+}));
+
 vi.mock('./run-manager.js', () => ({
   startRun: vi.fn(),
   getRun: vi.fn(),
@@ -35,6 +39,7 @@ vi.mock('../projects/projects.js', () => ({
 }));
 
 import { loadConfig } from './config.js';
+import { collectMachineMetrics } from './metrics.js';
 import { startRun, getRun, getRuns, cancelRun, sendInput } from './run-manager.js';
 import { getHubSync } from '../hub/hub-sync.js';
 import { readAuth } from '../hub/auth.js';
@@ -45,6 +50,7 @@ import { createRoutes, setAgents, setRefreshHandler } from './routes.js';
 const mockLoadProjects = vi.mocked(loadProjects);
 
 const mockLoadConfig = vi.mocked(loadConfig);
+const mockCollectMachineMetrics = vi.mocked(collectMachineMetrics);
 const mockGetRuns = vi.mocked(getRuns);
 const mockGetRun = vi.mocked(getRun);
 const mockStartRun = vi.mocked(startRun);
@@ -119,6 +125,46 @@ describe('daemon routes', () => {
       expect(data.machineId).toBe('machine-1');
       expect(data.hubConnected).toBe(false);
       expect(typeof data.uptime).toBe('number');
+    });
+  });
+
+  describe('GET /api/metrics', () => {
+    it('returns machine metrics from collector', async () => {
+      mockCollectMachineMetrics.mockResolvedValueOnce({
+        cpuUsage: 12.3,
+        cpuCount: 8,
+        memoryUsedMb: 5000,
+        memoryTotalMb: 16000,
+        diskUsedMb: 200000,
+        diskTotalMb: 500000,
+        loadAvg1m: 0.5,
+        loadAvg5m: 0.4,
+        loadAvg15m: 0.3,
+      });
+
+      const { status, data } = await request(server, 'GET', '/api/metrics');
+
+      expect(status).toBe(200);
+      expect(data).toEqual({
+        cpuUsage: 12.3,
+        cpuCount: 8,
+        memoryUsedMb: 5000,
+        memoryTotalMb: 16000,
+        diskUsedMb: 200000,
+        diskTotalMb: 500000,
+        loadAvg1m: 0.5,
+        loadAvg5m: 0.4,
+        loadAvg15m: 0.3,
+      });
+    });
+
+    it('returns 500 when collector fails', async () => {
+      mockCollectMachineMetrics.mockRejectedValueOnce(new Error('boom'));
+
+      const { status, data } = await request(server, 'GET', '/api/metrics');
+
+      expect(status).toBe(500);
+      expect(data).toEqual({ error: 'boom' });
     });
   });
 

--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -1,6 +1,7 @@
 import { type Router, Router as createRouter, json, type Request, type Response } from 'express';
 import { type Agent, type ActionRegistry, type JsonSchema } from '@agentage/core';
 import { loadConfig } from './config.js';
+import { collectMachineMetrics } from './metrics.js';
 import { cancelRun, getRun, getRuns, sendInput, startRun } from './run-manager.js';
 import { getHubSync } from '../hub/hub-sync.js';
 import { readAuth } from '../hub/auth.js';
@@ -55,6 +56,16 @@ export const createRoutes = (): Router => {
       hubUrl: auth?.hub?.url ?? null,
       userEmail: auth?.user?.email ?? null,
     });
+  });
+
+  router.get('/api/metrics', async (_req, res) => {
+    try {
+      const metrics = await collectMachineMetrics();
+      res.json(metrics);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
   });
 
   router.get('/api/agents', (_req, res) => {


### PR DESCRIPTION
## Summary

- New `GET /api/metrics` endpoint on the daemon returning the output of `collectMachineMetrics()` (CPU/memory/disk/load)
- Collector already runs once per heartbeat; this makes the values readable on demand
- Enables MCP clients (and other local tooling) to query host health without waiting for the next heartbeat

## Why

Post-MVP follow-up from the machine-metrics feature. Unblocks the `machine_metrics` MCP tool (next PR in @agentage/mcp) and gives the monitoring agent an in-process signal to call.

## Test plan
- [ ] 33 routes tests pass (added GET /api/metrics success + 500-on-collector-error)
- [ ] 534 tests total green
- [ ] After release: curl http://127.0.0.1:4243/api/metrics returns JSON with cpuUsage, memoryUsedMb, etc.