### PR TITLE
Release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.21.0] - 2026-04-24
+
+### New Features
+- Add `--scope` flag to setup command for configuring MCP with user-specific scope settings
+
 ## [0.20.3] - 2026-04-24
 
 ### New Features

--- a/changelog-content.md
+++ b/changelog-content.md
@@ -1,2 +1,2 @@
 ### New Features
-- Add `setup mcp` subcommand to configure MCP (Model Context Protocol) settings in current directory
+- Add `--scope` flag to setup command for configuring MCP with user-specific scope settings

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentage/cli",
-  "version": "0.20.3",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentage/cli",
-      "version": "0.20.3",
+      "version": "0.21.0",
       "license": "MIT",
       "dependencies": {
         "@agentage/core": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentage/cli",
-  "version": "0.20.3",
+  "version": "0.21.0",
   "description": "Agentage CLI and daemon — control plane for AI agents",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release v0.21.0

This PR prepares the release of version 0.21.0.

### Changes
### New Features
- Add `--scope` flag to setup command for configuring MCP with user-specific scope settings

### Checklist
- [ ] Review the changelog
- [ ] Verify version numbers are correct
- [ ] Merge when ready to release

---

Once merged, this will automatically:
1. Create a git tag `v0.21.0`
2. Trigger the publish workflow
3. Publish to npm with provenance