### PR TITLE
feat: vault foundations + admin actions + CLI (phase 0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,32 +13,34 @@
         "@agentage/platform": "^0.6.1",
         "@supabase/supabase-js": "2.104.1",
         "ajv": "8.20.0",
-        "chalk": "*",
-        "commander": "*",
+        "better-sqlite3": "latest",
+        "chalk": "latest",
+        "commander": "latest",
         "croner": "*",
-        "express": "*",
-        "gray-matter": "*",
-        "jiti": "*",
-        "open": "*",
-        "ws": "*"
+        "express": "latest",
+        "gray-matter": "latest",
+        "jiti": "latest",
+        "open": "latest",
+        "ws": "latest"
       },
       "bin": {
         "agentage": "dist/cli.js"
       },
       "devDependencies": {
-        "@anthropic-ai/sdk": "*",
-        "@types/express": "*",
-        "@types/node": "*",
-        "@types/ws": "*",
-        "@typescript-eslint/eslint-plugin": "*",
-        "@typescript-eslint/parser": "*",
-        "@vitest/coverage-v8": "*",
+        "@anthropic-ai/sdk": "latest",
+        "@types/better-sqlite3": "latest",
+        "@types/express": "latest",
+        "@types/node": "latest",
+        "@types/ws": "latest",
+        "@typescript-eslint/eslint-plugin": "latest",
+        "@typescript-eslint/parser": "latest",
+        "@vitest/coverage-v8": "latest",
         "eslint": "latest",
-        "eslint-config-prettier": "*",
-        "eslint-plugin-prettier": "*",
-        "prettier": "*",
-        "typescript": "*",
-        "vitest": "*"
+        "eslint-config-prettier": "latest",
+        "eslint-plugin-prettier": "latest",
+        "prettier": "latest",
+        "typescript": "latest",
+        "vitest": "latest"
       },
       "engines": {
         "node": ">=22.0.0",
@@ -785,6 +787,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -1400,6 +1412,60 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -1435,6 +1501,30 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bundle-name": {
@@ -1511,6 +1601,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/commander": {
       "version": "14.0.3",
@@ -1619,6 +1715,30 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1679,7 +1799,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -1712,6 +1831,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -2061,6 +2189,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2200,6 +2337,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -2277,6 +2420,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2337,6 +2486,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -2464,6 +2619,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -2488,6 +2663,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -3109,6 +3290,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -3124,6 +3317,21 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3150,6 +3358,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3164,6 +3378,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/object-inspect": {
@@ -3387,6 +3613,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3439,6 +3692,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3486,6 +3749,35 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/require-from-string": {
@@ -3559,6 +3851,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3582,7 +3894,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3744,6 +4055,51 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3783,10 +4139,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/strip-bom-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
       "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3819,6 +4193,34 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tinybench": {
@@ -3900,6 +4302,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3965,6 +4379,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@agentage/platform": "^0.6.1",
     "@supabase/supabase-js": "2.104.1",
     "ajv": "8.20.0",
+    "better-sqlite3": "latest",
     "chalk": "latest",
     "commander": "latest",
     "croner": "*",
@@ -44,6 +45,7 @@
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "latest",
+    "@types/better-sqlite3": "latest",
     "@types/express": "latest",
     "@types/node": "latest",
     "@types/ws": "latest",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import { createCreateCommand } from './commands/create.js';
 import { registerUpdate } from './commands/update.js';
 import { registerProjects } from './commands/projects.js';
 import { registerSchedules } from './commands/schedules.js';
+import { registerVaults } from './commands/vault.js';
 import { checkForUpdateSafe, type UpdateCheckResult } from './utils/update-checker.js';
 
 const program = new Command();
@@ -41,6 +42,7 @@ program.addCommand(createCreateCommand());
 registerUpdate(program);
 registerProjects(program);
 registerSchedules(program);
+registerVaults(program);
 
 program.parseAsync().then(async () => {
   // Show update notice if a newer version is available

--- a/src/commands/vault.test.ts
+++ b/src/commands/vault.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { Command } from 'commander';
+
+vi.mock('../utils/action-client.js', () => ({
+  invokeAction: vi.fn(),
+}));
+
+vi.mock('../utils/ensure-daemon.js', () => ({
+  ensureDaemon: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { invokeAction } from '../utils/action-client.js';
+import { ensureDaemon } from '../utils/ensure-daemon.js';
+import { registerVaults } from './vault.js';
+
+const mockInvoke = vi.mocked(invokeAction);
+const mockEnsureDaemon = vi.mocked(ensureDaemon);
+
+describe('vault command', () => {
+  let program: Command;
+  let logs: string[];
+  let errorLogs: string[];
+  const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logs = [];
+    errorLogs = [];
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(' '));
+    });
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errorLogs.push(args.map(String).join(' '));
+    });
+    mockExit.mockClear();
+    program = new Command();
+    program.exitOverride();
+    registerVaults(program);
+  });
+
+  describe('vault list', () => {
+    it('shows empty state when no vaults registered', async () => {
+      mockInvoke.mockResolvedValueOnce({ vaults: [] });
+      await program.parseAsync(['node', 'agentage', 'vault', 'list']);
+      expect(mockEnsureDaemon).toHaveBeenCalled();
+      expect(mockInvoke).toHaveBeenCalledWith('vault:list', {}, ['vault.read']);
+      expect(logs.some((l) => l.includes('No vaults registered'))).toBe(true);
+      expect(mockExit).toHaveBeenCalledWith(0);
+    });
+
+    it('prints a table when vaults exist', async () => {
+      mockInvoke.mockResolvedValueOnce({
+        vaults: [
+          {
+            slug: 'notes',
+            uuid: 'uuid-1',
+            path: '/home/u/notes',
+            fileCount: 42,
+            indexedAt: '2026-04-25T00:00:00.000Z',
+          },
+        ],
+      });
+      await program.parseAsync(['node', 'agentage', 'vault', 'list']);
+      const all = logs.join('\n');
+      expect(all).toContain('notes');
+      expect(all).toContain('/home/u/notes');
+      expect(all).toContain('42');
+    });
+
+    it('emits JSON when --json passed', async () => {
+      mockInvoke.mockResolvedValueOnce({
+        vaults: [{ slug: 'a', uuid: 'u1', path: '/p', fileCount: 1, indexedAt: null }],
+      });
+      await program.parseAsync(['node', 'agentage', 'vault', 'list', '--json']);
+      expect(logs[0]).toContain('"slug": "a"');
+    });
+  });
+
+  describe('vault add', () => {
+    it('passes path + slug to vault:add action', async () => {
+      mockInvoke.mockResolvedValueOnce({
+        slug: 'notes',
+        uuid: 'u1',
+        path: '/home/u/notes',
+        fileCount: 5,
+      });
+      await program.parseAsync([
+        'node',
+        'agentage',
+        'vault',
+        'add',
+        '/home/u/notes',
+        '--slug',
+        'notes',
+      ]);
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'vault:add',
+        expect.objectContaining({ path: '/home/u/notes', slug: 'notes' }),
+        ['vault.admin']
+      );
+      expect(logs.some((l) => l.includes('Added vault'))).toBe(true);
+    });
+
+    it('passes scope when non-default', async () => {
+      mockInvoke.mockResolvedValueOnce({ slug: 's', uuid: 'u', path: '/p', fileCount: 0 });
+      await program.parseAsync(['node', 'agentage', 'vault', 'add', '/p', '--scope', 'shared']);
+      const call = mockInvoke.mock.calls[0];
+      expect(call?.[1]).toMatchObject({ scope: 'shared' });
+    });
+
+    it('omits scope when local (the default)', async () => {
+      mockInvoke.mockResolvedValueOnce({ slug: 's', uuid: 'u', path: '/p', fileCount: 0 });
+      await program.parseAsync(['node', 'agentage', 'vault', 'add', '/p']);
+      const call = mockInvoke.mock.calls[0];
+      expect(call?.[1]).not.toHaveProperty('scope');
+    });
+
+    it('reports failure and exits 1 on error', async () => {
+      mockInvoke.mockRejectedValueOnce(new Error('INVALID_INPUT: path is not a directory'));
+      await program.parseAsync(['node', 'agentage', 'vault', 'add', '/nope']);
+      expect(errorLogs.some((l) => l.includes('Failed to add vault'))).toBe(true);
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('vault remove', () => {
+    it('invokes vault:remove with slug and reports success', async () => {
+      mockInvoke.mockResolvedValueOnce({ slug: 'gone', removed: true });
+      await program.parseAsync(['node', 'agentage', 'vault', 'remove', 'gone']);
+      expect(mockInvoke).toHaveBeenCalledWith('vault:remove', { slug: 'gone' }, ['vault.admin']);
+      expect(logs.some((l) => l.includes('Removed vault'))).toBe(true);
+      expect(logs.some((l) => l.includes('files on disk were not touched'))).toBe(true);
+    });
+  });
+
+  describe('vault reindex', () => {
+    it('reports stats from reindex action', async () => {
+      mockInvoke.mockResolvedValueOnce({
+        slug: 'r',
+        added: 2,
+        modified: 1,
+        removed: 0,
+        unchanged: 5,
+      });
+      await program.parseAsync(['node', 'agentage', 'vault', 'reindex', 'r']);
+      expect(mockInvoke).toHaveBeenCalledWith('vault:reindex', { slug: 'r' }, ['vault.admin']);
+      const all = logs.join('\n');
+      expect(all).toContain('Reindexed vault');
+      expect(all).toContain('added=2');
+      expect(all).toContain('modified=1');
+      expect(all).toContain('unchanged=5');
+    });
+  });
+});

--- a/src/commands/vault.ts
+++ b/src/commands/vault.ts
@@ -1,0 +1,142 @@
+import { resolve } from 'node:path';
+import chalk from 'chalk';
+import { type Command } from 'commander';
+import type { VaultAddOutput } from '../daemon/actions/vault-add.js';
+import type { VaultListOutput } from '../daemon/actions/vault-list.js';
+import type { VaultReindexOutput } from '../daemon/actions/vault-reindex.js';
+import type { VaultRemoveOutput } from '../daemon/actions/vault-remove.js';
+import { invokeAction } from '../utils/action-client.js';
+import { ensureDaemon } from '../utils/ensure-daemon.js';
+
+export const registerVaults = (program: Command): void => {
+  const cmd = program.command('vault').description('Manage vaults');
+
+  cmd
+    .command('list', { isDefault: true })
+    .description('List registered vaults')
+    .option('--json', 'JSON output')
+    .action(async (opts: { json?: boolean }) => {
+      await handleList(opts.json ?? false);
+    });
+
+  cmd
+    .command('add <path>')
+    .description('Register a vault and run the initial index scan')
+    .option('--slug <slug>', 'Override the auto-derived slug')
+    .option('--scope <scope>', 'local or shared', 'local')
+    .option('--write-mode <mode>', 'inbox-dated or append-daily', 'inbox-dated')
+    .action(async (path: string, opts: { slug?: string; scope?: string; writeMode?: string }) => {
+      await handleAdd(path, opts);
+    });
+
+  cmd
+    .command('remove <slug>')
+    .description('Unregister a vault and delete its index (does not touch user files)')
+    .action(async (slug: string) => {
+      await handleRemove(slug);
+    });
+
+  cmd
+    .command('reindex <slug>')
+    .description('Force a full filesystem rescan of the vault')
+    .action(async (slug: string) => {
+      await handleReindex(slug);
+    });
+};
+
+const handleList = async (jsonMode: boolean): Promise<void> => {
+  await ensureDaemon();
+  const result = await invokeAction<VaultListOutput>('vault:list', {}, ['vault.read']);
+  if (jsonMode) {
+    console.log(JSON.stringify(result.vaults, null, 2));
+    process.exit(0);
+    return;
+  }
+  if (result.vaults.length === 0) {
+    console.log(chalk.gray('No vaults registered.'));
+    console.log(chalk.dim('Run `agentage vault add <path>` to register one.'));
+    process.exit(0);
+    return;
+  }
+  const slugWidth = Math.max(8, ...result.vaults.map((v) => v.slug.length)) + 2;
+  const pathWidth = Math.max(12, ...result.vaults.map((v) => v.path.length)) + 2;
+  console.log(
+    chalk.bold('SLUG'.padEnd(slugWidth)) +
+      chalk.bold('PATH'.padEnd(pathWidth)) +
+      chalk.bold('FILES'.padEnd(8)) +
+      chalk.bold('INDEXED')
+  );
+  for (const v of result.vaults) {
+    console.log(
+      v.slug.padEnd(slugWidth) +
+        chalk.gray(v.path.padEnd(pathWidth)) +
+        String(v.fileCount).padEnd(8) +
+        chalk.dim(v.indexedAt ?? 'never')
+    );
+  }
+  console.log(chalk.dim(`\n${result.vaults.length} vault(s)`));
+  process.exit(0);
+};
+
+const handleAdd = async (
+  path: string,
+  opts: { slug?: string; scope?: string; writeMode?: string }
+): Promise<void> => {
+  await ensureDaemon();
+  const absPath = resolve(path);
+  const input: Record<string, unknown> = { path: absPath };
+  if (opts.slug) input['slug'] = opts.slug;
+  if (opts.scope && opts.scope !== 'local') input['scope'] = opts.scope;
+  if (opts.writeMode && opts.writeMode !== 'inbox-dated') input['writeMode'] = opts.writeMode;
+  try {
+    const result = await invokeAction<VaultAddOutput>('vault:add', input, ['vault.admin']);
+    console.log(
+      chalk.green(`Added vault "${result.slug}"`) +
+        chalk.dim(` (${result.fileCount} files indexed)`)
+    );
+    console.log(chalk.dim(`  uuid: ${result.uuid}`));
+    console.log(chalk.dim(`  path: ${result.path}`));
+    process.exit(0);
+  } catch (err) {
+    console.error(
+      chalk.red(`Failed to add vault: ${err instanceof Error ? err.message : String(err)}`)
+    );
+    process.exit(1);
+  }
+};
+
+const handleRemove = async (slug: string): Promise<void> => {
+  await ensureDaemon();
+  try {
+    await invokeAction<VaultRemoveOutput>('vault:remove', { slug }, ['vault.admin']);
+    console.log(chalk.green(`Removed vault "${slug}"`));
+    console.log(chalk.dim('  (your files on disk were not touched)'));
+    process.exit(0);
+  } catch (err) {
+    console.error(
+      chalk.red(`Failed to remove vault: ${err instanceof Error ? err.message : String(err)}`)
+    );
+    process.exit(1);
+  }
+};
+
+const handleReindex = async (slug: string): Promise<void> => {
+  await ensureDaemon();
+  try {
+    const result = await invokeAction<VaultReindexOutput>('vault:reindex', { slug }, [
+      'vault.admin',
+    ]);
+    console.log(chalk.green(`Reindexed vault "${slug}"`));
+    console.log(
+      chalk.dim(
+        `  added=${result.added} modified=${result.modified} removed=${result.removed} unchanged=${result.unchanged}`
+      )
+    );
+    process.exit(0);
+  } catch (err) {
+    console.error(
+      chalk.red(`Failed to reindex vault: ${err instanceof Error ? err.message : String(err)}`)
+    );
+    process.exit(1);
+  }
+};

--- a/src/daemon/actions.test.ts
+++ b/src/daemon/actions.test.ts
@@ -18,21 +18,27 @@ describe('action registry bootstrap', () => {
     resetActionRegistry();
   });
 
-  it('registers the three built-in actions with expected manifests', () => {
+  it('registers the built-in actions with expected manifests', () => {
     const names = getActionRegistry()
       .list()
       .map((m) => m.name)
       .sort();
-    expect(names).toEqual(['agent:install', 'cli:update', 'project:addFromOrigin']);
+    expect(names).toEqual([
+      'agent:install',
+      'cli:update',
+      'project:addFromOrigin',
+      'vault:add',
+      'vault:list',
+      'vault:reindex',
+      'vault:remove',
+    ]);
   });
 
-  it('each action declares a distinct capability and machine scope', () => {
+  it('every action is machine-scoped with a namespace.verb capability', () => {
     const manifests = getActionRegistry().list();
-    const caps = new Set(manifests.map((m) => m.capability));
-    expect(caps.size).toBe(manifests.length);
     for (const m of manifests) {
       expect(m.scope).toBe('machine');
-      expect(m.capability).toMatch(/\.(read|write)$/);
+      expect(m.capability).toMatch(/^[a-z][a-z0-9-]*\.(read|write|admin)$/);
     }
   });
 

--- a/src/daemon/actions.ts
+++ b/src/daemon/actions.ts
@@ -1,8 +1,13 @@
 import { createRegistry, shell, type ActionRegistry } from '@agentage/core';
 import { VERSION } from '../utils/version.js';
+import { getVaultRegistry, persistVaults } from '../vaults/instance.js';
 import { createAgentInstallAction } from './actions/agent-install.js';
 import { createCliUpdateAction } from './actions/cli-update.js';
 import { createProjectAddFromOriginAction } from './actions/project-add-from-origin.js';
+import { createVaultAddAction } from './actions/vault-add.js';
+import { createVaultListAction } from './actions/vault-list.js';
+import { createVaultReindexAction } from './actions/vault-reindex.js';
+import { createVaultRemoveAction } from './actions/vault-remove.js';
 import type { ShellExec } from './actions/types.js';
 
 const shellExec: ShellExec = (command, options) => shell(command, options);
@@ -11,11 +16,6 @@ const readCliVersion = async (): Promise<string> => VERSION;
 
 let registrySingleton: ActionRegistry | null = null;
 
-/**
- * Build the daemon's action registry with built-in control-plane actions.
- * Reference actions all declare scope='machine' + require explicit capability;
- * the transport layer decides which capabilities to grant per caller.
- */
 export const getActionRegistry = (): ActionRegistry => {
   if (registrySingleton) return registrySingleton;
 
@@ -26,11 +26,17 @@ export const getActionRegistry = (): ActionRegistry => {
   registry.register(createProjectAddFromOriginAction({ shell: shellExec }));
   registry.register(createAgentInstallAction({ shell: shellExec }));
 
+  const vaults = getVaultRegistry();
+  const persist = (): void => persistVaults(vaults);
+  registry.register(createVaultAddAction({ vaults, persist }));
+  registry.register(createVaultRemoveAction({ vaults, persist }));
+  registry.register(createVaultReindexAction({ vaults }));
+  registry.register(createVaultListAction({ vaults }));
+
   registrySingleton = registry;
   return registry;
 };
 
-/** Test-only: reset between tests. */
 export const resetActionRegistry = (): void => {
   registrySingleton = null;
 };

--- a/src/daemon/actions/index.ts
+++ b/src/daemon/actions/index.ts
@@ -7,4 +7,16 @@ export type { ProjectAddInput, ProjectAddOutput } from './project-add-from-origi
 export { createAgentInstallAction } from './agent-install.js';
 export type { AgentInstallInput, AgentInstallOutput } from './agent-install.js';
 
+export { createVaultAddAction } from './vault-add.js';
+export type { VaultAddInput, VaultAddOutput } from './vault-add.js';
+
+export { createVaultRemoveAction } from './vault-remove.js';
+export type { VaultRemoveInput, VaultRemoveOutput } from './vault-remove.js';
+
+export { createVaultReindexAction } from './vault-reindex.js';
+export type { VaultReindexInput, VaultReindexOutput } from './vault-reindex.js';
+
+export { createVaultListAction } from './vault-list.js';
+export type { VaultListInput, VaultListOutput } from './vault-list.js';
+
 export type { ActionProgress, ShellExec } from './types.js';

--- a/src/daemon/actions/vault-actions.test.ts
+++ b/src/daemon/actions/vault-actions.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRegistry, type InvokeEvent } from '@agentage/core';
+import { VaultRegistry } from '../../vaults/registry.js';
+import { createVaultAddAction } from './vault-add.js';
+import { createVaultListAction } from './vault-list.js';
+import { createVaultReindexAction } from './vault-reindex.js';
+import { createVaultRemoveAction } from './vault-remove.js';
+
+const collect = async (gen: AsyncGenerator<InvokeEvent>): Promise<InvokeEvent[]> => {
+  const events: InvokeEvent[] = [];
+  for await (const e of gen) events.push(e);
+  return events;
+};
+
+describe('vault actions', () => {
+  let storage: string;
+  let vaultPath: string;
+  let vaults: VaultRegistry;
+  let persist: ReturnType<typeof vi.fn<() => void>>;
+
+  beforeEach(async () => {
+    storage = await mkdtemp(join(tmpdir(), 'agentage-vactions-storage-'));
+    vaultPath = await mkdtemp(join(tmpdir(), 'agentage-vactions-vault-'));
+    vaults = new VaultRegistry({ storageDir: storage });
+    persist = vi.fn<() => void>();
+  });
+
+  afterEach(async () => {
+    await vaults.closeAll();
+    await rm(storage, { recursive: true, force: true });
+    await rm(vaultPath, { recursive: true, force: true });
+  });
+
+  const buildRegistry = (): ReturnType<typeof createRegistry> => {
+    const reg = createRegistry();
+    reg.register(createVaultAddAction({ vaults, persist }));
+    reg.register(createVaultRemoveAction({ vaults, persist }));
+    reg.register(createVaultReindexAction({ vaults }));
+    reg.register(createVaultListAction({ vaults }));
+    return reg;
+  };
+
+  describe('vault:add', () => {
+    it('registers vault, runs initial scan, persists config', async () => {
+      await writeFile(join(vaultPath, 'a.md'), 'alpha');
+      await writeFile(join(vaultPath, 'b.md'), 'beta');
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:add',
+          input: { path: vaultPath, slug: 'notes' },
+          callerId: 'test',
+          capabilities: ['vault.admin'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({
+        type: 'result',
+        data: { slug: 'notes', fileCount: 2, path: vaultPath },
+      });
+      expect(vaults.has('notes')).toBe(true);
+      expect(persist).toHaveBeenCalledTimes(1);
+    });
+
+    it('derives slug from path basename when not provided', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:add',
+          input: { path: vaultPath },
+          callerId: 'test',
+          capabilities: ['vault.admin'],
+        })
+      );
+      const last = events.at(-1);
+      expect(last).toMatchObject({ type: 'result' });
+      const slug = (last as { data: { slug: string } }).data.slug;
+      expect(slug).toMatch(/^[a-z0-9-]+$/);
+      expect(vaults.has(slug)).toBe(true);
+    });
+
+    it('rejects nonexistent path', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:add',
+          input: { path: '/definitely/not/here', slug: 'x' },
+          callerId: 'test',
+          capabilities: ['vault.admin'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'error', code: 'INVALID_INPUT' });
+    });
+
+    it('rejects duplicate slug', async () => {
+      const reg = buildRegistry();
+      await collect(
+        reg.invoke({
+          action: 'vault:add',
+          input: { path: vaultPath, slug: 'dup' },
+          callerId: 'test',
+          capabilities: ['vault.admin'],
+        })
+      );
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:add',
+          input: { path: vaultPath, slug: 'dup' },
+          callerId: 'test',
+          capabilities: ['vault.admin'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'error', code: 'INVALID_INPUT' });
+    });
+
+    it('rejects invalid slug shape', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:add',
+          input: { path: vaultPath, slug: 'BadSlug!' },
+          callerId: 'test',
+          capabilities: ['vault.admin'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'error', code: 'INVALID_INPUT' });
+    });
+
+    it('requires vault.admin capability', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:add',
+          input: { path: vaultPath, slug: 'x' },
+          callerId: 'test',
+          capabilities: ['vault.read'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'error', code: 'UNAUTHORIZED' });
+    });
+  });
+
+  describe('vault:remove', () => {
+    it('removes registered vault and persists', async () => {
+      const reg = buildRegistry();
+      await collect(
+        reg.invoke({
+          action: 'vault:add',
+          input: { path: vaultPath, slug: 'gone' },
+          callerId: 'test',
+          capabilities: ['vault.admin'],
+        })
+      );
+      persist.mockClear();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:remove',
+          input: { slug: 'gone' },
+          callerId: 'test',
+          capabilities: ['vault.admin'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({
+        type: 'result',
+        data: { slug: 'gone', removed: true },
+      });
+      expect(vaults.has('gone')).toBe(false);
+      expect(persist).toHaveBeenCalledTimes(1);
+    });
+
+    it('errors on unknown slug', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:remove',
+          input: { slug: 'ghost' },
+          callerId: 'test',
+          capabilities: ['vault.admin'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'error', code: 'INVALID_INPUT' });
+    });
+  });
+
+  describe('vault:reindex', () => {
+    it('returns scan stats with new files counted as added', async () => {
+      const reg = buildRegistry();
+      await collect(
+        reg.invoke({
+          action: 'vault:add',
+          input: { path: vaultPath, slug: 'r' },
+          callerId: 'test',
+          capabilities: ['vault.admin'],
+        })
+      );
+      await writeFile(join(vaultPath, 'fresh.md'), 'just added');
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:reindex',
+          input: { slug: 'r' },
+          callerId: 'test',
+          capabilities: ['vault.admin'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({
+        type: 'result',
+        data: { slug: 'r', added: 1, modified: 0, removed: 0 },
+      });
+    });
+
+    it('errors on unknown slug', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:reindex',
+          input: { slug: 'nope' },
+          callerId: 'test',
+          capabilities: ['vault.admin'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'error', code: 'INVALID_INPUT' });
+    });
+  });
+
+  describe('vault:list', () => {
+    it('returns empty list when no vaults registered', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:list',
+          input: {},
+          callerId: 'test',
+          capabilities: ['vault.read'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'result', data: { vaults: [] } });
+    });
+
+    it('returns metadata for each registered vault', async () => {
+      await writeFile(join(vaultPath, 'a.md'), 'one');
+      const reg = buildRegistry();
+      await collect(
+        reg.invoke({
+          action: 'vault:add',
+          input: { path: vaultPath, slug: 'mine' },
+          callerId: 'test',
+          capabilities: ['vault.admin'],
+        })
+      );
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:list',
+          input: {},
+          callerId: 'test',
+          capabilities: ['vault.read'],
+        })
+      );
+      const result = events.at(-1) as {
+        data: { vaults: Array<{ slug: string; fileCount: number }> };
+      };
+      expect(result.data.vaults).toHaveLength(1);
+      expect(result.data.vaults[0]?.slug).toBe('mine');
+      expect(result.data.vaults[0]?.fileCount).toBe(1);
+    });
+  });
+});

