### PR TITLE
fix(daemon): validate config.json + migrate legacy discovery.dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Bug Fixes
+- Validate `~/.agentage/config.json` shape at load and rewrite the file when it
+  is malformed, partial, or carries a foreign schema. Previously a desktop-era
+  or hand-edited file could spread an underspecified object into the daemon
+  config and crash at runtime.
+
+### Migration
+- `discovery.dirs` (cli@<0.18) is now auto-migrated into the new
+  `agents.default` / `agents.additional` shape on first load. Old paths are
+  preserved as `agents.additional` entries so custom search paths survive the
+  upgrade. No user action required; the next daemon start rewrites
+  `config.json` in the new format.
+
 ## [0.22.1] - 2026-04-25
 
 ### New Features

--- a/src/daemon/config.test.ts
+++ b/src/daemon/config.test.ts
@@ -216,4 +216,84 @@ describe('config', () => {
     config.projects.additional = ['/b', '/a'];
     expect(getProjectsDirs(config)).toEqual(['/a', '/b']);
   });
+
+  // -------------------------------------------------------------------------
+  // Schema validation — mirrors cli#108 (loadProjects auto-rewrite). A foreign
+  // or malformed config.json must not crash the daemon; load returns a valid
+  // config and rewrites the file.
+  // -------------------------------------------------------------------------
+
+  it('rewrites config.json when JSON is malformed', async () => {
+    writeFileSync(join(testDir, 'config.json'), '{ this is not json');
+
+    const { loadConfig } = await import('./config.js');
+    const config = loadConfig();
+
+    expect(config.daemon.port).toBe(4243);
+    expect(config.agents.default).toBe(join(homedir(), 'agents'));
+
+    const rewritten = JSON.parse(readFileSync(join(testDir, 'config.json'), 'utf-8'));
+    expect(rewritten.daemon.port).toBe(4243);
+    expect(Array.isArray(rewritten.agents.additional)).toBe(true);
+  });
+
+  it('rewrites config.json when shape is partial / foreign', async () => {
+    writeFileSync(
+      join(testDir, 'config.json'),
+      JSON.stringify({ unrelated: 'shape', no_agents: true }) + '\n'
+    );
+
+    const { loadConfig } = await import('./config.js');
+    const config = loadConfig();
+
+    expect(config.agents.default).toBe(join(homedir(), 'agents'));
+    expect(config.projects.default).toBe(join(homedir(), 'projects'));
+    expect(config.daemon.port).toBe(4243);
+
+    const rewritten = JSON.parse(readFileSync(join(testDir, 'config.json'), 'utf-8'));
+    expect(rewritten.daemon.port).toBe(4243);
+    expect(rewritten.agents).toBeDefined();
+  });
+
+  it('migrates legacy discovery.dirs into agents.additional', async () => {
+    writeFileSync(
+      join(testDir, 'config.json'),
+      JSON.stringify({
+        machine: { id: 'legacy', name: 'old' },
+        discovery: { dirs: ['/opt/custom-agents', '/srv/team-agents'] },
+      }) + '\n'
+    );
+
+    const { loadConfig } = await import('./config.js');
+    const config = loadConfig();
+
+    expect(config.agents.default).toBe(join(homedir(), 'agents'));
+    expect(config.agents.additional).toEqual(['/opt/custom-agents', '/srv/team-agents']);
+    expect(config.projects.default).toBe(join(homedir(), 'projects'));
+    expect(config.projects.additional).toEqual([]);
+
+    // Persisted in the new shape — `discovery.dirs` is gone.
+    const rewritten = JSON.parse(readFileSync(join(testDir, 'config.json'), 'utf-8'));
+    expect(rewritten.discovery).toBeUndefined();
+    expect(rewritten.agents.additional).toEqual(['/opt/custom-agents', '/srv/team-agents']);
+  });
+
+  it('valid config is loaded as-is without rewrite churn', async () => {
+    const valid = {
+      machine: { id: 'stable-id', name: 'host' },
+      daemon: { port: 4243 },
+      agents: { default: '/a', additional: [] },
+      projects: { default: '/p', additional: [] },
+      sync: { events: {} },
+    };
+    writeFileSync(join(testDir, 'config.json'), JSON.stringify(valid, null, 2) + '\n');
+    writeFileSync(join(testDir, 'machine.json'), JSON.stringify(valid.machine, null, 2) + '\n');
+    const before = readFileSync(join(testDir, 'config.json'), 'utf-8');
+
+    const { loadConfig } = await import('./config.js');
+    loadConfig();
+
+    const after = readFileSync(join(testDir, 'config.json'), 'utf-8');
+    expect(after).toBe(before);
+  });
 });

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -131,19 +131,80 @@ const createDefaultConfig = (machine: MachineIdentity): DaemonConfig => ({
   },
 });
 
