### PR TITLE
feat(daemon): include action capabilities in heartbeat

### DIFF
--- a/src/hub/hub-client.ts
+++ b/src/hub/hub-client.ts
@@ -25,6 +25,17 @@ export interface HubClient {
       daemonVersion: string;
       agentsDefault?: string;
       projectsDefault?: string;
+      actions?: Array<{
+        name: string;
+        version: string;
+        title: string;
+        description: string;
+        scope: 'machine' | 'hub' | 'project';
+        capability: string;
+        idempotent: boolean;
+        inputSchema?: Record<string, unknown>;
+        deprecatedSince?: string;
+      }>;
       resources?: {
         cpuUsage?: number;
         cpuCount?: number;

--- a/src/hub/hub-sync.test.ts
+++ b/src/hub/hub-sync.test.ts
@@ -44,6 +44,10 @@ vi.mock('../projects/projects.js', () => ({
   loadProjects: vi.fn(),
 }));
 
+vi.mock('../daemon/actions.js', () => ({
+  getActionRegistry: vi.fn(() => ({ list: () => [] })),
+}));
+
 vi.mock('../daemon/metrics.js', () => ({
   collectMachineMetrics: vi.fn().mockResolvedValue({
     cpuUsage: 12.3,
@@ -243,6 +247,7 @@ describe('hub-sync', () => {
         daemonVersion: '0.7.1',
         agentsDefault: '/tmp/agents',
         projectsDefault: '/tmp/projects',
+        actions: [],
         resources: {
           cpuUsage: 12.3,
           cpuCount: 8,
@@ -255,6 +260,47 @@ describe('hub-sync', () => {
           loadAvg15m: 0.9,
         },
       });
+    });
+
+    it('includes daemon action capabilities in heartbeat payload', async () => {
+      const { getActionRegistry } = await import('../daemon/actions.js');
+      vi.mocked(getActionRegistry).mockReturnValue({
+        list: () => [
+          {
+            name: 'cli:update' as const,
+            version: '1.0',
+            title: 'Update CLI',
+            description: 'Reinstall daemon globally',
+            scope: 'machine',
+            capability: 'cli.write',
+            idempotent: false,
+          },
+        ],
+      } as unknown as ReturnType<typeof getActionRegistry>);
+
+      mockReadAuth.mockReturnValue(testAuth);
+      mockGetAgents.mockReturnValue([] as ReturnType<typeof getAgents>);
+      mockGetRuns.mockReturnValue([] as ReturnType<typeof getRuns>);
+      mockLoadProjects.mockReturnValue([]);
+
+      const sync = createHubSync();
+      await sync.start();
+      await sync.triggerHeartbeat();
+
+      const call = mockHubClient.heartbeat.mock.calls[0][1] as {
+        actions: Array<Record<string, unknown>>;
+      };
+      expect(call.actions).toEqual([
+        {
+          name: 'cli:update',
+          version: '1.0',
+          title: 'Update CLI',
+          description: 'Reinstall daemon globally',
+          scope: 'machine',
+          capability: 'cli.write',
+          idempotent: false,
+        },
+      ]);
     });
 
     it('includes inputSchema in agent payload when declared', async () => {

--- a/src/hub/hub-sync.ts
+++ b/src/hub/hub-sync.ts
@@ -8,6 +8,7 @@ import { logInfo, logWarn } from '../daemon/logger.js';
 import { getAgents } from '../daemon/routes.js';
 import { cancelRun, sendInput, getRuns } from '../daemon/run-manager.js';
 import { getScheduler } from '../daemon/scheduler.js';
+import { getActionRegistry } from '../daemon/actions.js';
 import { loadProjects } from '../projects/projects.js';
 
 import { collectMachineMetrics } from '../daemon/metrics.js';
@@ -110,6 +111,20 @@ export const createHubSync = (): HubSync => {
       );
     }
 
+    const actions = getActionRegistry()
+      .list()
+      .map((m) => ({
+        name: m.name,
+        version: m.version,
+        title: m.title,
+        description: m.description,
+        scope: m.scope,
+        capability: m.capability,
+        idempotent: m.idempotent,
+        ...(m.inputSchema && { inputSchema: m.inputSchema as Record<string, unknown> }),
+        ...(m.deprecatedSince && { deprecatedSince: m.deprecatedSince }),
+      }));
+
     const response = await hubClient.heartbeat(auth.hub.machineId, {
       agents,
       projects,
@@ -117,6 +132,7 @@ export const createHubSync = (): HubSync => {
       daemonVersion: VERSION,
       agentsDefault: config.agents.default,
       projectsDefault: config.projects.default,
+      actions,
       ...(resources && { resources }),
     });
 


### PR DESCRIPTION
## Summary

The daemon already registers a catalog of machine-scoped actions via `getActionRegistry()` (today: `cli:update`, `agent:install`, `project:add-from-origin`) and exposes them locally at `GET /api/actions`. The hub had no visibility into what each machine supports — every dashboard had to either hardcode the list or render nothing.

This adds an `actions` array to the heartbeat payload so the hub knows the live catalog per machine.

## What changes

- `src/hub/hub-sync.ts` — call `getActionRegistry().list()` once per heartbeat, map to a wire-friendly shape (drop `outputSchema`, `progressSchema`; keep `name`, `version`, `title`, `description`, `scope`, `capability`, `idempotent`, `inputSchema?`, `deprecatedSince?`).
- `src/hub/hub-client.ts` — add the `actions` field to the `heartbeat()` request type.
- `src/hub/hub-sync.test.ts` — mock `daemon/actions.js`, update the existing payload assertion to include `actions: []`, and add a focused test that registry contents flow through.

## Compatibility

- **Field is optional on the wire** — an older hub silently ignores it.
- **No CLI behaviour change** — heartbeat cadence + payload size grow by O(actions) per hub round-trip, which is small (a few hundred bytes).

## Companion PR

Hub-side: `agentage/web` PR (persists `actions` to `machines.actions JSONB`, dashboard reads it and renders the Commands tab dynamically). Either side can merge first.

## Verification

`npm run verify` — type-check + lint + format + 550 tests + build, all green.

## Test plan

- [ ] Pull, `npm install && npm run build && npm link`.
- [ ] `agentage status` (or whatever boots your daemon) → confirm a heartbeat fires.
- [ ] Inspect the request body sent to `POST /machines/:id/heartbeat` (e.g. via dashboard logs or hub access logs) — should include `actions: [...]` with `cli:update`, `agent:install`, `project:add-from-origin`.