### PR TITLE
feat: vault content actions + CLI (files/read/search/edit)

### DIFF
--- a/src/commands/vault.test.ts
+++ b/src/commands/vault.test.ts
@@ -151,4 +151,183 @@ describe('vault command', () => {
       expect(all).toContain('unchanged=5');
     });
   });
+
+  describe('vault files', () => {
+    it('lists files with size + mtime', async () => {
+      mockInvoke.mockResolvedValueOnce({
+        slug: 'notes',
+        files: [
+          { path: 'a.md', size: 10, mtime: 1700000000000, sha256: 'h1' },
+          { path: 'b.md', size: 20, mtime: 1700000001000, sha256: 'h2' },
+        ],
+      });
+      await program.parseAsync(['node', 'agentage', 'vault', 'files', 'notes']);
+      expect(mockInvoke).toHaveBeenCalledWith('vault:files', { slug: 'notes', limit: 100 }, [
+        'vault.read',
+      ]);
+      const all = logs.join('\n');
+      expect(all).toContain('a.md');
+      expect(all).toContain('b.md');
+      expect(all).toContain('2 file(s)');
+    });
+
+    it('passes prefix when given', async () => {
+      mockInvoke.mockResolvedValueOnce({ slug: 'notes', files: [] });
+      await program.parseAsync([
+        'node',
+        'agentage',
+        'vault',
+        'files',
+        'notes',
+        '--prefix',
+        'inbox/',
+      ]);
+      const call = mockInvoke.mock.calls[0];
+      expect(call?.[1]).toMatchObject({ slug: 'notes', prefix: 'inbox/' });
+    });
+
+    it('--json prints raw array', async () => {
+      mockInvoke.mockResolvedValueOnce({
+        slug: 'notes',
+        files: [{ path: 'a.md', size: 1, mtime: 1, sha256: 'h' }],
+      });
+      await program.parseAsync(['node', 'agentage', 'vault', 'files', 'notes', '--json']);
+      expect(logs[0]).toContain('"path": "a.md"');
+    });
+  });
+
+  describe('vault read', () => {
+    it('writes file content to stdout', async () => {
+      const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      mockInvoke.mockResolvedValueOnce({
+        slug: 'notes',
+        path: 'a.md',
+        content: 'hello world\n',
+        size: 12,
+        mtime: 1,
+      });
+      await program.parseAsync(['node', 'agentage', 'vault', 'read', 'notes', 'a.md']);
+      expect(mockInvoke).toHaveBeenCalledWith('vault:read', { slug: 'notes', path: 'a.md' }, [
+        'vault.read',
+      ]);
+      expect(stdoutSpy).toHaveBeenCalledWith('hello world\n');
+      stdoutSpy.mockRestore();
+    });
+
+    it('appends trailing newline if file lacks one', async () => {
+      const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      mockInvoke.mockResolvedValueOnce({
+        slug: 'notes',
+        path: 'a.md',
+        content: 'no newline',
+        size: 10,
+        mtime: 1,
+      });
+      await program.parseAsync(['node', 'agentage', 'vault', 'read', 'notes', 'a.md']);
+      expect(stdoutSpy).toHaveBeenCalledWith('no newline');
+      expect(stdoutSpy).toHaveBeenCalledWith('\n');
+      stdoutSpy.mockRestore();
+    });
+  });
+
+  describe('vault search', () => {
+    it('prints ranked hits', async () => {
+      mockInvoke.mockResolvedValueOnce({
+        slug: 'notes',
+        query: 'rust',
+        hits: [
+          { path: 'a.md', score: -1.5, snippet: 'about <<rust>> language' },
+          { path: 'b.md', score: -0.8, snippet: 'mention of <<rust>>' },
+        ],
+      });
+      await program.parseAsync(['node', 'agentage', 'vault', 'search', 'notes', 'rust']);
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'vault:search',
+        { slug: 'notes', query: 'rust', limit: 20 },
+        ['vault.read']
+      );
+      const all = logs.join('\n');
+      expect(all).toContain('a.md');
+      expect(all).toContain('rust');
+      expect(all).toContain('2 hit(s)');
+    });
+
+    it('joins multi-word query', async () => {
+      mockInvoke.mockResolvedValueOnce({ slug: 'notes', query: 'foo bar', hits: [] });
+      await program.parseAsync(['node', 'agentage', 'vault', 'search', 'notes', 'foo', 'bar']);
+      const call = mockInvoke.mock.calls[0];
+      expect(call?.[1]).toMatchObject({ query: 'foo bar' });
+    });
+
+    it('reports no matches gracefully', async () => {
+      mockInvoke.mockResolvedValueOnce({ slug: 'notes', query: 'x', hits: [] });
+      await program.parseAsync(['node', 'agentage', 'vault', 'search', 'notes', 'x']);
+      const all = logs.join('\n');
+      expect(all).toContain('No matches');
+    });
+  });
+
+  describe('vault edit', () => {
+    it('passes --content to vault:edit with vault.write', async () => {
+      mockInvoke.mockResolvedValueOnce({
+        slug: 'notes',
+        path: 'inbox/2026-04-25-120000-abcd.md',
+        mode: 'inbox-dated',
+        bytesWritten: 5,
+      });
+      await program.parseAsync([
+        'node',
+        'agentage',
+        'vault',
+        'edit',
+        'notes',
+        '--content',
+        'hello',
+      ]);
+      expect(mockInvoke).toHaveBeenCalledWith('vault:edit', { slug: 'notes', content: 'hello' }, [
+        'vault.write',
+      ]);
+      const all = logs.join('\n');
+      expect(all).toContain('Wrote 5 bytes');
+    });
+
+    it('passes --mode and --path through', async () => {
+      mockInvoke.mockResolvedValueOnce({
+        slug: 'notes',
+        path: 'a.md',
+        mode: 'overwrite',
+        bytesWritten: 3,
+      });
+      await program.parseAsync([
+        'node',
+        'agentage',
+        'vault',
+        'edit',
+        'notes',
+        '--content',
+        'foo',
+        '--mode',
+        'overwrite',
+        '--path',
+        'a.md',
+      ]);
+      const call = mockInvoke.mock.calls[0];
+      expect(call?.[1]).toMatchObject({ mode: 'overwrite', path: 'a.md' });
+    });
+
+    it('errors if no --content and stdin is a TTY', async () => {
+      const originalIsTTY = process.stdin.isTTY;
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+      try {
+        await program.parseAsync(['node', 'agentage', 'vault', 'edit', 'notes']);
+        expect(errorLogs.some((l) => l.includes('No content'))).toBe(true);
+        expect(mockExit).toHaveBeenCalledWith(1);
+      } finally {
+        Object.defineProperty(process.stdin, 'isTTY', {
+          value: originalIsTTY,
+          configurable: true,
+        });
+      }
+    });
+  });
 });

