### PR TITLE
feat(setup): --scope flag for setup mcp + user-scope wiring in main setup

### DIFF
--- a/src/commands/setup-mcp.test.ts
+++ b/src/commands/setup-mcp.test.ts
@@ -6,17 +6,20 @@ import { runSetupMcp } from './setup-mcp.js';
 
 describe('runSetupMcp', () => {
   let dir: string;
+  let home: string;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'setup-mcp-'));
+    home = mkdtempSync(join(tmpdir(), 'setup-mcp-home-'));
   });
 
   afterEach(() => {
     rmSync(dir, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
   });
 
   it('creates .mcp.json and .vscode/mcp.json with npx entry by default', () => {
-    const results = runSetupMcp({ cwd: dir });
+    const results = runSetupMcp({ cwd: dir, home });
 
     expect(results).toHaveLength(2);
     expect(results.map((r) => r.action).sort()).toEqual(['created', 'created']);
@@ -37,7 +40,7 @@ describe('runSetupMcp', () => {
   });
 
   it('style=binary writes direct agentage-mcp command', () => {
-    runSetupMcp({ cwd: dir, style: 'binary' });
+    runSetupMcp({ cwd: dir, home, style: 'binary' });
     const project = JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf-8'));
     expect(project.mcpServers.agentage).toEqual({
       type: 'stdio',
@@ -47,21 +50,60 @@ describe('runSetupMcp', () => {
   });
 
   it('noProject=true skips .mcp.json', () => {
-    const results = runSetupMcp({ cwd: dir, noProject: true });
+    const results = runSetupMcp({ cwd: dir, home, noProject: true });
     expect(results).toHaveLength(1);
     expect(results[0]?.kind).toBe('vscode-workspace');
   });
 
   it('noVscode=true skips .vscode/mcp.json', () => {
-    const results = runSetupMcp({ cwd: dir, noVscode: true });
+    const results = runSetupMcp({ cwd: dir, home, noVscode: true });
     expect(results).toHaveLength(1);
     expect(results[0]?.kind).toBe('claude-code-project');
   });
 
-  it('both flags together throws', () => {
-    expect(() => runSetupMcp({ cwd: dir, noProject: true, noVscode: true })).toThrow(
+  it('both flags together in project scope throws', () => {
+    expect(() => runSetupMcp({ cwd: dir, home, noProject: true, noVscode: true })).toThrow(
       /no targets selected/
     );
+  });
+
+  it('scope=user writes ~/.claude.json and leaves cwd untouched', () => {
+    const results = runSetupMcp({ cwd: dir, home, scope: 'user' });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.kind).toBe('claude-code-user');
+
+    const userConfig = JSON.parse(readFileSync(join(home, '.claude.json'), 'utf-8'));
+    expect(userConfig.mcpServers.agentage).toEqual({
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', '@agentage/mcp'],
+    });
+
+    // cwd untouched
+    expect(() => readFileSync(join(dir, '.mcp.json'), 'utf-8')).toThrow();
+  });
+
+  it('scope=all writes project + vscode + user', () => {
+    const results = runSetupMcp({ cwd: dir, home, scope: 'all' });
+    const kinds = results.map((r) => r.kind).sort();
+    expect(kinds).toEqual(['claude-code-project', 'claude-code-user', 'vscode-workspace']);
+  });
+
+  it('scope=user preserves unrelated top-level fields in ~/.claude.json', () => {
+    writeFileSync(
+      join(home, '.claude.json'),
+      JSON.stringify({
+        projects: { '/somewhere': { lastOpened: 123 } },
+        oauthAccount: { emailAddress: 'x@y.z' },
+      })
+    );
+
+    runSetupMcp({ cwd: dir, home, scope: 'user' });
+
+    const userConfig = JSON.parse(readFileSync(join(home, '.claude.json'), 'utf-8'));
+    expect(userConfig.projects['/somewhere'].lastOpened).toBe(123);
+    expect(userConfig.oauthAccount.emailAddress).toBe('x@y.z');
+    expect(userConfig.mcpServers.agentage).toBeDefined();
   });
 
   it('preserves unrelated mcpServers entries', () => {
@@ -78,7 +120,7 @@ describe('runSetupMcp', () => {
       )
     );
 
-    runSetupMcp({ cwd: dir, noVscode: true });
+    runSetupMcp({ cwd: dir, home, noVscode: true });
 
     const project = JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf-8'));
     expect(project.mcpServers.other).toEqual({ type: 'stdio', command: 'other', args: [] });
@@ -99,7 +141,7 @@ describe('runSetupMcp', () => {
       )
     );
 
-    const results = runSetupMcp({ cwd: dir, noVscode: true });
+    const results = runSetupMcp({ cwd: dir, home, noVscode: true });
     expect(results[0]?.action).toBe('unchanged');
   });
 
@@ -117,7 +159,7 @@ describe('runSetupMcp', () => {
       )
     );
 
-    const results = runSetupMcp({ cwd: dir, noVscode: true });
+    const results = runSetupMcp({ cwd: dir, home, noVscode: true });
     expect(results[0]?.action).toBe('skipped');
     expect(results[0]?.reason).toMatch(/--force/);
 
@@ -139,7 +181,7 @@ describe('runSetupMcp', () => {
       )
     );
 
-    const results = runSetupMcp({ cwd: dir, noVscode: true, force: true });
+    const results = runSetupMcp({ cwd: dir, home, noVscode: true, force: true });
     expect(results[0]?.action).toBe('updated');
 
     const project = JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf-8'));
@@ -147,21 +189,21 @@ describe('runSetupMcp', () => {
   });
 
   it('creates .vscode directory when missing', () => {
-    runSetupMcp({ cwd: dir, noProject: true });
+    runSetupMcp({ cwd: dir, home, noProject: true });
     const vscode = JSON.parse(readFileSync(join(dir, '.vscode', 'mcp.json'), 'utf-8'));
     expect(vscode.servers.agentage).toBeDefined();
   });
 
   it('refuses to overwrite a malformed existing config', () => {
     writeFileSync(join(dir, '.mcp.json'), 'not-json-at-all');
-    expect(() => runSetupMcp({ cwd: dir, noVscode: true })).toThrow(/not a JSON object/);
+    expect(() => runSetupMcp({ cwd: dir, home, noVscode: true })).toThrow(/not a JSON object/);
   });
 
   it('adds agentage entry when config exists but has no mcpServers key', () => {
     mkdirSync(join(dir, '.vscode'), { recursive: true });
     writeFileSync(join(dir, '.vscode', 'mcp.json'), JSON.stringify({ otherField: true }));
 
-    const results = runSetupMcp({ cwd: dir, noProject: true });
+    const results = runSetupMcp({ cwd: dir, home, noProject: true });
     expect(results[0]?.action).toBe('added');
 
     const vscode = JSON.parse(readFileSync(join(dir, '.vscode', 'mcp.json'), 'utf-8'));

--- a/src/commands/setup-mcp.ts
+++ b/src/commands/setup-mcp.ts
@@ -1,9 +1,11 @@
 import { type Command } from 'commander';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import chalk from 'chalk';
 
 export type McpCommandStyle = 'npx' | 'binary';
+export type McpScope = 'project' | 'user' | 'all';
 
 interface McpServerEntry {
   type: 'stdio';
@@ -12,7 +14,7 @@ interface McpServerEntry {
 }
 
 interface McpConfigFile {
-  kind: 'claude-code-project' | 'vscode-workspace';
+  kind: 'claude-code-project' | 'vscode-workspace' | 'claude-code-user';
   path: string;
   /** Top-level key under which MCP servers live in this client's config. */
   key: 'mcpServers' | 'servers';
@@ -20,6 +22,8 @@ interface McpConfigFile {
 
 export interface SetupMcpOptions {
   cwd?: string;
+  home?: string;
+  scope?: McpScope;
   style?: McpCommandStyle;
   force?: boolean;
   noProject?: boolean;
@@ -27,7 +31,7 @@ export interface SetupMcpOptions {
   json?: boolean;
 }
 
-interface TargetResult {
+export interface TargetResult {
   kind: McpConfigFile['kind'];
   path: string;
   action: 'created' | 'added' | 'updated' | 'unchanged' | 'skipped';
@@ -39,20 +43,30 @@ const buildEntry = (style: McpCommandStyle): McpServerEntry =>
     ? { type: 'stdio', command: 'agentage-mcp', args: [] }
     : { type: 'stdio', command: 'npx', args: ['-y', '@agentage/mcp'] };
 
-const resolveTargets = (cwd: string, opts: SetupMcpOptions): McpConfigFile[] => {
+const resolveTargets = (cwd: string, home: string, opts: SetupMcpOptions): McpConfigFile[] => {
+  const scope: McpScope = opts.scope ?? 'project';
+  const wantProject = scope === 'project' || scope === 'all';
+  const wantUser = scope === 'user' || scope === 'all';
   const targets: McpConfigFile[] = [];
-  if (!opts.noProject) {
+  if (wantProject && !opts.noProject) {
     targets.push({
       kind: 'claude-code-project',
       path: join(cwd, '.mcp.json'),
       key: 'mcpServers',
     });
   }
-  if (!opts.noVscode) {
+  if (wantProject && !opts.noVscode) {
     targets.push({
       kind: 'vscode-workspace',
       path: join(cwd, '.vscode', 'mcp.json'),
       key: 'servers',
+    });
+  }
+  if (wantUser) {
+    targets.push({
+      kind: 'claude-code-user',
+      path: join(home, '.claude.json'),
+      key: 'mcpServers',
     });
   }
   return targets;
@@ -119,10 +133,13 @@ export const writeMcpConfig = (
 
 export const runSetupMcp = (opts: SetupMcpOptions = {}): TargetResult[] => {
   const cwd = resolve(opts.cwd ?? process.cwd());
+  const home = resolve(opts.home ?? homedir());
   const entry = buildEntry(opts.style ?? 'npx');
-  const targets = resolveTargets(cwd, opts);
+  const targets = resolveTargets(cwd, home, opts);
   if (targets.length === 0) {
-    throw new Error('no targets selected — drop --no-project / --no-vscode');
+    throw new Error(
+      'no targets selected — check --scope (project|user|all) and --no-project / --no-vscode'
+    );
   }
   return targets.map((t) => writeMcpConfig(t, entry, opts.force === true));
 };
@@ -142,28 +159,52 @@ const describeAction = (r: TargetResult): string => {
   }
 };
 
+const targetLabel = (kind: McpConfigFile['kind']): string => {
+  switch (kind) {
+    case 'claude-code-project':
+      return 'claude-code (project)';
+    case 'vscode-workspace':
+      return 'vscode (workspace)';
+    case 'claude-code-user':
+      return 'claude-code (user)';
+  }
+};
+
+export const printMcpResults = (results: TargetResult[]): void => {
+  for (const r of results) {
+    console.log(
+      `${describeAction(r).padEnd(20)} ${targetLabel(r.kind).padEnd(22)} ${chalk.dim(r.path)}`
+    );
+    if (r.reason) console.log(`  ${chalk.dim(r.reason)}`);
+  }
+};
+
 export const registerSetupMcp = (setup: Command): void => {
   setup
     .command('mcp')
-    .description('Wire the Agentage MCP shim into MCP client configs in the current directory')
+    .description(
+      'Wire the Agentage MCP shim into MCP client configs. Defaults to project scope (cwd).'
+    )
+    .option(
+      '--scope <scope>',
+      'Which configs to write: `project` (default: cwd .mcp.json + .vscode/mcp.json), `user` (~/.claude.json), or `all`'
+    )
     .option('--style <style>', 'Command style: `npx` (default) or `binary` for direct agentage-mcp')
     .option('--force', 'Overwrite an existing `agentage` entry that differs from the generated one')
-    .option('--no-project', 'Skip .mcp.json (Claude Code project scope)')
-    .option('--no-vscode', 'Skip .vscode/mcp.json (VSCode workspace)')
+    .option('--no-project', 'In `project`/`all` scope, skip .mcp.json (Claude Code project)')
+    .option('--no-vscode', 'In `project`/`all` scope, skip .vscode/mcp.json (VSCode workspace)')
     .option('--json', 'JSON output')
     .action((opts: SetupMcpOptions) => {
       const style: McpCommandStyle = opts.style === 'binary' ? 'binary' : 'npx';
-      const results = runSetupMcp({ ...opts, style });
+      const scope: McpScope =
+        opts.scope === 'user' || opts.scope === 'all' ? opts.scope : 'project';
+      const results = runSetupMcp({ ...opts, style, scope });
 
       if (opts.json) {
-        console.log(JSON.stringify({ cwd: process.cwd(), style, results }, null, 2));
+        console.log(JSON.stringify({ cwd: process.cwd(), scope, style, results }, null, 2));
         return;
       }
 
-      for (const r of results) {
-        const label = r.kind === 'vscode-workspace' ? 'vscode' : 'claude-code';
-        console.log(`${describeAction(r).padEnd(20)} ${label}  ${chalk.dim(r.path)}`);
-        if (r.reason) console.log(`  ${chalk.dim(r.reason)}`);
-      }
+      printMcpResults(results);
     });
 };

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -18,7 +18,13 @@ import { ensureDaemon } from '../utils/ensure-daemon.js';
 import { readAuth, saveAuth, deleteAuth, type AuthState } from '../hub/auth.js';
 import { startCallbackServer, getCallbackPort } from '../hub/auth-callback.js';
 import { createHubClient } from '../hub/hub-client.js';
-import { registerSetupMcp } from './setup-mcp.js';
+import {
+  printMcpResults,
+  registerSetupMcp,
+  runSetupMcp,
+  type McpCommandStyle,
+  type TargetResult,
+} from './setup-mcp.js';
 
 const DEFAULT_HUB_URL = 'https://agentage.io';
 
@@ -35,6 +41,8 @@ export interface SetupOptions {
   interactive?: boolean;
   force?: boolean;
   json?: boolean;
+  mcp?: boolean;
+  mcpStyle?: McpCommandStyle;
 }
 
 type SetupMode = 'fresh' | 'reauth' | 'disconnect' | 'standalone' | 'idempotent';
@@ -256,7 +264,8 @@ const printSummary = (
   config: DaemonConfig,
   mode: SetupMode,
   userEmail: string | null,
-  opts: SetupOptions
+  opts: SetupOptions,
+  mcp: TargetResult[] | null
 ): void => {
   if (opts.json) {
     console.log(
@@ -271,6 +280,7 @@ const printSummary = (
             userEmail,
           },
           agentsDir: config.agents.default,
+          mcp,
         },
         null,
         2
@@ -283,6 +293,10 @@ const printSummary = (
   console.log(`  Hub:        ${config.hub?.url ?? '(none)'}`);
   console.log(`  Agents dir: ${config.agents.default}`);
   if (userEmail) console.log(`  User:       ${userEmail}`);
+  if (mcp && mcp.length > 0) {
+    console.log(chalk.bold('\nMCP clients:'));
+    printMcpResults(mcp);
+  }
   if (mode === 'standalone') {
     console.log(chalk.dim('\nStandalone mode — run `agentage setup --reauth` to connect to hub.'));
   } else {
@@ -362,7 +376,21 @@ export const runSetup = async (opts: SetupOptions): Promise<void> => {
     userEmail = readAuth()?.user?.email ?? null;
   }
 
-  printSummary(config, mode, userEmail, opts);
+  // Wire user-scope MCP configs so Claude Code (any project) sees the daemon.
+  // Only on fresh setup — reauth keeps existing MCP wiring, standalone skips
+  // because we haven't proven daemon + auth yet.
+  let mcp: TargetResult[] | null = null;
+  if (mode === 'fresh' && opts.mcp !== false) {
+    try {
+      mcp = runSetupMcp({ scope: 'user', style: opts.mcpStyle ?? 'npx' });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(chalk.yellow(`\nMCP wiring skipped: ${msg}`));
+      console.error(chalk.dim('Run `agentage setup mcp --scope=user` manually if desired.'));
+    }
+  }
+
+  printSummary(config, mode, userEmail, opts, mcp);
   process.exit(0);
 };
 
@@ -381,6 +409,8 @@ export const registerSetup = (program: Command): void => {
     .option('-y, --yes', 'Skip confirmation')
     .option('--no-interactive', 'Refuse to prompt; error if input would be needed')
     .option('--force', 'Overwrite existing machine identity on rename')
+    .option('--no-mcp', 'Skip the user-scope MCP wiring stage (~/.claude.json). Fresh mode only.')
+    .option('--mcp-style <style>', 'MCP command style: `npx` (default) or `binary`')
     .option('--json', 'JSON output')
     .action(async (opts: SetupOptions) => {
       await runSetup(opts);


### PR DESCRIPTION
## Summary

- `agentage setup mcp --scope <project|user|all>` — new flag. `project` (default) writes cwd `.mcp.json` + `.vscode/mcp.json` (unchanged). `user` writes `~/.claude.json`. `all` does both.
- New target `claude-code-user` preserves every other top-level field in `~/.claude.json` (projects, oauthAccount, etc.) when merging.
- `agentage setup` (fresh mode only) now wires user-scope MCP as its last stage. `--no-mcp` skips; `--mcp-style <npx|binary>` picks command style. Failure is a yellow notice, not a setup failure.
- Summary output (text + `--json`) reports each MCP target's action.
- Mental model: `setup` = "make this machine work with Claude everywhere"; `setup mcp` = "make this repo work".

## Why

Follow-up to [agentage/cli#154] per design discussion in [work/tasks/mcp-ship-plan] Phase 3. Deferred reauth/disconnect/standalone/idempotent paths — they're reconfig, not first-run, and shouldn't silently rewrite MCP entries.

## Test plan
- [ ] 3 new tests: scope=user target, scope=all target set, user-scope preserves unrelated top-level keys
- [ ] All 549 tests pass
- [ ] Smoke: `cd /tmp && agentage setup mcp --scope=user` merges `agentage` into `~/.claude.json` without disturbing existing entries
- [ ] Manual smoke: fresh `agentage setup` on a new machine writes `~/.claude.json` at the end