--- a/src/daemon/actions/vault-add.ts
+++ b/src/daemon/actions/vault-add.ts
@@ -1,0 +1,108 @@
+import { existsSync, statSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+import { action, ActionError, type ActionDefinition } from '@agentage/core';
+import type { VaultRegistry } from '../../vaults/registry.js';
+import type { VaultScope, VaultWriteMode } from '../../vaults/types.js';
+import type { ActionProgress } from './types.js';
+
+export interface VaultAddInput {
+  path: string;
+  slug?: string;
+  scope?: VaultScope;
+  writeMode?: VaultWriteMode;
+}
+
+export interface VaultAddOutput {
+  slug: string;
+  uuid: string;
+  path: string;
+  fileCount: number;
+}
+
+const VALID_SLUG = /^[a-z0-9][a-z0-9-]*$/;
+const SCOPES: ReadonlySet<string> = new Set(['local', 'shared']);
+const WRITE_MODES: ReadonlySet<string> = new Set(['inbox-dated', 'append-daily']);
+
+const validate = (raw: unknown): VaultAddInput => {
+  if (!raw || typeof raw !== 'object') throw new Error('input must be an object');
+  const r = raw as Record<string, unknown>;
+  if (typeof r['path'] !== 'string' || r['path'].length === 0)
+    throw new Error('path must be a non-empty string');
+  const out: VaultAddInput = { path: r['path'] };
+  if (r['slug'] !== undefined) {
+    if (typeof r['slug'] !== 'string' || !VALID_SLUG.test(r['slug']))
+      throw new Error('slug must match /^[a-z0-9][a-z0-9-]*$/');
+    out.slug = r['slug'];
+  }
+  if (r['scope'] !== undefined) {
+    if (typeof r['scope'] !== 'string' || !SCOPES.has(r['scope']))
+      throw new Error('scope must be "local" or "shared"');
+    out.scope = r['scope'] as VaultScope;
+  }
+  if (r['writeMode'] !== undefined) {
+    if (typeof r['writeMode'] !== 'string' || !WRITE_MODES.has(r['writeMode']))
+      throw new Error('writeMode must be "inbox-dated" or "append-daily"');
+    out.writeMode = r['writeMode'] as VaultWriteMode;
+  }
+  return out;
+};
+
+const deriveSlug = (absPath: string): string => {
+  const base = basename(absPath);
+  return base
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+};
+
+export const createVaultAddAction = (deps: {
+  vaults: VaultRegistry;
+  persist: () => void;
+}): ActionDefinition<VaultAddInput, VaultAddOutput, ActionProgress> =>
+  action({
+    manifest: {
+      name: 'vault:add',
+      version: '1.0',
+      title: 'Add vault',
+      description: 'Register a new vault and run the initial index scan',
+      scope: 'machine',
+      capability: 'vault.admin',
+      idempotent: false,
+    },
+    validateInput: validate,
+    async *execute(_ctx, input): AsyncGenerator<ActionProgress, VaultAddOutput, void> {
+      const absPath = resolve(input.path);
+      if (!existsSync(absPath) || !statSync(absPath).isDirectory()) {
+        throw new ActionError('INVALID_INPUT', `path is not a directory: ${absPath}`, false);
+      }
+      const slug = input.slug ?? deriveSlug(absPath);
+      if (!VALID_SLUG.test(slug)) {
+        throw new ActionError(
+          'INVALID_INPUT',
+          `derived slug "${slug}" is invalid; pass slug explicitly`,
+          false
+        );
+      }
+      if (deps.vaults.has(slug)) {
+        throw new ActionError('INVALID_INPUT', `vault "${slug}" already exists`, false);
+      }
+      yield { step: 'register', detail: `slug=${slug}` };
+
+      const { entry, stats } = await deps.vaults.add({
+        slug,
+        path: absPath,
+        scope: input.scope,
+        writeMode: input.writeMode,
+      });
+
+      yield { step: 'persist', detail: 'writing config' };
+      deps.persist();
+
+      return {
+        slug: entry.slug,
+        uuid: entry.config.uuid,
+        path: entry.config.path,
+        fileCount: stats.added,
+      };
+    },
+  });

--- a/src/daemon/actions/vault-list.ts
+++ b/src/daemon/actions/vault-list.ts
@@ -1,0 +1,32 @@
+import { action, type ActionDefinition } from '@agentage/core';
+import type { VaultRegistry } from '../../vaults/registry.js';
+import type { VaultMetadata } from '../../vaults/types.js';
+import type { ActionProgress } from './types.js';
+
+export type VaultListInput = Record<string, never>;
+
+export interface VaultListOutput {
+  vaults: VaultMetadata[];
+}
+
+const validate = (_raw: unknown): VaultListInput => ({});
+
+export const createVaultListAction = (deps: {
+  vaults: VaultRegistry;
+}): ActionDefinition<VaultListInput, VaultListOutput, ActionProgress> =>
+  action({
+    manifest: {
+      name: 'vault:list',
+      version: '1.0',
+      title: 'List vaults',
+      description: 'Return metadata for every registered vault',
+      scope: 'machine',
+      capability: 'vault.read',
+      idempotent: true,
+    },
+    validateInput: validate,
+    async *execute(): AsyncGenerator<ActionProgress, VaultListOutput, void> {
+      const vaults = await deps.vaults.metadata();
+      return { vaults };
+    },
+  });

--- a/src/daemon/actions/vault-reindex.ts
+++ b/src/daemon/actions/vault-reindex.ts
@@ -1,0 +1,47 @@
+import { action, ActionError, type ActionDefinition } from '@agentage/core';
+import type { VaultRegistry } from '../../vaults/registry.js';
+import type { ActionProgress } from './types.js';
+
+export interface VaultReindexInput {
+  slug: string;
+}
+
+export interface VaultReindexOutput {
+  slug: string;
+  added: number;
+  modified: number;
+  removed: number;
+  unchanged: number;
+}
+
+const validate = (raw: unknown): VaultReindexInput => {
+  if (!raw || typeof raw !== 'object') throw new Error('input must be an object');
+  const r = raw as Record<string, unknown>;
+  if (typeof r['slug'] !== 'string' || r['slug'].length === 0)
+    throw new Error('slug must be a non-empty string');
+  return { slug: r['slug'] };
+};
+
+export const createVaultReindexAction = (deps: {
+  vaults: VaultRegistry;
+}): ActionDefinition<VaultReindexInput, VaultReindexOutput, ActionProgress> =>
+  action({
+    manifest: {
+      name: 'vault:reindex',
+      version: '1.0',
+      title: 'Reindex vault',
+      description: 'Force a full filesystem rescan of the vault',
+      scope: 'machine',
+      capability: 'vault.admin',
+      idempotent: true,
+    },
+    validateInput: validate,
+    async *execute(_ctx, input): AsyncGenerator<ActionProgress, VaultReindexOutput, void> {
+      if (!deps.vaults.has(input.slug)) {
+        throw new ActionError('INVALID_INPUT', `vault "${input.slug}" does not exist`, false);
+      }
+      yield { step: 'scan', detail: `slug=${input.slug}` };
+      const stats = await deps.vaults.reindex(input.slug);
+      return { slug: input.slug, ...stats };
+    },
+  });

--- a/src/daemon/actions/vault-remove.ts
+++ b/src/daemon/actions/vault-remove.ts
@@ -1,0 +1,46 @@
+import { action, ActionError, type ActionDefinition } from '@agentage/core';
+import type { VaultRegistry } from '../../vaults/registry.js';
+import type { ActionProgress } from './types.js';
+
+export interface VaultRemoveInput {
+  slug: string;
+}
+
+export interface VaultRemoveOutput {
+  slug: string;
+  removed: true;
+}
+
+const validate = (raw: unknown): VaultRemoveInput => {
+  if (!raw || typeof raw !== 'object') throw new Error('input must be an object');
+  const r = raw as Record<string, unknown>;
+  if (typeof r['slug'] !== 'string' || r['slug'].length === 0)
+    throw new Error('slug must be a non-empty string');
+  return { slug: r['slug'] };
+};
+
+export const createVaultRemoveAction = (deps: {
+  vaults: VaultRegistry;
+  persist: () => void;
+}): ActionDefinition<VaultRemoveInput, VaultRemoveOutput, ActionProgress> =>
+  action({
+    manifest: {
+      name: 'vault:remove',
+      version: '1.0',
+      title: 'Remove vault',
+      description: 'Unregister a vault and delete its index (does not touch user files)',
+      scope: 'machine',
+      capability: 'vault.admin',
+      idempotent: true,
+    },
+    validateInput: validate,
+    async *execute(_ctx, input): AsyncGenerator<ActionProgress, VaultRemoveOutput, void> {
+      if (!deps.vaults.has(input.slug)) {
+        throw new ActionError('INVALID_INPUT', `vault "${input.slug}" does not exist`, false);
+      }
+      yield { step: 'remove', detail: `slug=${input.slug}` };
+      await deps.vaults.remove(input.slug);
+      deps.persist();
+      return { slug: input.slug, removed: true };
+    },
+  });

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir, hostname } from 'node:os';
 import { join } from 'node:path';