--- a/src/commands/vault.ts
+++ b/src/commands/vault.ts
@@ -2,9 +2,13 @@ import { resolve } from 'node:path';
 import chalk from 'chalk';
 import { type Command } from 'commander';
 import type { VaultAddOutput } from '../daemon/actions/vault-add.js';
+import type { VaultEditOutput } from '../daemon/actions/vault-edit.js';
+import type { VaultFilesOutput } from '../daemon/actions/vault-files.js';
 import type { VaultListOutput } from '../daemon/actions/vault-list.js';
+import type { VaultReadOutput } from '../daemon/actions/vault-read.js';
 import type { VaultReindexOutput } from '../daemon/actions/vault-reindex.js';
 import type { VaultRemoveOutput } from '../daemon/actions/vault-remove.js';
+import type { VaultSearchOutput } from '../daemon/actions/vault-search.js';
 import { invokeAction } from '../utils/action-client.js';
 import { ensureDaemon } from '../utils/ensure-daemon.js';
 
@@ -41,6 +45,44 @@ export const registerVaults = (program: Command): void => {
     .description('Force a full filesystem rescan of the vault')
     .action(async (slug: string) => {
       await handleReindex(slug);
+    });
+
+  cmd
+    .command('files <slug>')
+    .description('List files in a vault')
+    .option('--prefix <prefix>', 'Filter by path prefix (e.g. inbox/)')
+    .option('--limit <n>', 'Max results', '100')
+    .option('--json', 'JSON output')
+    .action(async (slug: string, opts: { prefix?: string; limit?: string; json?: boolean }) => {
+      await handleFiles(slug, opts);
+    });
+
+  cmd
+    .command('read <slug> <path>')
+    .description('Print the content of a vault-relative file')
+    .action(async (slug: string, path: string) => {
+      await handleRead(slug, path);
+    });
+
+  cmd
+    .command('search <slug> <query...>')
+    .description('Full-text search the vault index (FTS5)')
+    .option('--limit <n>', 'Max hits', '20')
+    .option('--json', 'JSON output')
+    .action(
+      async (slug: string, queryParts: string[], opts: { limit?: string; json?: boolean }) => {
+        await handleSearch(slug, queryParts.join(' '), opts);
+      }
+    );
+
+  cmd
+    .command('edit <slug>')
+    .description('Write content to a vault (default: new file in inbox/)')
+    .option('--content <text>', 'Content to write (otherwise reads stdin)')
+    .option('--mode <mode>', 'inbox-dated, append-daily, or overwrite')
+    .option('--path <path>', 'Vault-relative path (required for overwrite)')
+    .action(async (slug: string, opts: { content?: string; mode?: string; path?: string }) => {
+      await handleEdit(slug, opts);
     });
 };
 
@@ -137,6 +179,135 @@ const handleReindex = async (slug: string): Promise<void> => {
     console.error(
       chalk.red(`Failed to reindex vault: ${err instanceof Error ? err.message : String(err)}`)
     );
+    process.exit(1);
+  }
+};
+
+const handleFiles = async (
+  slug: string,
+  opts: { prefix?: string; limit?: string; json?: boolean }
+): Promise<void> => {
+  await ensureDaemon();
+  const input: Record<string, unknown> = { slug };
+  if (opts.prefix) input['prefix'] = opts.prefix;
+  if (opts.limit) input['limit'] = parseInt(opts.limit, 10);
+  try {
+    const result = await invokeAction<VaultFilesOutput>('vault:files', input, ['vault.read']);
+    if (opts.json) {
+      console.log(JSON.stringify(result.files, null, 2));
+      process.exit(0);
+      return;
+    }
+    if (result.files.length === 0) {
+      console.log(chalk.gray('No files.'));
+      process.exit(0);
+      return;
+    }
+    const pathWidth = Math.max(8, ...result.files.map((f) => f.path.length)) + 2;
+    console.log(
+      chalk.bold('PATH'.padEnd(pathWidth)) + chalk.bold('SIZE'.padEnd(10)) + chalk.bold('MTIME')
+    );
+    for (const f of result.files) {
+      console.log(
+        f.path.padEnd(pathWidth) +
+          chalk.dim(String(f.size).padEnd(10)) +
+          chalk.dim(new Date(f.mtime).toISOString())
+      );
+    }
+    console.log(chalk.dim(`\n${result.files.length} file(s)`));
+    process.exit(0);
+  } catch (err) {
+    console.error(
+      chalk.red(`Failed to list files: ${err instanceof Error ? err.message : String(err)}`)
+    );
+    process.exit(1);
+  }
+};
+
+const handleRead = async (slug: string, path: string): Promise<void> => {
+  await ensureDaemon();
+  try {
+    const result = await invokeAction<VaultReadOutput>('vault:read', { slug, path }, [
+      'vault.read',
+    ]);
+    process.stdout.write(result.content);
+    if (!result.content.endsWith('\n')) process.stdout.write('\n');
+    process.exit(0);
+  } catch (err) {
+    console.error(chalk.red(`Failed to read: ${err instanceof Error ? err.message : String(err)}`));
+    process.exit(1);
+  }
+};
+
+const handleSearch = async (
+  slug: string,
+  query: string,
+  opts: { limit?: string; json?: boolean }
+): Promise<void> => {
+  await ensureDaemon();
+  const input: Record<string, unknown> = { slug, query };
+  if (opts.limit) input['limit'] = parseInt(opts.limit, 10);
+  try {
+    const result = await invokeAction<VaultSearchOutput>('vault:search', input, ['vault.read']);
+    if (opts.json) {
+      console.log(JSON.stringify(result.hits, null, 2));
+      process.exit(0);
+      return;
+    }
+    if (result.hits.length === 0) {
+      console.log(chalk.gray(`No matches for "${query}".`));
+      process.exit(0);
+      return;
+    }
+    for (const hit of result.hits) {
+      console.log(chalk.bold(hit.path) + chalk.dim(`  (score ${hit.score.toFixed(3)})`));
+      console.log('  ' + hit.snippet.replace(/\n/g, ' '));
+      console.log();
+    }
+    console.log(chalk.dim(`${result.hits.length} hit(s)`));
+    process.exit(0);
+  } catch (err) {
+    console.error(
+      chalk.red(`Failed to search: ${err instanceof Error ? err.message : String(err)}`)
+    );
+    process.exit(1);
+  }
+};
+
+const readStdin = async (): Promise<string> => {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+};
+
+const handleEdit = async (
+  slug: string,
+  opts: { content?: string; mode?: string; path?: string }
+): Promise<void> => {
+  await ensureDaemon();
+  let content = opts.content;
+  if (content === undefined) {
+    if (process.stdin.isTTY) {
+      console.error(chalk.red('No content: pass --content "..." or pipe text to stdin'));
+      process.exit(1);
+      return;
+    }
+    content = await readStdin();
+  }
+  const input: Record<string, unknown> = { slug, content };
+  if (opts.mode) input['mode'] = opts.mode;
+  if (opts.path) input['path'] = opts.path;
+  try {
+    const result = await invokeAction<VaultEditOutput>('vault:edit', input, ['vault.write']);
+    console.log(
+      chalk.green(`Wrote ${result.bytesWritten} bytes`) +
+        chalk.dim(` to ${result.path} (mode=${result.mode})`)
+    );
+    process.exit(0);
+  } catch (err) {
+    console.error(chalk.red(`Failed to edit: ${err instanceof Error ? err.message : String(err)}`));
     process.exit(1);
   }
 };

