### PR TITLE
feat(daemon): AGENTAGE_BIND_HOST option (security-by-default loopback)

### DIFF
--- a/src/daemon/config.test.ts
+++ b/src/daemon/config.test.ts
@@ -179,6 +179,39 @@ describe('config', () => {
     delete process.env['AGENTAGE_PORT'];
   });
 
+  it('getBindHost defaults to 127.0.0.1 when daemon.bindHost is unset', async () => {
+    const { loadConfig, getBindHost } = await import('./config.js');
+    const config = loadConfig();
+    expect(getBindHost(config)).toBe('127.0.0.1');
+  });
+
+  it('getBindHost returns daemon.bindHost when set in config', async () => {
+    const { loadConfig, getBindHost, saveConfig } = await import('./config.js');
+    const config = loadConfig();
+    config.daemon.bindHost = '0.0.0.0';
+    saveConfig(config);
+    const reloaded = loadConfig();
+    expect(getBindHost(reloaded)).toBe('0.0.0.0');
+  });
+
+  it('AGENTAGE_BIND_HOST overrides daemon.bindHost (in-memory, not persisted)', async () => {
+    process.env['AGENTAGE_BIND_HOST'] = '192.168.1.5';
+    const { loadConfig, getBindHost, saveConfig } = await import('./config.js');
+    const config = loadConfig();
+    expect(getBindHost(config)).toBe('192.168.1.5');
+
+    // Persisted config still reflects the on-disk value (undefined here)
+    const raw = readFileSync(join(testDir, 'config.json'), 'utf-8');
+    const saved = JSON.parse(raw);
+    expect(saved.daemon.bindHost).toBeUndefined();
+
+    delete process.env['AGENTAGE_BIND_HOST'];
+    // Re-save without the env var so subsequent tests see clean config
+    const cleanConfig = loadConfig();
+    delete cleanConfig.daemon.bindHost;
+    saveConfig(cleanConfig);
+  });
+
   it('AGENTAGE_AGENTS_DIR overrides agents.default (in-memory, not persisted)', async () => {
     process.env['AGENTAGE_AGENTS_DIR'] = '/tmp/custom-agents';
     const { loadConfig } = await import('./config.js');

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -29,6 +29,14 @@ export interface DaemonConfig {
   machine: MachineIdentity;
   daemon: {
     port: number;
+    /**
+     * Host interface the daemon binds to. Defaults to '127.0.0.1'
+     * (loopback only — no LAN/network access). Set to '0.0.0.0' to
+     * expose to all interfaces (e.g. for tailscale, LAN testing).
+     * The daemon has no auth on its action endpoints, so non-loopback
+     * binding is opt-in.
+     */
+    bindHost?: string;
   };
   hub?: {
     url: string;
@@ -40,6 +48,11 @@ export interface DaemonConfig {
     events: SyncEvents;
   };
 }
+
+export const DEFAULT_BIND_HOST = '127.0.0.1';
+
+export const getBindHost = (config: DaemonConfig): string =>
+  config.daemon.bindHost ?? DEFAULT_BIND_HOST;
 
 export const getVaultStorageDir = (): string => join(getConfigDir(), 'vaults');
 
@@ -213,6 +226,11 @@ export const loadConfig = (): DaemonConfig => {
   const portOverride = process.env['AGENTAGE_PORT'];
   if (portOverride) {
     config.daemon.port = parseInt(portOverride, 10);
+  }
+
+  const bindHostOverride = process.env['AGENTAGE_BIND_HOST'];
+  if (bindHostOverride) {
+    config.daemon.bindHost = bindHostOverride;
   }
 
   const agentsOverride = process.env['AGENTAGE_AGENTS_DIR'];

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -1,7 +1,7 @@
 import { createServer, type Server } from 'node:http';
 import express from 'express';
 import { type Agent, type AgentFactory } from '@agentage/core';
-import { loadConfig, getAgentsDirs } from './config.js';
+import { loadConfig, getAgentsDirs, getBindHost } from './config.js';
 import { logInfo } from './logger.js';
 import { createRoutes, setAgents, setRefreshHandler } from './routes.js';
 import { setupWebSocket } from './websocket.js';
@@ -38,6 +38,7 @@ export const createDaemonServer = (): DaemonServer => {
   const start = async (): Promise<void> => {
     const config = loadConfig();
     const port = config.daemon.port;
+    const host = getBindHost(config);
 
     return new Promise((resolve, reject) => {
       server.on('error', (err: NodeJS.ErrnoException) => {
@@ -48,8 +49,8 @@ export const createDaemonServer = (): DaemonServer => {
         }
       });
 
-      server.listen(port, () => {
-        logInfo(`Daemon server listening on port ${port}`);
+      server.listen(port, host, () => {
+        logInfo(`Daemon server listening on ${host}:${port}`);
         resolve();
       });
     });


### PR DESCRIPTION
## Summary

The daemon's \`server.listen(port)\` call had no host arg, so Node bound to all interfaces (\`0.0.0.0\`/\`*\`) by default. Combined with the fact that vault and agent action endpoints have **no auth** (capability headers are informational, not enforced at the wire), every personal-mesh daemon was exposed to its entire LAN.

This PR tightens the default to \`127.0.0.1\` (loopback only) and adds an opt-in escape hatch.

## Surface

- \`DaemonConfig.daemon.bindHost?: string\` — persisted in config.json
- \`AGENTAGE_BIND_HOST\` env var — runtime override, in-memory only (matches \`AGENTAGE_PORT\` semantics — never written to disk)
- \`getBindHost(config)\` helper — single source of truth (env > config > \`127.0.0.1\`)
- \`server.listen(port, host, ...)\` — passes the resolved host

## Use cases

| Scenario | Setting |
|---|---|
| Default (most users) | nothing — daemon is loopback-only |
| Test from another machine on LAN | \`AGENTAGE_BIND_HOST=0.0.0.0\` |
| Bind only to a tailscale IP | \`AGENTAGE_BIND_HOST=100.x.y.z\` |
| Permanent setup | \`config.json: { "daemon": { "port": 4243, "bindHost": "0.0.0.0" } }\` |

## Migration impact

Users who were relying on the daemon being accessible over LAN without explicit configuration will hit "connection refused" until they set \`AGENTAGE_BIND_HOST=0.0.0.0\`. The break is intentional — it's the prompt to think about whether you want to expose the unauthenticated control plane.

## Tests (3 new)

- \`getBindHost\` defaults to 127.0.0.1
- \`getBindHost\` reads \`daemon.bindHost\` from config when set
- \`AGENTAGE_BIND_HOST\` overrides config value, in-memory only (verifies the env var doesn't persist to disk)

Pre-existing \`watcher.test.ts\` flake unaffected (same 2 failures on master).

## Pairs with

- agentage/mcp PR (config-port-resolution fix) — together they unblock proper \`AGENTAGE_CONFIG_DIR\` isolation for testing/multi-daemon setups, which is what surfaced both bugs in the vault smoke test.

## Test plan

- [x] \`npm run verify\` passes (652 tests, 2 pre-existing watcher flakes)
- [ ] Smoke: \`agentage daemon restart\`, \`ss -tnlp | grep 4243\` shows \`127.0.0.1:4243\` (was \`*:4243\`)
- [ ] \`AGENTAGE_BIND_HOST=0.0.0.0 agentage daemon restart\`, \`ss -tnlp\` shows \`*:4243\`
- [ ] From another LAN host: \`curl http://<host>:4243/api/health\` returns OK after the env override