### PR TITLE
feat(daemon): emit vault metadata in heartbeat

### DIFF
--- a/src/hub/hub-client.ts
+++ b/src/hub/hub-client.ts
@@ -36,6 +36,13 @@ export interface HubClient {
         inputSchema?: Record<string, unknown>;
         deprecatedSince?: string;
       }>;
+      vaults?: Array<{
+        slug: string;
+        uuid: string;
+        path: string;
+        fileCount: number;
+        indexedAt: string | null;
+      }>;
       resources?: {
         cpuUsage?: number;
         cpuCount?: number;

--- a/src/hub/hub-sync.test.ts
+++ b/src/hub/hub-sync.test.ts
@@ -48,6 +48,10 @@ vi.mock('../daemon/actions.js', () => ({
   getActionRegistry: vi.fn(() => ({ list: () => [] })),
 }));
 
+vi.mock('../vaults/instance.js', () => ({
+  getVaultRegistry: vi.fn(() => ({ metadata: async () => [] })),
+}));
+
 vi.mock('../daemon/metrics.js', () => ({
   collectMachineMetrics: vi.fn().mockResolvedValue({
     cpuUsage: 12.3,
@@ -260,6 +264,57 @@ describe('hub-sync', () => {
           loadAvg15m: 0.9,
         },
       });
+    });
+
+    it('omits vaults key when no vaults registered', async () => {
+      mockReadAuth.mockReturnValue(testAuth);
+      mockGetAgents.mockReturnValue([] as ReturnType<typeof getAgents>);
+      mockGetRuns.mockReturnValue([] as ReturnType<typeof getRuns>);
+      mockLoadProjects.mockReturnValue([]);
+
+      const sync = createHubSync();
+      await sync.start();
+      await sync.triggerHeartbeat();
+
+      const call = mockHubClient.heartbeat.mock.calls[0][1] as Record<string, unknown>;
+      expect(call.vaults).toBeUndefined();
+    });
+
+    it('includes vault metadata in heartbeat when vaults registered', async () => {
+      const { getVaultRegistry } = await import('../vaults/instance.js');
+      vi.mocked(getVaultRegistry).mockReturnValueOnce({
+        metadata: async () => [
+          {
+            slug: 'notes',
+            uuid: 'b6377f6d-ae6e-40b6-9435-48f3414374ed',
+            path: '/home/u/notes',
+            fileCount: 42,
+            indexedAt: '2026-04-25T01:19:33.453Z',
+          },
+        ],
+      } as unknown as ReturnType<typeof getVaultRegistry>);
+
+      mockReadAuth.mockReturnValue(testAuth);
+      mockGetAgents.mockReturnValue([] as ReturnType<typeof getAgents>);
+      mockGetRuns.mockReturnValue([] as ReturnType<typeof getRuns>);
+      mockLoadProjects.mockReturnValue([]);
+
+      const sync = createHubSync();
+      await sync.start();
+      await sync.triggerHeartbeat();
+
+      const call = mockHubClient.heartbeat.mock.calls[0][1] as {
+        vaults?: Array<Record<string, unknown>>;
+      };
+      expect(call.vaults).toEqual([
+        {
+          slug: 'notes',
+          uuid: 'b6377f6d-ae6e-40b6-9435-48f3414374ed',
+          path: '/home/u/notes',
+          fileCount: 42,
+          indexedAt: '2026-04-25T01:19:33.453Z',
+        },
+      ]);
     });
 
     it('includes daemon action capabilities in heartbeat payload', async () => {

--- a/src/hub/hub-sync.ts
+++ b/src/hub/hub-sync.ts
@@ -10,6 +10,7 @@ import { cancelRun, sendInput, getRuns } from '../daemon/run-manager.js';
 import { getScheduler } from '../daemon/scheduler.js';
 import { getActionRegistry } from '../daemon/actions.js';
 import { loadProjects } from '../projects/projects.js';
+import { getVaultRegistry } from '../vaults/instance.js';
 
 import { collectMachineMetrics } from '../daemon/metrics.js';
 import { VERSION } from '../utils/version.js';
@@ -125,6 +126,15 @@ export const createHubSync = (): HubSync => {
         ...(m.deprecatedSince && { deprecatedSince: m.deprecatedSince }),
       }));
 
+    let vaults: Awaited<ReturnType<ReturnType<typeof getVaultRegistry>['metadata']>> = [];
+    try {
+      vaults = await getVaultRegistry().metadata();
+    } catch (err) {
+      logWarn(
+        `[hub-sync] vault metadata collection failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
     const response = await hubClient.heartbeat(auth.hub.machineId, {
       agents,
       projects,
@@ -133,6 +143,7 @@ export const createHubSync = (): HubSync => {
       agentsDefault: config.agents.default,
       projectsDefault: config.projects.default,
       actions,
+      ...(vaults.length > 0 && { vaults }),
       ...(resources && { resources }),
     });
 


### PR DESCRIPTION
## Summary

PR 4a of 2 — daemon side. Daemon now collects \`getVaultRegistry().metadata()\` and ships it on every heartbeat as \`vaults: VaultMetadata[]\` so the hub knows which vaults exist on each machine.

Hub-side counterpart (Zod schema acceptance + persistence + dashboard render) ships in the companion PR on agentage/web.

## Wire shape per vault

\`\`\`ts
{ slug, uuid, path, fileCount, indexedAt: string | null }
\`\`\`

## Behavior

- Omitted from the payload when no vaults registered (clean wire for users not using vaults).
- Wrapped in try/catch — a broken VaultRegistry never breaks the heartbeat itself; emits a \`logWarn\` and ships an empty list.
- Symmetric with the existing \`actions\` and \`resources\` patterns.

## Tests

- 2 new hub-sync tests:
  - \`omits vaults key when no vaults registered\` — proves the spread guard
  - \`includes vault metadata in heartbeat when vaults registered\` — full payload shape
- All 647 existing tests still pass.

## Pairs with

- agentage/web PR (separate link) — adds Zod acceptance, machines.vaults JSONB column, and \`/dashboard/vaults\` page

## Test plan

- [ ] \`npm run verify\` passes
- [ ] After web side merges + deploys: real daemon heartbeat at 30s interval populates \`machines.vaults\` row in the hub DB