--- a/src/daemon/actions.test.ts
+++ b/src/daemon/actions.test.ts
@@ -28,9 +28,13 @@ describe('action registry bootstrap', () => {
       'cli:update',
       'project:addFromOrigin',
       'vault:add',
+      'vault:edit',
+      'vault:files',
       'vault:list',
+      'vault:read',
       'vault:reindex',
       'vault:remove',
+      'vault:search',
     ]);
   });
 

--- a/src/daemon/actions.ts
+++ b/src/daemon/actions.ts
@@ -5,9 +5,13 @@ import { createAgentInstallAction } from './actions/agent-install.js';
 import { createCliUpdateAction } from './actions/cli-update.js';
 import { createProjectAddFromOriginAction } from './actions/project-add-from-origin.js';
 import { createVaultAddAction } from './actions/vault-add.js';
+import { createVaultEditAction } from './actions/vault-edit.js';
+import { createVaultFilesAction } from './actions/vault-files.js';
 import { createVaultListAction } from './actions/vault-list.js';
+import { createVaultReadAction } from './actions/vault-read.js';
 import { createVaultReindexAction } from './actions/vault-reindex.js';
 import { createVaultRemoveAction } from './actions/vault-remove.js';
+import { createVaultSearchAction } from './actions/vault-search.js';
 import type { ShellExec } from './actions/types.js';
 
 const shellExec: ShellExec = (command, options) => shell(command, options);
