### PR TITLE
feat(setup): add setup mcp subcommand to wire MCP configs in cwd

### DIFF
--- a/src/commands/setup-mcp.test.ts
+++ b/src/commands/setup-mcp.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runSetupMcp } from './setup-mcp.js';
+
+describe('runSetupMcp', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'setup-mcp-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('creates .mcp.json and .vscode/mcp.json with npx entry by default', () => {
+    const results = runSetupMcp({ cwd: dir });
+
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.action).sort()).toEqual(['created', 'created']);
+
+    const project = JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf-8'));
+    expect(project.mcpServers.agentage).toEqual({
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', '@agentage/mcp'],
+    });
+
+    const vscode = JSON.parse(readFileSync(join(dir, '.vscode', 'mcp.json'), 'utf-8'));
+    expect(vscode.servers.agentage).toEqual({
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', '@agentage/mcp'],
+    });
+  });
+
+  it('style=binary writes direct agentage-mcp command', () => {
+    runSetupMcp({ cwd: dir, style: 'binary' });
+    const project = JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf-8'));
+    expect(project.mcpServers.agentage).toEqual({
+      type: 'stdio',
+      command: 'agentage-mcp',
+      args: [],
+    });
+  });
+
+  it('noProject=true skips .mcp.json', () => {
+    const results = runSetupMcp({ cwd: dir, noProject: true });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.kind).toBe('vscode-workspace');
+  });
+
+  it('noVscode=true skips .vscode/mcp.json', () => {
+    const results = runSetupMcp({ cwd: dir, noVscode: true });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.kind).toBe('claude-code-project');
+  });
+
+  it('both flags together throws', () => {
+    expect(() => runSetupMcp({ cwd: dir, noProject: true, noVscode: true })).toThrow(
+      /no targets selected/
+    );
+  });
+
+  it('preserves unrelated mcpServers entries', () => {
+    writeFileSync(
+      join(dir, '.mcp.json'),
+      JSON.stringify(
+        {
+          mcpServers: {
+            other: { type: 'stdio', command: 'other', args: [] },
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    runSetupMcp({ cwd: dir, noVscode: true });
+
+    const project = JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf-8'));
+    expect(project.mcpServers.other).toEqual({ type: 'stdio', command: 'other', args: [] });
+    expect(project.mcpServers.agentage.command).toBe('npx');
+  });
+
+  it('returns unchanged when entry already matches', () => {
+    writeFileSync(
+      join(dir, '.mcp.json'),
+      JSON.stringify(
+        {
+          mcpServers: {
+            agentage: { type: 'stdio', command: 'npx', args: ['-y', '@agentage/mcp'] },
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const results = runSetupMcp({ cwd: dir, noVscode: true });
+    expect(results[0]?.action).toBe('unchanged');
+  });
+
+  it('skips with reason when existing entry differs and force is off', () => {
+    writeFileSync(
+      join(dir, '.mcp.json'),
+      JSON.stringify(
+        {
+          mcpServers: {
+            agentage: { type: 'stdio', command: 'agentage-mcp', args: [] },
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const results = runSetupMcp({ cwd: dir, noVscode: true });
+    expect(results[0]?.action).toBe('skipped');
+    expect(results[0]?.reason).toMatch(/--force/);
+
+    const project = JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf-8'));
+    expect(project.mcpServers.agentage.command).toBe('agentage-mcp');
+  });
+
+  it('force=true overwrites a differing entry', () => {
+    writeFileSync(
+      join(dir, '.mcp.json'),
+      JSON.stringify(
+        {
+          mcpServers: {
+            agentage: { type: 'stdio', command: 'agentage-mcp', args: [] },
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const results = runSetupMcp({ cwd: dir, noVscode: true, force: true });
+    expect(results[0]?.action).toBe('updated');
+
+    const project = JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf-8'));
+    expect(project.mcpServers.agentage.command).toBe('npx');
+  });
+
+  it('creates .vscode directory when missing', () => {
+    runSetupMcp({ cwd: dir, noProject: true });
+    const vscode = JSON.parse(readFileSync(join(dir, '.vscode', 'mcp.json'), 'utf-8'));
+    expect(vscode.servers.agentage).toBeDefined();
+  });
+
+  it('refuses to overwrite a malformed existing config', () => {
+    writeFileSync(join(dir, '.mcp.json'), 'not-json-at-all');
+    expect(() => runSetupMcp({ cwd: dir, noVscode: true })).toThrow(/not a JSON object/);
+  });
+
+  it('adds agentage entry when config exists but has no mcpServers key', () => {
+    mkdirSync(join(dir, '.vscode'), { recursive: true });
+    writeFileSync(join(dir, '.vscode', 'mcp.json'), JSON.stringify({ otherField: true }));
+
+    const results = runSetupMcp({ cwd: dir, noProject: true });
+    expect(results[0]?.action).toBe('added');
+
+    const vscode = JSON.parse(readFileSync(join(dir, '.vscode', 'mcp.json'), 'utf-8'));
+    expect(vscode.otherField).toBe(true);
+    expect(vscode.servers.agentage).toBeDefined();
+  });
+});

--- a/src/commands/setup-mcp.ts
+++ b/src/commands/setup-mcp.ts
@@ -1,0 +1,169 @@
+import { type Command } from 'commander';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import chalk from 'chalk';
+
+export type McpCommandStyle = 'npx' | 'binary';
+
+interface McpServerEntry {
+  type: 'stdio';
+  command: string;
+  args: string[];
+}
+
+interface McpConfigFile {
+  kind: 'claude-code-project' | 'vscode-workspace';
+  path: string;
+  /** Top-level key under which MCP servers live in this client's config. */
+  key: 'mcpServers' | 'servers';
+}
+
+export interface SetupMcpOptions {
+  cwd?: string;
+  style?: McpCommandStyle;
+  force?: boolean;
+  noProject?: boolean;
+  noVscode?: boolean;
+  json?: boolean;
+}
+
+interface TargetResult {
+  kind: McpConfigFile['kind'];
+  path: string;
+  action: 'created' | 'added' | 'updated' | 'unchanged' | 'skipped';
+  reason?: string;
+}
+
+const buildEntry = (style: McpCommandStyle): McpServerEntry =>
+  style === 'binary'
+    ? { type: 'stdio', command: 'agentage-mcp', args: [] }
+    : { type: 'stdio', command: 'npx', args: ['-y', '@agentage/mcp'] };
+
+const resolveTargets = (cwd: string, opts: SetupMcpOptions): McpConfigFile[] => {
+  const targets: McpConfigFile[] = [];
+  if (!opts.noProject) {
+    targets.push({
+      kind: 'claude-code-project',
+      path: join(cwd, '.mcp.json'),
+      key: 'mcpServers',
+    });
+  }
+  if (!opts.noVscode) {
+    targets.push({
+      kind: 'vscode-workspace',
+      path: join(cwd, '.vscode', 'mcp.json'),
+      key: 'servers',
+    });
+  }
+  return targets;
+};
+
+const readJson = (path: string): Record<string, unknown> => {
+  if (!existsSync(path)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Fall through — treat as empty to avoid wiping a malformed config blindly
+  }
+  throw new Error(`existing ${path} is not a JSON object — refusing to overwrite`);
+};
+
+const entriesEqual = (a: McpServerEntry, b: unknown): boolean => {
+  if (!b || typeof b !== 'object') return false;
+  const other = b as Partial<McpServerEntry>;
+  if (other.type !== a.type || other.command !== a.command) return false;
+  if (!Array.isArray(other.args) || other.args.length !== a.args.length) return false;
+  return other.args.every((v, i) => v === a.args[i]);
+};
+
+export const writeMcpConfig = (
+  target: McpConfigFile,
+  entry: McpServerEntry,
+  force: boolean
+): TargetResult => {
+  const existed = existsSync(target.path);
+  const doc = readJson(target.path);
+  const servers =
+    doc[target.key] && typeof doc[target.key] === 'object' && !Array.isArray(doc[target.key])
+      ? (doc[target.key] as Record<string, unknown>)
+      : {};
+
+  const prior = servers['agentage'];
+  if (prior !== undefined) {
+    if (entriesEqual(entry, prior)) {
+      return { kind: target.kind, path: target.path, action: 'unchanged' };
+    }
+    if (!force) {
+      return {
+        kind: target.kind,
+        path: target.path,
+        action: 'skipped',
+        reason: 'existing `agentage` entry differs — pass --force to overwrite',
+      };
+    }
+  }
+
+  servers['agentage'] = entry;
+  doc[target.key] = servers;
+
+  mkdirSync(dirname(target.path), { recursive: true });
+  writeFileSync(target.path, JSON.stringify(doc, null, 2) + '\n', 'utf-8');
+
+  if (!existed) return { kind: target.kind, path: target.path, action: 'created' };
+  if (prior === undefined) return { kind: target.kind, path: target.path, action: 'added' };
+  return { kind: target.kind, path: target.path, action: 'updated' };
+};
+
+export const runSetupMcp = (opts: SetupMcpOptions = {}): TargetResult[] => {
+  const cwd = resolve(opts.cwd ?? process.cwd());
+  const entry = buildEntry(opts.style ?? 'npx');
+  const targets = resolveTargets(cwd, opts);
+  if (targets.length === 0) {
+    throw new Error('no targets selected — drop --no-project / --no-vscode');
+  }
+  return targets.map((t) => writeMcpConfig(t, entry, opts.force === true));
+};
+
+const describeAction = (r: TargetResult): string => {
+  switch (r.action) {
+    case 'created':
+      return chalk.green('created');
+    case 'added':
+      return chalk.green('added');
+    case 'updated':
+      return chalk.yellow('updated');
+    case 'unchanged':
+      return chalk.gray('unchanged');
+    case 'skipped':
+      return chalk.yellow('skipped');
+  }
+};
+
+export const registerSetupMcp = (setup: Command): void => {
+  setup
+    .command('mcp')
+    .description('Wire the Agentage MCP shim into MCP client configs in the current directory')
+    .option('--style <style>', 'Command style: `npx` (default) or `binary` for direct agentage-mcp')
+    .option('--force', 'Overwrite an existing `agentage` entry that differs from the generated one')
+    .option('--no-project', 'Skip .mcp.json (Claude Code project scope)')
+    .option('--no-vscode', 'Skip .vscode/mcp.json (VSCode workspace)')
+    .option('--json', 'JSON output')
+    .action((opts: SetupMcpOptions) => {
+      const style: McpCommandStyle = opts.style === 'binary' ? 'binary' : 'npx';
+      const results = runSetupMcp({ ...opts, style });
+
+      if (opts.json) {
+        console.log(JSON.stringify({ cwd: process.cwd(), style, results }, null, 2));
+        return;
+      }
+
+      for (const r of results) {
+        const label = r.kind === 'vscode-workspace' ? 'vscode' : 'claude-code';
+        console.log(`${describeAction(r).padEnd(20)} ${label}  ${chalk.dim(r.path)}`);
+        if (r.reason) console.log(`  ${chalk.dim(r.reason)}`);
+      }
+    });
+};

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -18,6 +18,7 @@ import { ensureDaemon } from '../utils/ensure-daemon.js';
 import { readAuth, saveAuth, deleteAuth, type AuthState } from '../hub/auth.js';
 import { startCallbackServer, getCallbackPort } from '../hub/auth-callback.js';
 import { createHubClient } from '../hub/hub-client.js';
+import { registerSetupMcp } from './setup-mcp.js';
 
 const DEFAULT_HUB_URL = 'https://agentage.io';
 
@@ -366,7 +367,7 @@ export const runSetup = async (opts: SetupOptions): Promise<void> => {
 };
 
 export const registerSetup = (program: Command): void => {
-  program
+  const setup = program
     .command('setup')
     .description('Configure machine, hub, and authentication')
     .option('--name <name>', 'Machine name (default: hostname)')
@@ -384,4 +385,6 @@ export const registerSetup = (program: Command): void => {
     .action(async (opts: SetupOptions) => {
       await runSetup(opts);
     });
+
+  registerSetupMcp(setup);
 };


### PR DESCRIPTION
## Summary

- New `agentage setup mcp` subcommand writes `.mcp.json` (Claude Code project scope) and `.vscode/mcp.json` (VSCode workspace) in the current directory
- Defaults to `npx -y @agentage/mcp` so only `@agentage/cli` needs to be installed; `--style=binary` switches to direct `agentage-mcp`
- Idempotent: matching entry → unchanged; differing entry → skipped with reason (override with `--force`); unrelated MCP servers in existing configs are preserved; malformed configs throw instead of clobbering
- Flags: `--no-project` / `--no-vscode` to skip a target, `--style <npx|binary>`, `--json`

## Why

MCP wiring folded into the existing `agentage setup` surface rather than a separate `agentage mcp install/uninstall/status` command tree. Fewer commands to discover; natural fit with `setup`, which already configures the daemon the shim connects to. Handles the "I just checked out a project, give it Claude-Code + VSCode access to my agents" case in one command.

Supersedes Phase 3 of [work/tasks/mcp-ship-plan] — ships the high-value fraction (per-directory wiring) without the per-client installer table (Claude Desktop / Cursor can follow as additive targets if dogfood demands).

## Test plan
- [ ] 12 new unit tests covering: create, style variants, skip flags, preserve existing, unchanged on match, skip-with-reason on differ, force overwrites, creates .vscode dir, refuses malformed config, adds under existing config without mcpServers key
- [ ] 546 tests total pass
- [ ] Smoke: `cd /tmp/foo && agentage setup mcp` creates both files with correct content