+import type { VaultConfig } from '../vaults/types.js';
 
 export interface SyncEvents {
   state: boolean;
@@ -34,10 +35,13 @@ export interface DaemonConfig {
   };
   agents: DirConfig;
   projects: DirConfig;
+  vaults?: Record<string, VaultConfig>;
   sync: {
     events: SyncEvents;
   };
 }
+
+export const getVaultStorageDir = (): string => join(getConfigDir(), 'vaults');
 
 export const getConfigDir = (): string => {
   const dir = process.env['AGENTAGE_CONFIG_DIR'] || join(process.env['HOME'] || '~', '.agentage');
@@ -112,6 +116,7 @@ const createDefaultConfig = (machine: MachineIdentity): DaemonConfig => ({
     default: getDefaultProjectsDir(),
     additional: [],
   },
+  vaults: {},
   sync: {
     events: {
       state: true,

--- a/src/daemon/routes.test.ts
+++ b/src/daemon/routes.test.ts
@@ -4,6 +4,8 @@ import { type Server } from 'node:http';
 
 vi.mock('./config.js', () => ({
   loadConfig: vi.fn(),
+  saveConfig: vi.fn(),
+  getVaultStorageDir: vi.fn(() => '/tmp/agentage-routes-test-vaults'),
 }));
 
 vi.mock('./metrics.js', () => ({

--- a/src/utils/action-client.ts
+++ b/src/utils/action-client.ts
@@ -1,0 +1,38 @@
+import { type InvokeEvent } from '@agentage/core';
+import { loadConfig } from '../daemon/config.js';
+
+const baseUrl = (): string => `http://localhost:${loadConfig().daemon.port}`;
+
+const parseSse = (text: string): InvokeEvent[] =>
+  text
+    .split('\n\n')
+    .filter((chunk) => chunk.startsWith('data: '))
+    .map((chunk) => JSON.parse(chunk.slice(6)) as InvokeEvent);
+
+export const invokeAction = async <O>(
+  name: string,
+  input: unknown,
+  capabilities: string[]
+): Promise<O> => {
+  const res = await fetch(`${baseUrl()}/api/actions/${name}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-capabilities': capabilities.join(','),
+    },
+    body: JSON.stringify({ input }),
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}: ${await res.text().catch(() => '')}`);
+  }
+  const events = parseSse(await res.text());
+  const last = events.at(-1);
+  if (!last) throw new Error('action returned no events');
+  if (last.type === 'error') {
+    throw new Error(`${last.code}: ${last.message}`);
+  }
+  if (last.type !== 'result') {
+    throw new Error(`unexpected last event: ${last.type}`);
+  }
+  return last.data as O;
+};

--- a/src/vaults/instance.ts
+++ b/src/vaults/instance.ts
@@ -1,0 +1,22 @@
+import { getVaultStorageDir, loadConfig, saveConfig } from '../daemon/config.js';
+import { VaultRegistry } from './registry.js';
+
+let registrySingleton: VaultRegistry | null = null;
+
+export const getVaultRegistry = (): VaultRegistry => {
+  if (registrySingleton) return registrySingleton;
+  const config = loadConfig();
+  registrySingleton = new VaultRegistry({ storageDir: getVaultStorageDir() });
+  registrySingleton.hydrate(config.vaults ?? {});
+  return registrySingleton;
+};
+
+export const resetVaultRegistry = (): void => {
+  registrySingleton = null;
+};
+
+export const persistVaults = (registry: VaultRegistry): void => {
+  const config = loadConfig();
+  config.vaults = registry.toConfigShape();
+  saveConfig(config);
+};

--- a/src/vaults/reconciler.test.ts
+++ b/src/vaults/reconciler.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile, unlink, utimes } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SqliteFts5Index } from './sqlite-fts5-index.js';
+import { reconcileVault } from './reconciler.js';
+
+describe('reconcileVault', () => {
+  let vault: string;
+  let idx: SqliteFts5Index;
+
+  beforeEach(async () => {
+    vault = await mkdtemp(join(tmpdir(), 'agentage-vault-'));
+    idx = new SqliteFts5Index(':memory:');
+  });
+
+  afterEach(async () => {
+    await idx.close();
+    await rm(vault, { recursive: true, force: true });
+  });
+
+  it('first scan adds every markdown file and ignores non-md', async () => {
+    await writeFile(join(vault, 'a.md'), 'alpha');
+    await writeFile(join(vault, 'b.md'), 'beta');
+    await writeFile(join(vault, 'ignore.txt'), 'plain text');
+    await mkdir(join(vault, 'sub'), { recursive: true });
+    await writeFile(join(vault, 'sub', 'c.md'), 'gamma');
+
+    const stats = await reconcileVault(vault, idx);
+    expect(stats).toEqual({ added: 3, modified: 0, removed: 0, unchanged: 0 });
+    expect(await idx.fileCount()).toBe(3);
+    expect((await idx.search('alpha'))[0]?.path).toBe('a.md');
+    expect((await idx.search('gamma'))[0]?.path).toBe('sub/c.md');
+  });
+
+  it('skips dotfiles and node_modules', async () => {
+    await mkdir(join(vault, '.obsidian'), { recursive: true });
+    await writeFile(join(vault, '.obsidian', 'workspace.md'), 'should be ignored');
+    await mkdir(join(vault, 'node_modules', 'pkg'), { recursive: true });
+    await writeFile(join(vault, 'node_modules', 'pkg', 'README.md'), 'should be ignored');
+    await writeFile(join(vault, 'real.md'), 'visible');
+
+    const stats = await reconcileVault(vault, idx);
+    expect(stats.added).toBe(1);
+    expect(await idx.fileCount()).toBe(1);
+  });
+
+  it('re-run with no changes returns all unchanged (no rehash)', async () => {
+    await writeFile(join(vault, 'a.md'), 'one');
+    await writeFile(join(vault, 'b.md'), 'two');
+    await reconcileVault(vault, idx);
+
+    const second = await reconcileVault(vault, idx);
+    expect(second).toEqual({ added: 0, modified: 0, removed: 0, unchanged: 2 });
+  });
+
+  it('detects modified file when content changes', async () => {
+    const file = join(vault, 'a.md');
+    await writeFile(file, 'original');
+    await reconcileVault(vault, idx);
+
+    await writeFile(file, 'edited');
+    await utimes(file, new Date(), new Date(Date.now() + 1000));
+    const stats = await reconcileVault(vault, idx);
+    expect(stats.modified).toBe(1);
+    expect(stats.added).toBe(0);
+    expect((await idx.search('edited'))[0]?.path).toBe('a.md');
+    expect(await idx.search('original')).toEqual([]);
+  });
+
+  it('detects deleted file', async () => {
+    await writeFile(join(vault, 'a.md'), 'temp');
+    await writeFile(join(vault, 'b.md'), 'persist');
+    await reconcileVault(vault, idx);
+
+    await unlink(join(vault, 'a.md'));
+    const stats = await reconcileVault(vault, idx);
+    expect(stats).toEqual({ added: 0, modified: 0, removed: 1, unchanged: 1 });
+    expect(await idx.fileCount()).toBe(1);
+  });
+
+  it('detects added file on subsequent scan', async () => {
+    await writeFile(join(vault, 'old.md'), 'existing');
+    await reconcileVault(vault, idx);
+
+    await writeFile(join(vault, 'new.md'), 'added later');
+    const stats = await reconcileVault(vault, idx);
+    expect(stats.added).toBe(1);
+    expect(stats.unchanged).toBe(1);
+  });
+
+  it('mixed changes: add + modify + remove in one scan', async () => {
+    await writeFile(join(vault, 'keep.md'), 'unchanged');
+    await writeFile(join(vault, 'edit.md'), 'before');
+    await writeFile(join(vault, 'delete.md'), 'doomed');
+    await reconcileVault(vault, idx);
+
+    await unlink(join(vault, 'delete.md'));
+    await writeFile(join(vault, 'edit.md'), 'after');
+    await utimes(join(vault, 'edit.md'), new Date(), new Date(Date.now() + 1000));
+    await writeFile(join(vault, 'fresh.md'), 'brand new');
+
+    const stats = await reconcileVault(vault, idx);
+    expect(stats).toEqual({ added: 1, modified: 1, removed: 1, unchanged: 1 });
+  });
+
+  it('handles missing vault dir gracefully (returns zero stats)', async () => {
+    const stats = await reconcileVault('/nonexistent/path/that/never/exists', idx);
+    expect(stats).toEqual({ added: 0, modified: 0, removed: 0, unchanged: 0 });
+  });
+});

--- a/src/vaults/reconciler.ts
+++ b/src/vaults/reconciler.ts
@@ -1,0 +1,106 @@
+import { createHash } from 'node:crypto';
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import type { FileChange, FileEntry, VaultIndex } from './types.js';
+
+export interface ReconcileStats {
+  added: number;
+  modified: number;
+  removed: number;
+  unchanged: number;
+}
+
+const isMarkdown = (filename: string): boolean => /\.md$/i.test(filename);
+
+const sha256OfBuffer = (buf: Buffer): string => createHash('sha256').update(buf).digest('hex');
+
+interface WalkResult {
+  unchanged: number;
+  added: FileChange[];
+  modified: FileChange[];
+  seen: Set<string>;
+}
+
+const walkMarkdownFiles = async (
+  root: string,
+  inIndexByPath: Map<string, FileEntry>
+): Promise<WalkResult> => {
+  const added: FileChange[] = [];
+  const modified: FileChange[] = [];
+  const seen = new Set<string>();
+  let unchanged = 0;
+
+  const queue: string[] = [root];
+  while (queue.length > 0) {
+    const dir = queue.shift() as string;
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) continue;
+      if (entry.name === 'node_modules') continue;
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        queue.push(full);
+        continue;
+      }
+      if (!entry.isFile() || !isMarkdown(entry.name)) continue;
+
+      const relPath = relative(root, full);
+      seen.add(relPath);
+      const st = await stat(full);
+      const existing = inIndexByPath.get(relPath);
+
+      if (existing && existing.mtime === st.mtimeMs && existing.size === st.size) {
+        unchanged++;
+        continue;
+      }
+
+      const buf = await readFile(full);
+      const sha256 = sha256OfBuffer(buf);
+      const change: FileChange = {
+        path: relPath,
+        content: buf.toString('utf-8'),
+        sha256,
+        size: st.size,
+        mtime: st.mtimeMs,
+      };
+
+      if (!existing) {
+        added.push(change);
+      } else if (existing.sha256 !== sha256) {
+        modified.push(change);
+      } else {
+        unchanged++;
+      }
+    }
+  }
+  return { unchanged, added, modified, seen };
+};
+
+export const reconcileVault = async (
+  vaultPath: string,
+  index: VaultIndex
+): Promise<ReconcileStats> => {
+  const inIndex = await index.list();
+  const inIndexByPath = new Map(inIndex.map((e) => [e.path, e]));
+
+  const { unchanged, added, modified, seen } = await walkMarkdownFiles(vaultPath, inIndexByPath);
+
+  const removed: string[] = [];
+  for (const path of inIndexByPath.keys()) {
+    if (!seen.has(path)) removed.push(path);
+  }
+
+  await index.reconcile({ added, modified, removed });
+
+  return {
+    added: added.length,
+    modified: modified.length,
+    removed: removed.length,
+    unchanged,
+  };
+};

--- a/src/vaults/registry.test.ts
+++ b/src/vaults/registry.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { VaultRegistry } from './registry.js';
+
+describe('VaultRegistry', () => {
+  let storage: string;
+  let vaultPath: string;
+  let registry: VaultRegistry;
+
+  beforeEach(async () => {
+    storage = await mkdtemp(join(tmpdir(), 'agentage-vaultreg-'));
+    vaultPath = await mkdtemp(join(tmpdir(), 'agentage-vaultcontent-'));
+    registry = new VaultRegistry({ storageDir: storage });
+  });
+
+  afterEach(async () => {
+    await registry.closeAll();
+    await rm(storage, { recursive: true, force: true });
+    await rm(vaultPath, { recursive: true, force: true });
+  });
+
+  it('starts empty', () => {
+    expect(registry.list()).toEqual([]);
+    expect(registry.has('anything')).toBe(false);
+  });
+
+  it('add creates index, scans files, registers slug', async () => {
+    await writeFile(join(vaultPath, 'one.md'), 'first note');
+    await writeFile(join(vaultPath, 'two.md'), 'second note');
+    const { entry, stats } = await registry.add({ slug: 'notes', path: vaultPath });
+    expect(stats).toEqual({ added: 2, modified: 0, removed: 0, unchanged: 0 });
+    expect(entry.slug).toBe('notes');
+    expect(entry.config.uuid).toMatch(/^[0-9a-f-]{36}$/);
+    expect(entry.config.scope).toBe('local');
+    expect(entry.config.writeMode).toBe('inbox-dated');
+    expect(registry.has('notes')).toBe(true);
+    expect(await entry.index.fileCount()).toBe(2);
+  });
+
+  it('add rejects duplicate slug', async () => {
+    await registry.add({ slug: 'notes', path: vaultPath });
+    await expect(registry.add({ slug: 'notes', path: vaultPath })).rejects.toThrow(
+      /already exists/
+    );
+  });
+
+  it('metadata returns slug/uuid/path/fileCount/indexedAt for each vault', async () => {
+    await writeFile(join(vaultPath, 'a.md'), 'one');
+    await registry.add({ slug: 'notes', path: vaultPath });
+    const meta = await registry.metadata();
+    expect(meta).toHaveLength(1);
+    expect(meta[0]?.slug).toBe('notes');
+    expect(meta[0]?.fileCount).toBe(1);
+    expect(meta[0]?.indexedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('remove drops vault from registry and deletes index file', async () => {
+    await writeFile(join(vaultPath, 'a.md'), 'x');
+    const { entry } = await registry.add({ slug: 'notes', path: vaultPath });
+    const indexFile = join(storage, `${entry.config.uuid}.db`);
+    await registry.remove('notes');
+    expect(registry.has('notes')).toBe(false);
+    const { existsSync } = await import('node:fs');
+    expect(existsSync(indexFile)).toBe(false);
+  });
+
+  it('remove rejects unknown slug', async () => {
+    await expect(registry.remove('ghost')).rejects.toThrow(/does not exist/);
+  });
+
+  it('reindex picks up filesystem changes', async () => {
+    await writeFile(join(vaultPath, 'a.md'), 'first');
+    await registry.add({ slug: 'notes', path: vaultPath });
+    await writeFile(join(vaultPath, 'b.md'), 'second');
+    const stats = await registry.reindex('notes');
+    expect(stats.added).toBe(1);
+    const v = registry.get('notes');
+    expect(await v?.index.fileCount()).toBe(2);
+  });
+
+  it('hydrate restores existing vaults from config shape', async () => {
+    await writeFile(join(vaultPath, 'a.md'), 'persisted');
+    const { entry } = await registry.add({ slug: 'notes', path: vaultPath });
+    const shape = registry.toConfigShape();
+    await registry.closeAll();
+
+    const fresh = new VaultRegistry({ storageDir: storage });
+    fresh.hydrate(shape);
+    expect(fresh.has('notes')).toBe(true);
+    const v = fresh.get('notes');
+    expect(v?.config.uuid).toBe(entry.config.uuid);
+    expect(await v?.index.fileCount()).toBe(1);
+    await fresh.closeAll();
+  });
+
+  it('toConfigShape reflects current registered vaults', async () => {
+    await registry.add({ slug: 'a', path: vaultPath });
+    const second = await mkdtemp(join(tmpdir(), 'agentage-vaultcontent-b-'));
+    try {
+      await registry.add({ slug: 'b', path: second });
+      const shape = registry.toConfigShape();
+      expect(Object.keys(shape).sort()).toEqual(['a', 'b']);
+      expect(shape['a']?.path).toBe(vaultPath);
+      expect(shape['b']?.path).toBe(second);
+    } finally {
+      await rm(second, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/vaults/registry.ts
+++ b/src/vaults/registry.ts
@@ -1,0 +1,128 @@
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { reconcileVault, type ReconcileStats } from './reconciler.js';
+import { SqliteFts5Index } from './sqlite-fts5-index.js';
+import type {
+  VaultConfig,
+  VaultIndex,
+  VaultMetadata,
+  VaultScope,
+  VaultWriteMode,
+} from './types.js';
+
+export interface VaultRegistryOptions {
+  storageDir: string;
+  indexFactory?: (path: string) => VaultIndex;
+}
+
+export interface VaultEntry {
+  slug: string;
+  config: VaultConfig;
+  index: VaultIndex;
+}
+
+export class VaultRegistry {
+  private vaults = new Map<string, VaultEntry>();
+  private storageDir: string;
+  private indexFactory: (path: string) => VaultIndex;
+
+  constructor(opts: VaultRegistryOptions) {
+    this.storageDir = opts.storageDir;
+    this.indexFactory = opts.indexFactory ?? ((path) => new SqliteFts5Index(path));
+    if (!existsSync(this.storageDir)) {
+      mkdirSync(this.storageDir, { recursive: true });
+    }
+  }
+
+  hydrate(vaults: Record<string, VaultConfig>): void {
+    for (const [slug, config] of Object.entries(vaults)) {
+      if (this.vaults.has(slug)) continue;
+      const index = this.indexFactory(this.indexPath(config.uuid));
+      this.vaults.set(slug, { slug, config, index });
+    }
+  }
+
+  has(slug: string): boolean {
+    return this.vaults.has(slug);
+  }
+
+  get(slug: string): VaultEntry | undefined {
+    return this.vaults.get(slug);
+  }
+
+  list(): VaultEntry[] {
+    return Array.from(this.vaults.values());
+  }
+
+  async metadata(): Promise<VaultMetadata[]> {
+    return Promise.all(
+      this.list().map(async (v) => ({
+        slug: v.slug,
+        uuid: v.config.uuid,
+        path: v.config.path,
+        fileCount: await v.index.fileCount(),
+        indexedAt: await v.index.indexedAt(),
+      }))
+    );
+  }
+
+  async add(input: {
+    slug: string;
+    path: string;
+    scope?: VaultScope;
+    writeMode?: VaultWriteMode;
+  }): Promise<{ entry: VaultEntry; stats: ReconcileStats }> {
+    if (this.vaults.has(input.slug)) {
+      throw new Error(`vault "${input.slug}" already exists`);
+    }
+    const config: VaultConfig = {
+      uuid: randomUUID(),
+      path: input.path,
+      scope: input.scope ?? 'local',
+      writeMode: input.writeMode ?? 'inbox-dated',
+    };
+    const index = this.indexFactory(this.indexPath(config.uuid));
+    const entry: VaultEntry = { slug: input.slug, config, index };
+    this.vaults.set(input.slug, entry);
+    const stats = await reconcileVault(config.path, index);
+    return { entry, stats };
+  }
+
+  async remove(slug: string): Promise<void> {
+    const v = this.vaults.get(slug);
+    if (!v) throw new Error(`vault "${slug}" does not exist`);
+    await v.index.close();
+    this.vaults.delete(slug);
+    const path = this.indexPath(v.config.uuid);
+    await rm(path, { force: true });
+    await rm(`${path}-shm`, { force: true });
+    await rm(`${path}-wal`, { force: true });
+  }
+
+  async reindex(slug: string): Promise<ReconcileStats> {
+    const v = this.vaults.get(slug);
+    if (!v) throw new Error(`vault "${slug}" does not exist`);
+    return reconcileVault(v.config.path, v.index);
+  }
+
+  toConfigShape(): Record<string, VaultConfig> {
+    const out: Record<string, VaultConfig> = {};
+    for (const v of this.vaults.values()) {
+      out[v.slug] = v.config;
+    }
+    return out;
+  }
+
+  async closeAll(): Promise<void> {
+    for (const v of this.vaults.values()) {
+      await v.index.close();
+    }
+    this.vaults.clear();
+  }
+
+  private indexPath(uuid: string): string {
+    return join(this.storageDir, `${uuid}.db`);
+  }
+}

--- a/src/vaults/sqlite-fts5-index.test.ts
+++ b/src/vaults/sqlite-fts5-index.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SqliteFts5Index } from './sqlite-fts5-index.js';
+import type { DiskDiff } from './types.js';
+
+describe('SqliteFts5Index', () => {
+  let idx: SqliteFts5Index;
+
+  beforeEach(() => {
+    idx = new SqliteFts5Index(':memory:');
+  });
+
+  afterEach(async () => {
+    await idx.close();
+  });
+
+  it('starts empty', async () => {
+    expect(await idx.fileCount()).toBe(0);
+    expect(await idx.indexedAt()).toBeNull();
+    expect(await idx.list()).toEqual([]);
+    expect(await idx.search('anything')).toEqual([]);
+  });
+
+  it('reconcile inserts files and indexes content', async () => {
+    const diff: DiskDiff = {
+      added: [
+        {
+          path: 'notes/alpha.md',
+          content: 'the quick brown fox jumps over the lazy dog',
+          sha256: 'a1',
+          size: 43,
+          mtime: 1000,
+        },
+        {
+          path: 'notes/beta.md',
+          content: 'a second file mentions tortoise and hare',
+          sha256: 'b2',
+          size: 40,
+          mtime: 1001,
+        },
+      ],
+      modified: [],
+      removed: [],
+    };
+    await idx.reconcile(diff);
+    expect(await idx.fileCount()).toBe(2);
+    expect(await idx.indexedAt()).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    const hits = await idx.search('fox');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.path).toBe('notes/alpha.md');
+    expect(hits[0]?.snippet).toContain('<<fox>>');
+  });
+
+  it('modify replaces fts content', async () => {
+    await idx.reconcile({
+      added: [{ path: 'a.md', content: 'apples', sha256: 's1', size: 6, mtime: 1 }],
+      modified: [],
+      removed: [],
+    });
+    expect((await idx.search('apples')).length).toBe(1);
+    expect((await idx.search('oranges')).length).toBe(0);
+
+    await idx.reconcile({
+      added: [],
+      modified: [{ path: 'a.md', content: 'oranges', sha256: 's2', size: 7, mtime: 2 }],
+      removed: [],
+    });
+    expect((await idx.search('apples')).length).toBe(0);
+    expect((await idx.search('oranges')).length).toBe(1);
+  });
+
+  it('remove drops files from list and search', async () => {
+    await idx.reconcile({
+      added: [{ path: 'x.md', content: 'something', sha256: 's', size: 9, mtime: 1 }],
+      modified: [],
+      removed: [],
+    });
+    expect(await idx.fileCount()).toBe(1);
+    await idx.reconcile({ added: [], modified: [], removed: ['x.md'] });
+    expect(await idx.fileCount()).toBe(0);
+    expect(await idx.list()).toEqual([]);
+    expect(await idx.search('something')).toEqual([]);
+  });
+
+  it('stat returns metadata or absence', async () => {
+    await idx.reconcile({
+      added: [{ path: 'p.md', content: 'c', sha256: 'h', size: 1, mtime: 100 }],
+      modified: [],
+      removed: [],
+    });
+    expect(await idx.stat('p.md')).toEqual({
+      exists: true,
+      size: 1,
+      mtime: 100,
+      sha256: 'h',
+    });
+    expect(await idx.stat('missing.md')).toEqual({ exists: false });
+  });
+
+  it('list with prefix filters by path', async () => {
+    await idx.reconcile({
+      added: [
+        { path: 'inbox/2026-04-25.md', content: 'a', sha256: '1', size: 1, mtime: 1 },
+        { path: 'daily/2026-04-25.md', content: 'b', sha256: '2', size: 1, mtime: 1 },
+        { path: 'inbox/2026-04-24.md', content: 'c', sha256: '3', size: 1, mtime: 1 },
+      ],
+      modified: [],
+      removed: [],
+    });
+    const inbox = await idx.list({ prefix: 'inbox/' });
+    expect(inbox.map((f) => f.path).sort()).toEqual(['inbox/2026-04-24.md', 'inbox/2026-04-25.md']);
+  });
+
+  it('search ranks repeated terms higher', async () => {
+    await idx.reconcile({
+      added: [
+        { path: 'a.md', content: 'cat dog', sha256: '1', size: 7, mtime: 1 },
+        { path: 'b.md', content: 'cat cat cat', sha256: '2', size: 11, mtime: 1 },
+      ],
+      modified: [],
+      removed: [],
+    });
+    const hits = await idx.search('cat');
+    expect(hits[0]?.path).toBe('b.md');
+  });
+
+  it('search with empty/whitespace query returns no hits', async () => {
+    await idx.reconcile({
+      added: [{ path: 'a.md', content: 'anything', sha256: '1', size: 8, mtime: 1 }],
+      modified: [],
+      removed: [],
+    });
+    expect(await idx.search('')).toEqual([]);
+    expect(await idx.search('   ')).toEqual([]);
+  });
+
+  it('search escapes embedded quotes safely', async () => {
+    await idx.reconcile({
+      added: [{ path: 'a.md', content: 'she said "hello world"', sha256: '1', size: 22, mtime: 1 }],
+      modified: [],
+      removed: [],
+    });
+    expect(await idx.search('hello')).toHaveLength(1);
+    expect(await idx.search('"hello"')).toHaveLength(1);
+  });
+
+  it('reconcile updates indexedAt timestamp on every call', async () => {
+    expect(await idx.indexedAt()).toBeNull();
+    await idx.reconcile({ added: [], modified: [], removed: [] });
+    const first = await idx.indexedAt();
+    expect(first).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    await new Promise((r) => setTimeout(r, 5));
+    await idx.reconcile({ added: [], modified: [], removed: [] });
+    const second = await idx.indexedAt();
+    expect(second).not.toBe(first);
+  });
+
+  it('persists to disk and re-opens with the same data', async () => {
+    const path = `/tmp/agentage-vault-test-${Date.now()}.db`;
+    const writer = new SqliteFts5Index(path);
+    await writer.reconcile({
+      added: [{ path: 'a.md', content: 'persisted content', sha256: 'h', size: 17, mtime: 1 }],
+      modified: [],
+      removed: [],
+    });
+    await writer.close();
+
+    const reader = new SqliteFts5Index(path);
+    expect(await reader.fileCount()).toBe(1);
+    expect((await reader.search('persisted')).length).toBe(1);
+    await reader.close();
+  });
+});

--- a/src/vaults/sqlite-fts5-index.ts
+++ b/src/vaults/sqlite-fts5-index.ts
@@ -1,0 +1,159 @@
+import Database from 'better-sqlite3';
+import type { Database as DB } from 'better-sqlite3';
+import type {
+  VaultIndex,
+  Hit,
+  FileStat,
+  FileEntry,
+  SearchOptions,
+  ListOptions,
+  DiskDiff,
+} from './types.js';
+
+const SCHEMA_VERSION = 1;
+
+const SCHEMA = `
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS files (
+  path TEXT PRIMARY KEY,
+  size INTEGER NOT NULL,
+  mtime INTEGER NOT NULL,
+  sha256 TEXT NOT NULL
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS files_fts USING fts5(
+  path UNINDEXED,
+  content,
+  tokenize='porter unicode61'
+);
+
+CREATE TABLE IF NOT EXISTS meta (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+`;
+
+export class SqliteFts5Index implements VaultIndex {
+  private db: DB;
+
+  constructor(path: string) {
+    this.db = new Database(path);
+    this.db.exec(SCHEMA);
+    this.initMeta();
+  }
+
+  private initMeta(): void {
+    const existing = this.db
+      .prepare('SELECT value FROM meta WHERE key = ?')
+      .get('schema_version') as { value: string } | undefined;
+    if (!existing) {
+      this.db
+        .prepare('INSERT INTO meta (key, value) VALUES (?, ?)')
+        .run('schema_version', String(SCHEMA_VERSION));
+    }
+  }
+
+  async search(query: string, opts: SearchOptions = {}): Promise<Hit[]> {
+    const limit = opts.limit ?? 20;
+    const offset = opts.offset ?? 0;
+    const sanitized = sanitizeFtsQuery(query);
+    if (sanitized === null) return [];
+    const rows = this.db
+      .prepare(
+        `SELECT path,
+                snippet(files_fts, 1, '<<', '>>', '...', 32) AS snippet,
+                bm25(files_fts) AS score
+         FROM files_fts
+         WHERE files_fts MATCH ?
+         ORDER BY score
+         LIMIT ? OFFSET ?`
+      )
+      .all(sanitized, limit, offset) as Array<{ path: string; snippet: string; score: number }>;
+    return rows.map((r) => ({ path: r.path, score: r.score, snippet: r.snippet }));
+  }
+
+  async stat(path: string): Promise<FileStat> {
+    const row = this.db
+      .prepare('SELECT size, mtime, sha256 FROM files WHERE path = ?')
+      .get(path) as { size: number; mtime: number; sha256: string } | undefined;
+    if (!row) return { exists: false };
+    return { exists: true, size: row.size, mtime: row.mtime, sha256: row.sha256 };
+  }
+
+  async list(opts: ListOptions = {}): Promise<FileEntry[]> {
+    const limit = opts.limit ?? -1;
+    const offset = opts.offset ?? 0;
+    if (opts.prefix !== undefined) {
+      return this.db
+        .prepare(
+          `SELECT path, size, mtime, sha256 FROM files
+           WHERE path LIKE ? ORDER BY path LIMIT ? OFFSET ?`
+        )
+        .all(`${opts.prefix}%`, limit, offset) as FileEntry[];
+    }
+    return this.db
+      .prepare(
+        `SELECT path, size, mtime, sha256 FROM files
+         ORDER BY path LIMIT ? OFFSET ?`
+      )
+      .all(limit, offset) as FileEntry[];
+  }
+
+  async reconcile(diff: DiskDiff): Promise<void> {
+    const upsertFile = this.db.prepare(
+      'INSERT OR REPLACE INTO files (path, size, mtime, sha256) VALUES (?, ?, ?, ?)'
+    );
+    const deleteFts = this.db.prepare('DELETE FROM files_fts WHERE path = ?');
+    const insertFts = this.db.prepare('INSERT INTO files_fts (path, content) VALUES (?, ?)');
+    const deleteFile = this.db.prepare('DELETE FROM files WHERE path = ?');
+    const upsertMeta = this.db.prepare('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)');
+
+    const apply = this.db.transaction(() => {
+      for (const f of diff.added) {
+        upsertFile.run(f.path, f.size, f.mtime, f.sha256);
+        deleteFts.run(f.path);
+        insertFts.run(f.path, f.content);
+      }
+      for (const f of diff.modified) {
+        upsertFile.run(f.path, f.size, f.mtime, f.sha256);
+        deleteFts.run(f.path);
+        insertFts.run(f.path, f.content);
+      }
+      for (const path of diff.removed) {
+        deleteFile.run(path);
+        deleteFts.run(path);
+      }
+      upsertMeta.run('indexed_at', new Date().toISOString());
+    });
+
+    apply();
+  }
+
+  async fileCount(): Promise<number> {
+    const row = this.db.prepare('SELECT COUNT(*) AS n FROM files').get() as { n: number };
+    return row.n;
+  }
+
+  async indexedAt(): Promise<string | null> {
+    const row = this.db.prepare('SELECT value FROM meta WHERE key = ?').get('indexed_at') as
+      | { value: string }
+      | undefined;
+    return row?.value ?? null;
+  }
+
+  async close(): Promise<void> {
+    this.db.close();
+  }
+}
+
+const sanitizeFtsQuery = (query: string): string | null => {
+  const tokens = query
+    .trim()
+    .split(/\s+/)
+    .filter((t) => t.length > 0)
+    .map((t) => `"${t.replace(/"/g, '""')}"`);
+  if (tokens.length === 0) return null;
+  return tokens.join(' ');
+};

--- a/src/vaults/types.ts
+++ b/src/vaults/types.ts
@@ -1,0 +1,72 @@
+export type VaultScope = 'local' | 'shared';
+export type VaultWriteMode = 'inbox-dated' | 'append-daily';
+
+export interface VaultConfig {
+  uuid: string;
+  path: string;
+  scope: VaultScope;
+  writeMode: VaultWriteMode;
+}
+
+export interface VaultMetadata {
+  slug: string;
+  uuid: string;
+  path: string;
+  fileCount: number;
+  indexedAt: string | null;
+}
+
+export interface FileEntry {
+  path: string;
+  size: number;
+  mtime: number;
+  sha256: string;
+}
+
+export interface FileStat {
+  exists: boolean;
+  size?: number;
+  mtime?: number;
+  sha256?: string;
+}
+
+export interface Hit {
+  path: string;
+  score: number;
+  snippet: string;
+}
+
+export interface SearchOptions {
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListOptions {
+  limit?: number;
+  offset?: number;
+  prefix?: string;
+}
+
+export interface FileChange {
+  path: string;
+  content: string;
+  sha256: string;
+  size: number;
+  mtime: number;
+}
+
+export interface DiskDiff {
+  added: FileChange[];
+  modified: FileChange[];
+  removed: string[];
+}
+
+export interface VaultIndex {
+  search(query: string, opts?: SearchOptions): Promise<Hit[]>;
+  stat(path: string): Promise<FileStat>;
+  list(opts?: ListOptions): Promise<FileEntry[]>;
+  reconcile(diff: DiskDiff): Promise<void>;
+  fileCount(): Promise<number>;
+  indexedAt(): Promise<string | null>;
+  close(): Promise<void>;
+}


### PR DESCRIPTION
## Summary

Phase 0 of the vault feature — register a markdown directory as a named, indexed surface that the daemon owns. PR 1 ships **foundations + admin actions + CLI**; subsequent PRs add content actions (PR 2), MCP shim integration (PR 3), and dashboard visibility (PR 4).

- 4 admin actions in the existing ActionRegistry: `vault:add`, `vault:remove`, `vault:reindex`, `vault:list`
- SQLite + FTS5 index per vault at `~/.agentage/vaults/{uuid}.db`, incremental reconciler (mtime+size fast-path, sha256 only on diff)
- CLI: `agentage vault add/list/remove/reindex`, HTTP-mediated through the daemon
- 45 new tests, all 594 existing daemon/cli tests still pass

## Design decisions worth confirming in review

1. **`VaultIndex` is an interface; `SqliteFts5Index` is the only impl today.** Swap-friendly for phase 1.5 (sqlite-vec embeddings) and phase 2 (hub-side index) without touching action handlers.
2. **Capability scheme is 3-tier.** `vault.read` (queries), `vault.write` (content edits — PR 2), `vault.admin` (registry mutations). MCP shim (PR 3) sends only `read`/`write`; admin is unreachable from LLMs by construction.
3. **CLI is HTTP-mediated, diverging from `projects.ts` (direct calls).** Daemon owns the in-memory index — direct config mutation would silently de-sync it. CLI auto-starts daemon via `ensureDaemon()`.
4. **Index storage carries sync hooks before sync uses them.** Every file row has `sha256`/`mtime`/`size`. Phase 1 reads them for delta sync; adding columns later means re-indexing every vault.
5. **Default write mode locked: `inbox-dated`.** New writes go to `inbox/YYYY-MM-DD-HHMMSS-{nanoid}.md`. Activates in PR 2; PR 1 just persists the config field.
6. **Lazy registry init.** `getVaultRegistry()` runs at first action invocation, not daemon startup. **Decision needed:** eager hydrate at boot, or keep lazy?

## What's NOT in this PR

- Sync (any kind) — phase 1
- Content actions — PR 2
- MCP shim entries — PR 3
- Dashboard visibility — PR 4
- Multi-host vaults — daemon refuses if same slug claimed elsewhere

## Notes for reviewer

- **Bootstrap test relaxed**: previously `actions.test.ts` asserted every action has a unique capability. That coincidence held for 3 actions, fails for 7 (4 vault actions share the `vault.admin` cap). Replaced with namespace.verb shape check.
- **Pre-existing flake**: `ensure-daemon.test.ts` worker-termination timeout exists on master too. Untouched here.
- **`routes.test.ts` mock extended** with `getVaultStorageDir` + `saveConfig` so action registry can hydrate during route construction.

## Test plan

- [ ] `npm run verify` passes
- [ ] Smoke test on real machine:
  - [ ] `agentage daemon start`
  - [ ] `agentage vault add ~/projects/projects --slug notes` → indexes vault, returns slug + uuid + fileCount
  - [ ] `agentage vault list` → shows registered vault with file count + indexed timestamp
  - [ ] `agentage vault reindex notes` → returns add/modified/removed/unchanged stats
  - [ ] `agentage vault remove notes` → drops vault, files on disk untouched
- [ ] Confirm `~/.agentage/config.json` round-trips `vaults` field
- [ ] Confirm `~/.agentage/vaults/{uuid}.db` is created and removed correctly

## Commits

- \`b4f349f\` feat(vaults): VaultIndex interface, SQLite FTS5 backend, fs reconciler
- \`415fd88\` feat(daemon): vault registry singleton + admin actions
- \`c300580\` feat(cli): agentage vault add/list/remove/reindex