@@ -32,6 +36,10 @@ export const getActionRegistry = (): ActionRegistry => {
   registry.register(createVaultRemoveAction({ vaults, persist }));
   registry.register(createVaultReindexAction({ vaults }));
   registry.register(createVaultListAction({ vaults }));
+  registry.register(createVaultFilesAction({ vaults }));
+  registry.register(createVaultReadAction({ vaults }));
+  registry.register(createVaultSearchAction({ vaults }));
+  registry.register(createVaultEditAction({ vaults }));
 
   registrySingleton = registry;
   return registry;

--- a/src/daemon/actions/index.ts
+++ b/src/daemon/actions/index.ts
@@ -19,4 +19,16 @@ export type { VaultReindexInput, VaultReindexOutput } from './vault-reindex.js';
 export { createVaultListAction } from './vault-list.js';
 export type { VaultListInput, VaultListOutput } from './vault-list.js';
 
+export { createVaultFilesAction } from './vault-files.js';
+export type { VaultFilesInput, VaultFilesOutput } from './vault-files.js';
+
+export { createVaultReadAction } from './vault-read.js';
+export type { VaultReadInput, VaultReadOutput } from './vault-read.js';
+
+export { createVaultSearchAction } from './vault-search.js';
+export type { VaultSearchInput, VaultSearchOutput } from './vault-search.js';
+
+export { createVaultEditAction } from './vault-edit.js';
+export type { VaultEditInput, VaultEditOutput } from './vault-edit.js';
+
 export type { ActionProgress, ShellExec } from './types.js';

--- a/src/daemon/actions/vault-content-actions.test.ts
+++ b/src/daemon/actions/vault-content-actions.test.ts
@@ -1,0 +1,381 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRegistry, type InvokeEvent } from '@agentage/core';
+import { VaultRegistry } from '../../vaults/registry.js';
+import { createVaultEditAction } from './vault-edit.js';
+import { createVaultFilesAction } from './vault-files.js';
+import { createVaultReadAction } from './vault-read.js';
+import { createVaultSearchAction } from './vault-search.js';
+
+const collect = async (gen: AsyncGenerator<InvokeEvent>): Promise<InvokeEvent[]> => {
+  const events: InvokeEvent[] = [];
+  for await (const e of gen) events.push(e);
+  return events;
+};
+
+describe('vault content actions', () => {
+  let storage: string;
+  let vaultPath: string;
+  let vaults: VaultRegistry;
+
+  beforeEach(async () => {
+    storage = await mkdtemp(join(tmpdir(), 'agentage-vcontent-storage-'));
+    vaultPath = await mkdtemp(join(tmpdir(), 'agentage-vcontent-vault-'));
+    vaults = new VaultRegistry({ storageDir: storage });
+    await writeFile(join(vaultPath, 'a.md'), 'apple banana cherry');
+    await writeFile(join(vaultPath, 'b.md'), 'banana date elderberry');
+    await vaults.add({ slug: 'fruits', path: vaultPath });
+  });
+
+  afterEach(async () => {
+    await vaults.closeAll();
+    await rm(storage, { recursive: true, force: true });
+    await rm(vaultPath, { recursive: true, force: true });
+  });
+
+  const buildRegistry = (): ReturnType<typeof createRegistry> => {
+    const reg = createRegistry();
+    reg.register(createVaultFilesAction({ vaults }));
+    reg.register(createVaultReadAction({ vaults }));
+    reg.register(createVaultSearchAction({ vaults }));
+    reg.register(createVaultEditAction({ vaults }));
+    return reg;
+  };
+
+  describe('vault:files', () => {
+    it('lists every markdown file in the vault', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:files',
+          input: { slug: 'fruits' },
+          callerId: 'test',
+          capabilities: ['vault.read'],
+        })
+      );
+      const last = events.at(-1) as { data: { files: Array<{ path: string }> } };
+      expect(last.data.files.map((f) => f.path).sort()).toEqual(['a.md', 'b.md']);
+    });
+
+    it('filters by prefix', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:files',
+          input: { slug: 'fruits', prefix: 'a' },
+          callerId: 'test',
+          capabilities: ['vault.read'],
+        })
+      );
+      const last = events.at(-1) as { data: { files: Array<{ path: string }> } };
+      expect(last.data.files.map((f) => f.path)).toEqual(['a.md']);
+    });
+
+    it('errors on unknown vault', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:files',
+          input: { slug: 'nope' },
+          callerId: 'test',
+          capabilities: ['vault.read'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'error', code: 'INVALID_INPUT' });
+    });
+
+    it('requires vault.read capability', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:files',
+          input: { slug: 'fruits' },
+          callerId: 'test',
+          capabilities: ['vault.write'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'error', code: 'UNAUTHORIZED' });
+    });
+  });
+
+  describe('vault:read', () => {
+    it('returns the content of a vault-relative file', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:read',
+          input: { slug: 'fruits', path: 'a.md' },
+          callerId: 'test',
+          capabilities: ['vault.read'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({
+        type: 'result',
+        data: { slug: 'fruits', path: 'a.md', content: 'apple banana cherry' },
+      });
+    });
+
+    it('errors when file does not exist', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:read',
+          input: { slug: 'fruits', path: 'missing.md' },
+          callerId: 'test',
+          capabilities: ['vault.read'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'error', code: 'INVALID_INPUT' });
+    });
+
+    it('rejects path-traversal attempts', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:read',
+          input: { slug: 'fruits', path: '../../etc/passwd' },
+          callerId: 'test',
+          capabilities: ['vault.read'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'error', code: 'INVALID_INPUT' });
+    });
+
+    it('rejects absolute paths', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:read',
+          input: { slug: 'fruits', path: '/etc/passwd' },
+          callerId: 'test',
+          capabilities: ['vault.read'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'error', code: 'INVALID_INPUT' });
+    });
+  });
+
+  describe('vault:search', () => {
+    it('returns ranked hits with snippets', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:search',
+          input: { slug: 'fruits', query: 'banana' },
+          callerId: 'test',
+          capabilities: ['vault.read'],
+        })
+      );
+      const last = events.at(-1) as { data: { hits: Array<{ path: string; snippet: string }> } };
+      expect(last.data.hits.length).toBe(2);
+      expect(last.data.hits[0]?.snippet).toContain('<<banana>>');
+    });
+
+    it('returns empty hits when no match', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:search',
+          input: { slug: 'fruits', query: 'tractor' },
+          callerId: 'test',
+          capabilities: ['vault.read'],
+        })
+      );
+      const last = events.at(-1) as { data: { hits: Array<unknown> } };
+      expect(last.data.hits).toEqual([]);
+    });
+
+    it('rejects empty query', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:search',
+          input: { slug: 'fruits', query: '' },
+          callerId: 'test',
+          capabilities: ['vault.read'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'error', code: 'INVALID_INPUT' });
+    });
+
+    it('respects limit', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:search',
+          input: { slug: 'fruits', query: 'banana', limit: 1 },
+          callerId: 'test',
+          capabilities: ['vault.read'],
+        })
+      );
+      const last = events.at(-1) as { data: { hits: Array<unknown> } };
+      expect(last.data.hits.length).toBe(1);
+    });
+  });
+
+  describe('vault:edit', () => {
+    it('writes inbox-dated by default and indexes the new file', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:edit',
+          input: { slug: 'fruits', content: 'a fresh note' },
+          callerId: 'test',
+          capabilities: ['vault.write'],
+        })
+      );
+      const last = events.at(-1) as {
+        data: { slug: string; path: string; mode: string; bytesWritten: number };
+      };
+      expect(last.data.mode).toBe('inbox-dated');
+      expect(last.data.path).toMatch(/^inbox\//);
+      expect(last.data.bytesWritten).toBe(12);
+
+      const onDisk = await readFile(join(vaultPath, last.data.path), 'utf-8');
+      expect(onDisk).toBe('a fresh note');
+
+      const v = vaults.get('fruits');
+      expect(await v?.index.fileCount()).toBe(3);
+    });
+
+    it('append-daily creates and appends the daily file', async () => {
+      const reg = buildRegistry();
+      await collect(
+        reg.invoke({
+          action: 'vault:edit',
+          input: { slug: 'fruits', content: 'first', mode: 'append-daily' },
+          callerId: 'test',
+          capabilities: ['vault.write'],
+        })
+      );
+      const events2 = await collect(
+        reg.invoke({
+          action: 'vault:edit',
+          input: { slug: 'fruits', content: 'second', mode: 'append-daily' },
+          callerId: 'test',
+          capabilities: ['vault.write'],
+        })
+      );
+      const last = events2.at(-1) as { data: { path: string } };
+      expect(last.data.path).toMatch(/^daily\/\d{4}-\d{2}-\d{2}\.md$/);
+      const onDisk = await readFile(join(vaultPath, last.data.path), 'utf-8');
+      expect(onDisk).toContain('first');
+      expect(onDisk).toContain('second');
+    });
+
+    it('overwrite mode writes to the explicit path', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:edit',
+          input: {
+            slug: 'fruits',
+            content: 'replaced contents',
+            mode: 'overwrite',
+            path: 'a.md',
+          },
+          callerId: 'test',
+          capabilities: ['vault.write'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'result', data: { path: 'a.md' } });
+      const onDisk = await readFile(join(vaultPath, 'a.md'), 'utf-8');
+      expect(onDisk).toBe('replaced contents');
+    });
+
+    it('overwrite mode rejects missing path', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:edit',
+          input: { slug: 'fruits', content: 'x', mode: 'overwrite' },
+          callerId: 'test',
+          capabilities: ['vault.write'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'error', code: 'INVALID_INPUT' });
+    });
+
+    it('overwrite mode rejects path-traversal', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:edit',
+          input: {
+            slug: 'fruits',
+            content: 'x',
+            mode: 'overwrite',
+            path: '../../etc/passwd',
+          },
+          callerId: 'test',
+          capabilities: ['vault.write'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'error', code: 'INVALID_INPUT' });
+    });
+
+    it('requires vault.write capability', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:edit',
+          input: { slug: 'fruits', content: 'x' },
+          callerId: 'test',
+          capabilities: ['vault.read'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'error', code: 'UNAUTHORIZED' });
+    });
+
+    it('rejects unknown vault', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:edit',
+          input: { slug: 'ghost', content: 'x' },
+          callerId: 'test',
+          capabilities: ['vault.write'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'error', code: 'INVALID_INPUT' });
+    });
+
+    it('rejects invalid mode', async () => {
+      const reg = buildRegistry();
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:edit',
+          input: { slug: 'fruits', content: 'x', mode: 'destroy' as 'overwrite' },
+          callerId: 'test',
+          capabilities: ['vault.write'],
+        })
+      );
+      expect(events.at(-1)).toMatchObject({ type: 'error', code: 'INVALID_INPUT' });
+    });
+
+    it('newly written file is searchable immediately', async () => {
+      const reg = buildRegistry();
+      await collect(
+        reg.invoke({
+          action: 'vault:edit',
+          input: { slug: 'fruits', content: 'pomegranate is unique' },
+          callerId: 'test',
+          capabilities: ['vault.write'],
+        })
+      );
+      const events = await collect(
+        reg.invoke({
+          action: 'vault:search',
+          input: { slug: 'fruits', query: 'pomegranate' },
+          callerId: 'test',
+          capabilities: ['vault.read'],
+        })
+      );
+      const last = events.at(-1) as { data: { hits: Array<{ path: string }> } };
+      expect(last.data.hits.length).toBe(1);
+      expect(last.data.hits[0]?.path).toMatch(/^inbox\//);
+    });
+  });
+});