+const isDirConfig = (value: unknown): value is DirConfig => {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as { default?: unknown; additional?: unknown };
+  return (
+    typeof v.default === 'string' &&
+    Array.isArray(v.additional) &&
+    v.additional.every((d) => typeof d === 'string')
+  );
+};
+
+const isValidConfigShape = (value: unknown): value is Partial<DaemonConfig> => {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Partial<DaemonConfig>;
+  // daemon.port must be a number
+  if (typeof v.daemon !== 'object' || v.daemon === null || typeof v.daemon.port !== 'number') {
+    return false;
+  }
+  if (!isDirConfig(v.agents)) return false;
+  if (!isDirConfig(v.projects)) return false;
+  if (typeof v.sync !== 'object' || v.sync === null) return false;
+  return true;
+};
+
+/**
+ * Migrate legacy `discovery.dirs` (singular config from cli@<0.18) into the
+ * current `agents.default` / `projects.default` shape. The old format
+ * carried a flat list of directories; we keep them as `agents.additional`
+ * so users don't lose their custom search paths after upgrading.
+ */
+const tryMigrateLegacyDiscovery = (raw: unknown): Partial<DaemonConfig> | undefined => {
+  if (typeof raw !== 'object' || raw === null) return undefined;
+  const v = raw as { discovery?: { dirs?: unknown } };
+  if (!v.discovery || !Array.isArray(v.discovery.dirs)) return undefined;
+  const dirs = v.discovery.dirs.filter((d): d is string => typeof d === 'string');
+  if (dirs.length === 0) return undefined;
+  return {
+    agents: { default: getDefaultAgentsDir(), additional: dirs },
+    projects: { default: getDefaultProjectsDir(), additional: [] },
+  };
+};
+
 export const loadConfig = (): DaemonConfig => {
   const configPath = join(getConfigDir(), 'config.json');
 
-  let rawConfig: Partial<DaemonConfig> | undefined;
+  let rawConfig: unknown;
   if (existsSync(configPath)) {
-    rawConfig = JSON.parse(readFileSync(configPath, 'utf-8')) as Partial<DaemonConfig>;
+    try {
+      rawConfig = JSON.parse(readFileSync(configPath, 'utf-8'));
+    } catch {
+      // Malformed JSON — treat as missing; we'll regenerate below.
+      rawConfig = undefined;
+    }
   }
 
-  const machine = resolveMachine(rawConfig?.machine);
+  const legacyMachine =
+    typeof rawConfig === 'object' && rawConfig !== null
+      ? (rawConfig as Partial<DaemonConfig>).machine
+      : undefined;
+  const machine = resolveMachine(legacyMachine);
 
-  const config: DaemonConfig = rawConfig
-    ? ({ ...rawConfig, machine } as DaemonConfig)
-    : createDefaultConfig(machine);
+  // Foreign schema (e.g. cli@<0.18 `discovery.dirs`, desktop-era files,
+  // partial writes) — migrate if we recognise it, otherwise rewrite from
+  // defaults. Either way, the on-disk file ends up valid and the daemon
+  // never spreads an underspecified object into a `DaemonConfig`.
+  let config: DaemonConfig;
+  if (rawConfig !== undefined && isValidConfigShape(rawConfig)) {
+    config = { ...(rawConfig as DaemonConfig), machine };
+  } else {
+    const migrated = tryMigrateLegacyDiscovery(rawConfig);
+    config = migrated
+      ? { ...createDefaultConfig(machine), ...migrated, machine }
+      : createDefaultConfig(machine);
+    saveConfig(config);
+  }
 
   if (!existsSync(configPath)) {
     saveConfig(config);


### PR DESCRIPTION
## Summary
Mirrors cli#108 (loadProjects auto-rewrite) for \`config.json\`. The previous loader spread a partial / desktop-era / hand-edited file into a \`DaemonConfig\` with an unsafe \`as\` cast, which crashed at runtime when downstream code touched the missing fields.

- New \`isValidConfigShape()\` type guard validates \`daemon.port\`, \`agents.{default,additional}\`, \`projects.{default,additional}\`, and \`sync\`.
- Foreign / partial / malformed \`config.json\` triggers a one-shot rewrite with \`createDefaultConfig()\` so subsequent operations work.
- New \`tryMigrateLegacyDiscovery()\` recognises the cli@<0.18 \`discovery.dirs\` shape and lifts those paths into \`agents.additional\`, then persists the new shape — custom search paths survive the upgrade. No user action required.
- 4 new vitest cases cover malformed JSON, partial / foreign shape, legacy migration, and zero-churn for already-valid configs.
- \`CHANGELOG.md\` gets **Bug Fixes** + **Migration** entries under \`[Unreleased]\`.

## Test plan
- [x] \`npm test -- --run src/daemon/config.test.ts\` — 22 passed (18 existing + 4 new).
- [x] \`npm run type-check\` clean.
- [x] \`npm run lint\` clean.
- [ ] Smoke a fresh \`agentage status\` against a config.json that contains \`discovery.dirs\` to verify migration in place.

## Notes
The pre-existing \`src/discovery/watcher.test.ts\` flake (timer-sensitive fs watcher) is unrelated and reproduces on plain master — tracked separately in cli#165.