--- a/src/daemon/actions/vault-edit.ts
+++ b/src/daemon/actions/vault-edit.ts
@@ -1,0 +1,89 @@
+import { action, ActionError, type ActionDefinition } from '@agentage/core';
+import type { VaultRegistry } from '../../vaults/registry.js';
+import { writeToVault, type EditMode } from '../../vaults/writer.js';
+import type { ActionProgress } from './types.js';
+
+export interface VaultEditInput {
+  slug: string;
+  content: string;
+  mode?: EditMode;
+  path?: string;
+}
+
+export interface VaultEditOutput {
+  slug: string;
+  path: string;
+  mode: EditMode;
+  bytesWritten: number;
+}
+
+const VALID_MODES: ReadonlySet<string> = new Set(['inbox-dated', 'append-daily', 'overwrite']);
+
+const validate = (raw: unknown): VaultEditInput => {
+  if (!raw || typeof raw !== 'object') throw new Error('input must be an object');
+  const r = raw as Record<string, unknown>;
+  if (typeof r['slug'] !== 'string' || r['slug'].length === 0)
+    throw new Error('slug must be a non-empty string');
+  if (typeof r['content'] !== 'string') throw new Error('content must be a string');
+  const out: VaultEditInput = { slug: r['slug'], content: r['content'] };
+  if (r['mode'] !== undefined) {
+    if (typeof r['mode'] !== 'string' || !VALID_MODES.has(r['mode']))
+      throw new Error('mode must be inbox-dated, append-daily, or overwrite');
+    out.mode = r['mode'] as EditMode;
+  }
+  if (r['path'] !== undefined) {
+    if (typeof r['path'] !== 'string') throw new Error('path must be a string');
+    out.path = r['path'];
+  }
+  return out;
+};
+
+export const createVaultEditAction = (deps: {
+  vaults: VaultRegistry;
+}): ActionDefinition<VaultEditInput, VaultEditOutput, ActionProgress> =>
+  action({
+    manifest: {
+      name: 'vault:edit',
+      version: '1.0',
+      title: 'Write content to vault',
+      description:
+        "Append or create a markdown file. Default mode is the vault's configured writeMode (typically inbox-dated, which creates a new file in inbox/ — never modifies existing notes)",
+      scope: 'machine',
+      capability: 'vault.write',
+      idempotent: false,
+    },
+    validateInput: validate,
+    async *execute(_ctx, input): AsyncGenerator<ActionProgress, VaultEditOutput, void> {
+      const v = deps.vaults.get(input.slug);
+      if (!v) {
+        throw new ActionError('INVALID_INPUT', `vault "${input.slug}" does not exist`, false);
+      }
+      const mode: EditMode = input.mode ?? v.config.writeMode;
+      if (mode === 'overwrite' && (!input.path || input.path.length === 0)) {
+        throw new ActionError('INVALID_INPUT', 'overwrite mode requires path', false);
+      }
+      yield { step: 'write', detail: `mode=${mode}` };
+      let result;
+      try {
+        result = await writeToVault(v.config.path, input.content, mode, input.path);
+      } catch (err) {
+        throw new ActionError(
+          'INVALID_INPUT',
+          err instanceof Error ? err.message : 'write failed',
+          false
+        );
+      }
+      yield { step: 'index', detail: `path=${result.relPath}` };
+      await v.index.reconcile({
+        added: [result.change],
+        modified: [],
+        removed: [],
+      });
+      return {
+        slug: input.slug,
+        path: result.relPath,
+        mode: result.mode,
+        bytesWritten: result.bytesWritten,
+      };
+    },
+  });

--- a/src/daemon/actions/vault-files.ts
+++ b/src/daemon/actions/vault-files.ts
@@ -1,0 +1,67 @@
+import { action, ActionError, type ActionDefinition } from '@agentage/core';
+import type { VaultRegistry } from '../../vaults/registry.js';
+import type { FileEntry } from '../../vaults/types.js';
+import type { ActionProgress } from './types.js';
+
+export interface VaultFilesInput {
+  slug: string;
+  prefix?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface VaultFilesOutput {
+  slug: string;
+  files: FileEntry[];
+}
+
+const validate = (raw: unknown): VaultFilesInput => {
+  if (!raw || typeof raw !== 'object') throw new Error('input must be an object');
+  const r = raw as Record<string, unknown>;
+  if (typeof r['slug'] !== 'string' || r['slug'].length === 0)
+    throw new Error('slug must be a non-empty string');
+  const out: VaultFilesInput = { slug: r['slug'] };
+  if (r['prefix'] !== undefined) {
+    if (typeof r['prefix'] !== 'string') throw new Error('prefix must be a string');
+    out.prefix = r['prefix'];
+  }
+  if (r['limit'] !== undefined) {
+    if (typeof r['limit'] !== 'number' || !Number.isInteger(r['limit']) || r['limit'] < 1)
+      throw new Error('limit must be a positive integer');
+    out.limit = r['limit'];
+  }
+  if (r['offset'] !== undefined) {
+    if (typeof r['offset'] !== 'number' || !Number.isInteger(r['offset']) || r['offset'] < 0)
+      throw new Error('offset must be a non-negative integer');
+    out.offset = r['offset'];
+  }
+  return out;
+};
+
+export const createVaultFilesAction = (deps: {
+  vaults: VaultRegistry;
+}): ActionDefinition<VaultFilesInput, VaultFilesOutput, ActionProgress> =>
+  action({
+    manifest: {
+      name: 'vault:files',
+      version: '1.0',
+      title: 'List files in vault',
+      description: 'List markdown files in a vault, optionally filtered by path prefix',
+      scope: 'machine',
+      capability: 'vault.read',
+      idempotent: true,
+    },
+    validateInput: validate,
+    async *execute(_ctx, input): AsyncGenerator<ActionProgress, VaultFilesOutput, void> {
+      const v = deps.vaults.get(input.slug);
+      if (!v) {
+        throw new ActionError('INVALID_INPUT', `vault "${input.slug}" does not exist`, false);
+      }
+      const opts: { prefix?: string; limit?: number; offset?: number } = {};
+      if (input.prefix !== undefined) opts.prefix = input.prefix;
+      if (input.limit !== undefined) opts.limit = input.limit;
+      if (input.offset !== undefined) opts.offset = input.offset;
+      const files = await v.index.list(opts);
+      return { slug: input.slug, files };
+    },
+  });

--- a/src/daemon/actions/vault-read.ts
+++ b/src/daemon/actions/vault-read.ts
@@ -1,0 +1,73 @@
+import { existsSync, statSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { action, ActionError, type ActionDefinition } from '@agentage/core';
+import { safeJoin } from '../../vaults/path-safety.js';
+import type { VaultRegistry } from '../../vaults/registry.js';
+import type { ActionProgress } from './types.js';
+
+export interface VaultReadInput {
+  slug: string;
+  path: string;
+}
+
+export interface VaultReadOutput {
+  slug: string;
+  path: string;
+  content: string;
+  size: number;
+  mtime: number;
+}
+
+const validate = (raw: unknown): VaultReadInput => {
+  if (!raw || typeof raw !== 'object') throw new Error('input must be an object');
+  const r = raw as Record<string, unknown>;
+  if (typeof r['slug'] !== 'string' || r['slug'].length === 0)
+    throw new Error('slug must be a non-empty string');
+  if (typeof r['path'] !== 'string' || r['path'].length === 0)
+    throw new Error('path must be a non-empty string');
+  return { slug: r['slug'], path: r['path'] };
+};
+
+export const createVaultReadAction = (deps: {
+  vaults: VaultRegistry;
+}): ActionDefinition<VaultReadInput, VaultReadOutput, ActionProgress> =>
+  action({
+    manifest: {
+      name: 'vault:read',
+      version: '1.0',
+      title: 'Read file from vault',
+      description: 'Read the content of a vault-relative markdown file from disk',
+      scope: 'machine',
+      capability: 'vault.read',
+      idempotent: true,
+    },
+    validateInput: validate,
+    async *execute(_ctx, input): AsyncGenerator<ActionProgress, VaultReadOutput, void> {
+      const v = deps.vaults.get(input.slug);
+      if (!v) {
+        throw new ActionError('INVALID_INPUT', `vault "${input.slug}" does not exist`, false);
+      }
+      let fullPath: string;
+      try {
+        fullPath = safeJoin(v.config.path, input.path);
+      } catch (err) {
+        throw new ActionError(
+          'INVALID_INPUT',
+          err instanceof Error ? err.message : 'invalid path',
+          false
+        );
+      }
+      if (!existsSync(fullPath)) {
+        throw new ActionError('INVALID_INPUT', `file not found: ${input.path}`, false);
+      }
+      const content = await readFile(fullPath, 'utf-8');
+      const st = statSync(fullPath);
+      return {
+        slug: input.slug,
+        path: input.path,
+        content,
+        size: st.size,
+        mtime: st.mtimeMs,
+      };
+    },
+  });

--- a/src/daemon/actions/vault-search.ts
+++ b/src/daemon/actions/vault-search.ts
@@ -1,0 +1,66 @@
+import { action, ActionError, type ActionDefinition } from '@agentage/core';
+import type { VaultRegistry } from '../../vaults/registry.js';
+import type { Hit } from '../../vaults/types.js';
+import type { ActionProgress } from './types.js';
+
+export interface VaultSearchInput {
+  slug: string;
+  query: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface VaultSearchOutput {
+  slug: string;
+  query: string;
+  hits: Hit[];
+}
+
+const validate = (raw: unknown): VaultSearchInput => {
+  if (!raw || typeof raw !== 'object') throw new Error('input must be an object');
+  const r = raw as Record<string, unknown>;
+  if (typeof r['slug'] !== 'string' || r['slug'].length === 0)
+    throw new Error('slug must be a non-empty string');
+  if (typeof r['query'] !== 'string' || r['query'].length === 0)
+    throw new Error('query must be a non-empty string');
+  const out: VaultSearchInput = { slug: r['slug'], query: r['query'] };
+  if (r['limit'] !== undefined) {
+    if (typeof r['limit'] !== 'number' || !Number.isInteger(r['limit']) || r['limit'] < 1)
+      throw new Error('limit must be a positive integer');
+    out.limit = r['limit'];
+  }
+  if (r['offset'] !== undefined) {
+    if (typeof r['offset'] !== 'number' || !Number.isInteger(r['offset']) || r['offset'] < 0)
+      throw new Error('offset must be a non-negative integer');
+    out.offset = r['offset'];
+  }
+  return out;
+};
+
+export const createVaultSearchAction = (deps: {
+  vaults: VaultRegistry;
+}): ActionDefinition<VaultSearchInput, VaultSearchOutput, ActionProgress> =>
+  action({
+    manifest: {
+      name: 'vault:search',
+      version: '1.0',
+      title: 'Search vault',
+      description:
+        'Full-text search the vault index using SQLite FTS5; returns ranked hits with snippets',
+      scope: 'machine',
+      capability: 'vault.read',
+      idempotent: true,
+    },
+    validateInput: validate,
+    async *execute(_ctx, input): AsyncGenerator<ActionProgress, VaultSearchOutput, void> {
+      const v = deps.vaults.get(input.slug);
+      if (!v) {
+        throw new ActionError('INVALID_INPUT', `vault "${input.slug}" does not exist`, false);
+      }
+      const opts: { limit?: number; offset?: number } = {};
+      if (input.limit !== undefined) opts.limit = input.limit;
+      if (input.offset !== undefined) opts.offset = input.offset;
+      const hits = await v.index.search(input.query, opts);
+      return { slug: input.slug, query: input.query, hits };
+    },
+  });

--- a/src/vaults/path-safety.test.ts
+++ b/src/vaults/path-safety.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { safeJoin } from './path-safety.js';
+
+describe('safeJoin', () => {
+  it('joins vault path with relative subpath', () => {
+    expect(safeJoin('/vault', 'notes/a.md')).toBe('/vault/notes/a.md');
+  });
+
+  it('rejects absolute paths', () => {
+    expect(() => safeJoin('/vault', '/etc/passwd')).toThrow(/absolute/);
+  });
+
+  it('rejects paths that escape via ..', () => {
+    expect(() => safeJoin('/vault', '../etc/passwd')).toThrow(/escapes/);
+    expect(() => safeJoin('/vault', 'notes/../../etc/passwd')).toThrow(/escapes/);
+  });
+
+  it('allows .. that stays within the vault', () => {
+    expect(safeJoin('/vault', 'a/../b.md')).toBe('/vault/b.md');
+  });
+
+  it('handles trailing slashes on vault path', () => {
+    expect(safeJoin('/vault/', 'a.md')).toBe('/vault/a.md');
+  });
+});

--- a/src/vaults/path-safety.ts
+++ b/src/vaults/path-safety.ts
@@ -1,0 +1,13 @@
+import { isAbsolute, relative, resolve } from 'node:path';
+
+export const safeJoin = (vaultPath: string, vaultRelPath: string): string => {
+  if (isAbsolute(vaultRelPath)) {
+    throw new Error('path must be vault-relative, not absolute');
+  }
+  const full = resolve(vaultPath, vaultRelPath);
+  const rel = relative(vaultPath, full);
+  if (rel.startsWith('..') || isAbsolute(rel)) {
+    throw new Error('path escapes the vault root');
+  }
+  return full;
+};

--- a/src/vaults/writer.test.ts
+++ b/src/vaults/writer.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeToVault } from './writer.js';
+
+describe('writeToVault', () => {
+  let vaultPath: string;
+
+  beforeEach(async () => {
+    vaultPath = await mkdtemp(join(tmpdir(), 'agentage-writer-'));
+  });
+
+  afterEach(async () => {
+    await rm(vaultPath, { recursive: true, force: true });
+  });
+
+  describe('inbox-dated', () => {
+    it('writes to inbox/<date-time-nanoid>.md', async () => {
+      const now = new Date('2026-04-25T13:45:30Z');
+      const result = await writeToVault(vaultPath, 'note body', 'inbox-dated', undefined, now);
+      expect(result.relPath).toMatch(/^inbox\/2026-04-25-134530-[0-9a-f]{8}\.md$/);
+      expect(result.bytesWritten).toBe(9);
+      const content = await readFile(join(vaultPath, result.relPath), 'utf-8');
+      expect(content).toBe('note body');
+    });
+
+    it('two writes in the same second produce distinct files via the nanoid', async () => {
+      const now = new Date('2026-04-25T13:45:30Z');
+      const a = await writeToVault(vaultPath, 'a', 'inbox-dated', undefined, now);
+      const b = await writeToVault(vaultPath, 'b', 'inbox-dated', undefined, now);
+      expect(a.relPath).not.toBe(b.relPath);
+    });
+  });
+
+  describe('append-daily', () => {
+    it('creates daily file with title + first block when not present', async () => {
+      const now = new Date('2026-04-25T09:15:00Z');
+      const result = await writeToVault(
+        vaultPath,
+        'morning thought',
+        'append-daily',
+        undefined,
+        now
+      );
+      expect(result.relPath).toBe('daily/2026-04-25.md');
+      const content = await readFile(join(vaultPath, result.relPath), 'utf-8');
+      expect(content).toBe('# 2026-04-25\n\n## 09:15\n\nmorning thought\n');
+    });
+
+    it('appends second block when file exists', async () => {
+      const morning = new Date('2026-04-25T09:15:00Z');
+      const evening = new Date('2026-04-25T21:30:00Z');
+      await writeToVault(vaultPath, 'morning', 'append-daily', undefined, morning);
+      await writeToVault(vaultPath, 'evening', 'append-daily', undefined, evening);
+      const content = await readFile(join(vaultPath, 'daily/2026-04-25.md'), 'utf-8');
+      expect(content).toBe('# 2026-04-25\n\n## 09:15\n\nmorning\n\n## 21:30\n\nevening\n');
+    });
+
+    it('appends correctly when existing file lacks trailing newline', async () => {
+      await writeFile(join(vaultPath, 'daily/2026-04-25.md').replace('daily/', ''), '');
+      // Pre-create a file without trailing newline
+      const { mkdir } = await import('node:fs/promises');
+      await mkdir(join(vaultPath, 'daily'), { recursive: true });
+      await writeFile(join(vaultPath, 'daily/2026-04-25.md'), '# 2026-04-25\n\nbare note');
+      const now = new Date('2026-04-25T12:00:00Z');
+      await writeToVault(vaultPath, 'follow-up', 'append-daily', undefined, now);
+      const content = await readFile(join(vaultPath, 'daily/2026-04-25.md'), 'utf-8');
+      expect(content).toContain('bare note\n\n## 12:00');
+      expect(content).toContain('follow-up');
+    });
+  });
+
+  describe('overwrite', () => {
+    it('writes to the explicit path', async () => {
+      const result = await writeToVault(vaultPath, 'replaces it', 'overwrite', 'notes/exact.md');
+      expect(result.relPath).toBe('notes/exact.md');
+      const content = await readFile(join(vaultPath, 'notes/exact.md'), 'utf-8');
+      expect(content).toBe('replaces it');
+    });
+
+    it('throws when path is missing', async () => {
+      await expect(writeToVault(vaultPath, 'x', 'overwrite', undefined)).rejects.toThrow(
+        /requires path/
+      );
+    });
+
+    it('rejects path-traversal attempts', async () => {
+      await expect(writeToVault(vaultPath, 'x', 'overwrite', '../../etc/passwd')).rejects.toThrow(
+        /escapes/
+      );
+    });
+  });
+
+  it('returns sha256 + size + mtime in change', async () => {
+    const result = await writeToVault(vaultPath, 'hello', 'overwrite', 'a.md');
+    expect(result.change.path).toBe('a.md');
+    expect(result.change.content).toBe('hello');
+    expect(result.change.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.change.size).toBe(5);
+    expect(result.change.mtime).toBeGreaterThan(0);
+  });
+});

--- a/src/vaults/writer.ts
+++ b/src/vaults/writer.ts
@@ -1,0 +1,82 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { createHash, randomBytes } from 'node:crypto';
+import { safeJoin } from './path-safety.js';
+import type { FileChange, VaultWriteMode } from './types.js';
+
+export type EditMode = VaultWriteMode | 'overwrite';
+
+export interface WriteResult {
+  relPath: string;
+  bytesWritten: number;
+  mode: EditMode;
+  change: FileChange;
+}
+
+const nanoid = (): string => randomBytes(4).toString('hex');
+
+const pad2 = (n: number): string => String(n).padStart(2, '0');
+
+const formatDate = (d: Date): string =>
+  `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}`;
+
+const formatTimeStamp = (d: Date): string =>
+  `${pad2(d.getUTCHours())}${pad2(d.getUTCMinutes())}${pad2(d.getUTCSeconds())}`;
+
+const formatTimeHeader = (d: Date): string => `${pad2(d.getUTCHours())}:${pad2(d.getUTCMinutes())}`;
+
+const sha256 = (s: string): string => createHash('sha256').update(s).digest('hex');
+
+export const writeToVault = async (
+  vaultPath: string,
+  content: string,
+  mode: EditMode,
+  explicitPath: string | undefined,
+  now: Date = new Date()
+): Promise<WriteResult> => {
+  let relPath: string;
+  let payload: string;
+
+  if (mode === 'inbox-dated') {
+    relPath = `inbox/${formatDate(now)}-${formatTimeStamp(now)}-${nanoid()}.md`;
+    payload = content;
+  } else if (mode === 'append-daily') {
+    const date = formatDate(now);
+    relPath = `daily/${date}.md`;
+    const fullPath = safeJoin(vaultPath, relPath);
+    const block = `\n## ${formatTimeHeader(now)}\n\n${content}\n`;
+    if (existsSync(fullPath)) {
+      let existing = await readFile(fullPath, 'utf-8');
+      if (!existing.endsWith('\n')) existing += '\n';
+      payload = existing + block;
+    } else {
+      payload = `# ${date}\n${block}`;
+    }
+  } else if (mode === 'overwrite') {
+    if (!explicitPath || explicitPath.length === 0) {
+      throw new Error('overwrite mode requires path');
+    }
+    relPath = explicitPath;
+    payload = content;
+  } else {
+    throw new Error(`unknown mode: ${mode as string}`);
+  }
+
+  const fullPath = safeJoin(vaultPath, relPath);
+  await mkdir(dirname(fullPath), { recursive: true });
+  await writeFile(fullPath, payload, 'utf-8');
+  const st = await stat(fullPath);
+  return {
+    relPath,
+    bytesWritten: Buffer.byteLength(payload, 'utf-8'),
+    mode,
+    change: {
+      path: relPath,
+      content: payload,
+      sha256: sha256(payload),
+      size: st.size,
+      mtime: st.mtimeMs,
+    },
+  };
+};


### PR DESCRIPTION
## Summary

PR 2 of 4. Stacks on top of #160. Adds the LLM-facing content surface:
4 new actions + 4 new CLI subcommands. After this PR merges, vaults
are usable for read/write workflows; PR 3 will surface the same actions
through the MCP shim so Claude Desktop / Cursor / etc. can call them.

- 4 actions in ActionRegistry (`vault:files/read/search/edit`)
- 4 CLI subcommands (`agentage vault files/read/search/edit`)
- New `writeToVault` helper handles 3 write modes (inbox-dated /
  append-daily / overwrite); after every write, the index updates
  incrementally — no full reconcile.
- New `safeJoin` path-safety utility — used by both `vault:read` and
  `vault:edit` to reject path traversal and absolutes.

## Capability split (firewalls the MCP shim later relies on)

| Action | Capability |
|---|---|
| `vault:files`, `vault:read`, `vault:search` | `vault.read` |
| `vault:edit` | `vault.write` |
| `vault:add`, `vault:remove`, `vault:reindex` (PR 1) | `vault.admin` |

PR 3's MCP shim will pass `vault.read` + `vault.write` only. `vault.admin`
remains unreachable from LLMs by construction.

## Write-mode behavior

- **inbox-dated** (default per vault config): `inbox/YYYY-MM-DD-HHMMSS-{nanoid}.md`. Two writes in the same second still produce distinct files via the nanoid. Never modifies an existing note.
- **append-daily**: `daily/YYYY-MM-DD.md`. Creates the file with `# YYYY-MM-DD\n\n## HH:MM\n\n<content>` if absent; otherwise appends `\n## HH:MM\n\n<content>` ensuring a blank line between blocks.
- **overwrite** (requires `path`): writes to the explicit vault-relative path. Rejected paths: absolute, or anything resolving outside the vault root.

After a write, the index is updated incrementally via `index.reconcile({added: [change]})` — INSERT OR REPLACE handles either the new-file or modified-file case, so we don't need a stat-then-decide round-trip.

## Test coverage

- `path-safety.test.ts` — 5 tests (joins, traversal, absolute, edge cases)
- `writer.test.ts` — 8 tests (all 3 modes, nanoid uniqueness, block spacing, traversal rejection, sha256/size/mtime in result)
- `vault-content-actions.test.ts` — 24 e2e tests including capability gating, path-traversal blocked on read + edit, immediate searchability after a write
- `vault.test.ts` — 11 new CLI tests (was 9, now 20) covering arg wiring, multi-word search joining, stdout streaming, stdin/TTY handling
- Bootstrap test extended for new manifests

Total: **645 tests pass, build clean.**

## Diff against PR 1 base

This PR's base is `feature/vaults-phase-0` (#160). When PR 1 merges to master, this PR auto-rebases.

## What's NOT in this PR

- MCP shim entries — PR 3
- Dashboard visibility — PR 4
- Any sync — phase 1

## Test plan

- [ ] `npm run verify` passes
- [ ] Smoke test (against PR 1 daemon):
  - [ ] `agentage vault files <slug>` → table of files
  - [ ] `agentage vault read <slug> <path>` → stdout
  - [ ] `agentage vault search <slug> "term"` → hits with snippets
  - [ ] `echo "test note" | agentage vault edit <slug>` → writes inbox-dated, prints byte count
  - [ ] `agentage vault edit <slug> --mode append-daily --content "follow-up"` → appends to today's daily
  - [ ] `agentage vault edit <slug> --mode overwrite --path notes/x.md --content "..."` → overwrites
  - [ ] `agentage vault search <slug> "<term from just-written content>"` → returns the new file (proves incremental indexing)

## Commits

- \`8619d70\` feat(vaults): writeToVault helper + path-safety utility
- \`59a8c7a\` feat(daemon): vault content actions (files/read/search/edit)
- \`0ba6929\` feat(cli): agentage vault files/read/search/edit