### PR TITLE
feat(setup): auto-register vaults from ~/projects/vaults + heartbeat the parent dir

### DIFF
--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -8,6 +8,12 @@ vi.mock('../daemon/config.js', () => ({
   loadConfig: vi.fn(),
   saveConfig: vi.fn(),
   getConfigDir: vi.fn(),
+  getDefaultVaultsDir: vi.fn(
+    (cfg?: { vaultsDefault?: string }) =>
+      process.env['AGENTAGE_DEFAULT_VAULTS_DIR'] ||
+      cfg?.vaultsDefault ||
+      '/nonexistent-default-vaults'
+  ),
 }));
 
 vi.mock('../utils/ensure-daemon.js', () => ({
@@ -33,6 +39,10 @@ vi.mock('open', () => ({
   default: vi.fn(),
 }));
 
+vi.mock('../utils/action-client.js', () => ({
+  invokeAction: vi.fn(),
+}));
+
 const mockQuestion = vi.fn();
 vi.mock('node:readline/promises', () => ({
   createInterface: () => ({
@@ -45,6 +55,7 @@ import { loadConfig, saveConfig, getConfigDir } from '../daemon/config.js';
 import { readAuth, saveAuth, deleteAuth } from '../hub/auth.js';
 import { startCallbackServer, getCallbackPort } from '../hub/auth-callback.js';
 import { createHubClient } from '../hub/hub-client.js';
+import { invokeAction } from '../utils/action-client.js';
 import { registerSetup } from './setup.js';
 
 const mockLoadConfig = vi.mocked(loadConfig);
@@ -56,6 +67,7 @@ const mockDeleteAuth = vi.mocked(deleteAuth);
 const mockStartCallback = vi.mocked(startCallbackServer);
 const mockGetCallbackPort = vi.mocked(getCallbackPort);
 const mockCreateHubClient = vi.mocked(createHubClient);
+const mockInvokeAction = vi.mocked(invokeAction);
 
 const baseConfig = () => ({
   machine: { id: 'machine-existing-1', name: 'test-host' },
@@ -447,6 +459,238 @@ describe('setup command', () => {
       registerSetup(cleanProgram);
 
       await expect(cleanProgram.parseAsync(['node', 'agentage', 'logout'])).rejects.toThrow();
+    });
+  });
+
+  describe('vault step (multi-vault directory scan)', () => {
+    let vaultsParent: string;
+
+    beforeEach(() => {
+      vaultsParent = mkdtempSync(join(tmpdir(), 'agentage-vaults-parent-'));
+      process.env['AGENTAGE_DEFAULT_VAULTS_DIR'] = vaultsParent;
+    });
+
+    afterEach(() => {
+      delete process.env['AGENTAGE_DEFAULT_VAULTS_DIR'];
+      rmSync(vaultsParent, { recursive: true, force: true });
+    });
+
+    it('auto-registers each subdirectory in the vaults dir as a vault', async () => {
+      const { mkdirSync: mk } = await import('node:fs');
+      mk(join(vaultsParent, 'notes'), { recursive: true });
+      mk(join(vaultsParent, 'work'), { recursive: true });
+
+      mockInvokeAction.mockImplementation(async (_name, input) => {
+        const i = input as { path: string };
+        return {
+          slug: i.path.endsWith('notes') ? 'notes' : 'work',
+          uuid: `uuid-${i.path}`,
+          path: i.path,
+          fileCount: i.path.endsWith('notes') ? 5 : 12,
+        };
+      });
+
+      try {
+        await program.parseAsync(['node', 'agentage', 'setup', '--token', 't1']);
+      } catch {
+        // ignore exitOverride
+      }
+
+      const calledPaths = mockInvokeAction.mock.calls.map((c) => (c[1] as { path: string }).path);
+      expect(calledPaths.sort()).toEqual([join(vaultsParent, 'notes'), join(vaultsParent, 'work')]);
+    });
+
+    it('skips dotfiles and non-directories under the vaults dir', async () => {
+      const { mkdirSync: mk } = await import('node:fs');
+      mk(join(vaultsParent, '.hidden'), { recursive: true });
+      mk(join(vaultsParent, 'real'), { recursive: true });
+      writeFileSync(join(vaultsParent, 'NOT-A-DIR.md'), 'x');
+
+      mockInvokeAction.mockResolvedValue({
+        slug: 'real',
+        uuid: 'u',
+        path: join(vaultsParent, 'real'),
+        fileCount: 0,
+      });
+
+      try {
+        await program.parseAsync(['node', 'agentage', 'setup', '--token', 't1']);
+      } catch {}
+
+      expect(mockInvokeAction).toHaveBeenCalledTimes(1);
+      const call = mockInvokeAction.mock.calls[0];
+      expect((call?.[1] as { path: string }).path).toBe(join(vaultsParent, 'real'));
+    });
+
+    it('silently skips already-registered subdirs on re-run', async () => {
+      const { mkdirSync: mk } = await import('node:fs');
+      mk(join(vaultsParent, 'notes'), { recursive: true });
+
+      mockInvokeAction.mockRejectedValueOnce(
+        new Error('action vault:add failed: INVALID_INPUT: vault "notes" already exists')
+      );
+      const errLogs: string[] = [];
+      const errSpy = vi.spyOn(console, 'error').mockImplementation((m) => {
+        errLogs.push(String(m));
+      });
+
+      try {
+        await program.parseAsync(['node', 'agentage', 'setup', '--token', 't1']);
+      } catch {}
+
+      // "already exists" must not produce a warning
+      expect(errLogs.some((l) => l.includes('already exists'))).toBe(false);
+      expect(errLogs.some((l) => l.includes('vault scan'))).toBe(false);
+      errSpy.mockRestore();
+    });
+
+    it('--no-vault skips the scan entirely', async () => {
+      const { mkdirSync: mk } = await import('node:fs');
+      mk(join(vaultsParent, 'notes'), { recursive: true });
+
+      try {
+        await program.parseAsync(['node', 'agentage', 'setup', '--token', 't1', '--no-vault']);
+      } catch {}
+      expect(mockInvokeAction).not.toHaveBeenCalled();
+    });
+
+    it('--vault <path> adds an extra vault on top of the dir scan', async () => {
+      const { mkdirSync: mk } = await import('node:fs');
+      mk(join(vaultsParent, 'notes'), { recursive: true });
+      const extra = mkdtempSync(join(tmpdir(), 'agentage-extra-'));
+
+      try {
+        mockInvokeAction.mockResolvedValue({
+          slug: 'x',
+          uuid: 'u',
+          path: '',
+          fileCount: 0,
+        });
+
+        try {
+          await program.parseAsync([
+            'node',
+            'agentage',
+            'setup',
+            '--token',
+            't1',
+            '--vault',
+            extra,
+            '--vault-slug',
+            'extra',
+          ]);
+        } catch {}
+
+        const paths = mockInvokeAction.mock.calls.map((c) => (c[1] as { path: string }).path);
+        expect(paths).toContain(join(vaultsParent, 'notes'));
+        expect(paths).toContain(extra);
+
+        const extraCall = mockInvokeAction.mock.calls.find(
+          (c) => (c[1] as { path: string }).path === extra
+        );
+        expect((extraCall?.[1] as { slug?: string }).slug).toBe('extra');
+      } finally {
+        rmSync(extra, { recursive: true, force: true });
+      }
+    });
+
+    it('--vaults-dir overrides the default and persists to config', async () => {
+      const customDir = mkdtempSync(join(tmpdir(), 'agentage-custom-vaults-'));
+      try {
+        const { mkdirSync: mk } = await import('node:fs');
+        mk(join(customDir, 'a'), { recursive: true });
+
+        mockInvokeAction.mockResolvedValue({
+          slug: 'a',
+          uuid: 'u',
+          path: join(customDir, 'a'),
+          fileCount: 0,
+        });
+
+        try {
+          await program.parseAsync([
+            'node',
+            'agentage',
+            'setup',
+            '--token',
+            't1',
+            '--vaults-dir',
+            customDir,
+          ]);
+        } catch {}
+
+        // Persisted into config.vaultsDefault via saveConfig
+        const lastSave = mockSaveConfig.mock.calls.at(-1);
+        expect((lastSave?.[0] as { vaultsDefault?: string }).vaultsDefault).toBe(customDir);
+      } finally {
+        rmSync(customDir, { recursive: true, force: true });
+      }
+    });
+
+    it('--reauth skips vault step (only fresh mode auto-registers)', async () => {
+      const { mkdirSync: mk } = await import('node:fs');
+      mk(join(vaultsParent, 'notes'), { recursive: true });
+
+      mockReadAuth.mockReturnValue({
+        session: { access_token: 'tok', refresh_token: '', expires_at: 0 },
+        user: { id: 'u', email: 'u@example.com' },
+        hub: { url: 'https://h.example.com', machineId: 'm-1' },
+      });
+
+      try {
+        await program.parseAsync(['node', 'agentage', 'setup', '--reauth', '--token', 't2']);
+      } catch {}
+      expect(mockInvokeAction).not.toHaveBeenCalled();
+    });
+
+    it('JSON output includes vaults.defaultDir + vaults.registered', async () => {
+      const { mkdirSync: mk } = await import('node:fs');
+      mk(join(vaultsParent, 'notes'), { recursive: true });
+
+      mockInvokeAction.mockResolvedValueOnce({
+        slug: 'notes',
+        uuid: 'json-uuid',
+        path: join(vaultsParent, 'notes'),
+        fileCount: 3,
+      });
+
+      const logs: string[] = [];
+      const logSpy = vi.spyOn(console, 'log').mockImplementation((m) => {
+        logs.push(String(m));
+      });
+
+      try {
+        await program.parseAsync(['node', 'agentage', 'setup', '--token', 't1', '--json']);
+      } catch {}
+
+      const jsonLog = logs.find((l) => l.startsWith('{'));
+      expect(jsonLog).toBeDefined();
+      const parsed = JSON.parse(jsonLog as string);
+      expect(parsed.vaults.defaultDir).toBe(vaultsParent);
+      expect(parsed.vaults.registered).toHaveLength(1);
+      expect(parsed.vaults.registered[0]).toMatchObject({
+        slug: 'notes',
+        uuid: 'json-uuid',
+        fileCount: 3,
+      });
+      logSpy.mockRestore();
+    });
+
+    it('absent vaults dir → no action calls, no warning', async () => {
+      // Point env to a non-existent path
+      process.env['AGENTAGE_DEFAULT_VAULTS_DIR'] = '/this/path/does/not/exist';
+      const errLogs: string[] = [];
+      const errSpy = vi.spyOn(console, 'error').mockImplementation((m) => {
+        errLogs.push(String(m));
+      });
+
+      try {
+        await program.parseAsync(['node', 'agentage', 'setup', '--token', 't1']);
+      } catch {}
+
+      expect(mockInvokeAction).not.toHaveBeenCalled();
+      expect(errLogs.some((l) => l.toLowerCase().includes('vault'))).toBe(false);
+      errSpy.mockRestore();
     });
   });
 });

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,5 +1,5 @@
 import { type Command } from 'commander';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import { hostname } from 'node:os';
 import { join, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -11,10 +11,13 @@ import {
   loadConfig,
   saveConfig,
   getConfigDir,
+  getDefaultVaultsDir,
   type DaemonConfig,
   type MachineIdentity,
 } from '../daemon/config.js';
+import type { VaultAddOutput } from '../daemon/actions/vault-add.js';
 import { ensureDaemon } from '../utils/ensure-daemon.js';
+import { invokeAction } from '../utils/action-client.js';
 import { readAuth, saveAuth, deleteAuth, type AuthState } from '../hub/auth.js';
 import { startCallbackServer, getCallbackPort } from '../hub/auth-callback.js';
 import { createHubClient } from '../hub/hub-client.js';
@@ -43,6 +46,9 @@ export interface SetupOptions {
   json?: boolean;
   mcp?: boolean;
   mcpStyle?: McpCommandStyle;
+  vault?: string | boolean;
+  vaultSlug?: string;
+  vaultsDir?: string;
 }
 
 type SetupMode = 'fresh' | 'reauth' | 'disconnect' | 'standalone' | 'idempotent';
@@ -260,12 +266,104 @@ const printIdempotent = (
   );
 };
 
+/**
+ * Resolve which vault to register during setup, mirroring how
+ * agents.default / projects.default work — the path is auto-applied
+ * without prompting:
+ *   - --no-vault                → skip entirely
+ *   - --vault <path>            → register that explicit path
+ *   - default                   → register getDefaultVaultPath() if it exists
+ *                                 on disk; otherwise skip silently (no warning)
+ *
+ * Failures from the daemon (slug clash, etc.) emit a warning but
+ * never crash setup.
+ */
+interface VaultStepResult {
+  registered: VaultAddOutput[];
+  vaultsDir: string;
+}
+
+/**
+ * Auto-register vaults during setup — no prompting, mirrors how
+ * agents.default / projects.default work:
+ *
+ *   1. --no-vault                 → skip entirely
+ *   2. --vaults-dir <path>        → persist as config.vaultsDefault
+ *   3. Scan getDefaultVaultsDir() → each subdirectory becomes one vault.
+ *      Slug clashes (already-registered) are silent re-runs. Per-subdir
+ *      failures get dim warnings; the loop continues.
+ *   4. --vault <path>             → register an additional explicit vault
+ *      (--vault-slug overrides slug for this one only).
+ *
+ * Returns the parent dir + every successfully-registered vault. The
+ * dir gets shipped on heartbeat (`vaultsDefault`) so the hub knows
+ * where the user keeps vaults even when the registry is empty.
+ */
+const runVaultStep = async (opts: SetupOptions, mode: SetupMode): Promise<VaultStepResult> => {
+  const empty: VaultStepResult = { registered: [], vaultsDir: '' };
+  if (opts.vault === false) return empty;
+  if (mode !== 'fresh') return empty;
+
+  if (typeof opts.vaultsDir === 'string' && opts.vaultsDir.length > 0) {
+    const cfg = loadConfig();
+    cfg.vaultsDefault = resolve(opts.vaultsDir);
+    saveConfig(cfg);
+  }
+
+  const vaultsDir = getDefaultVaultsDir(loadConfig());
+  const registered: VaultAddOutput[] = [];
+
+  if (existsSync(vaultsDir) && statSync(vaultsDir).isDirectory()) {
+    const entries = readdirSync(vaultsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name.startsWith('.')) continue;
+      const subPath = join(vaultsDir, entry.name);
+      try {
+        const result = await invokeAction<VaultAddOutput>('vault:add', { path: subPath }, [
+          'vault.admin',
+        ]);
+        registered.push(result);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (!/already exists/i.test(msg)) {
+          console.error(chalk.dim(`  vault scan: ${entry.name} skipped (${msg})`));
+        }
+      }
+    }
+  }
+
+  if (typeof opts.vault === 'string' && opts.vault.length > 0) {
+    const absPath = resolve(opts.vault);
+    if (!existsSync(absPath) || !statSync(absPath).isDirectory()) {
+      console.error(
+        chalk.yellow(`--vault path "${absPath}" is not a directory — skipping vault registration.`)
+      );
+    } else {
+      try {
+        const result = await invokeAction<VaultAddOutput>(
+          'vault:add',
+          { path: absPath, ...(opts.vaultSlug && { slug: opts.vaultSlug }) },
+          ['vault.admin']
+        );
+        registered.push(result);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(chalk.yellow(`Vault registration skipped: ${msg}`));
+      }
+    }
+  }
+
+  return { registered, vaultsDir };
+};
+
 const printSummary = (
   config: DaemonConfig,
   mode: SetupMode,
   userEmail: string | null,
   opts: SetupOptions,
-  mcp: TargetResult[] | null
+  mcp: TargetResult[] | null,
+  vaultStep: VaultStepResult
 ): void => {
   if (opts.json) {
     console.log(
@@ -281,6 +379,15 @@ const printSummary = (
           },
           agentsDir: config.agents.default,
           mcp,
+          vaults: {
+            defaultDir: vaultStep.vaultsDir || null,
+            registered: vaultStep.registered.map((v) => ({
+              slug: v.slug,
+              uuid: v.uuid,
+              path: v.path,
+              fileCount: v.fileCount,
+            })),
+          },
         },
         null,
         2
@@ -293,6 +400,15 @@ const printSummary = (
   console.log(`  Hub:        ${config.hub?.url ?? '(none)'}`);
   console.log(`  Agents dir: ${config.agents.default}`);
   if (userEmail) console.log(`  User:       ${userEmail}`);
+  if (vaultStep.vaultsDir) {
+    console.log(`  Vaults dir: ${vaultStep.vaultsDir}`);
+  }
+  if (vaultStep.registered.length > 0) {
+    const summary = vaultStep.registered
+      .map((v) => `${v.slug} ${chalk.dim(`(${v.fileCount})`)}`)
+      .join(', ');
+    console.log(`  Vaults:     ${summary}`);
+  }
   if (mcp && mcp.length > 0) {
     console.log(chalk.bold('\nMCP clients:'));
     printMcpResults(mcp);
@@ -390,7 +506,9 @@ export const runSetup = async (opts: SetupOptions): Promise<void> => {
     }
   }
 
-  printSummary(config, mode, userEmail, opts, mcp);
+  const vaultStep = await runVaultStep(opts, mode);
+
+  printSummary(config, mode, userEmail, opts, mcp, vaultStep);
   process.exit(0);
 };
 
@@ -411,6 +529,16 @@ export const registerSetup = (program: Command): void => {
     .option('--force', 'Overwrite existing machine identity on rename')
     .option('--no-mcp', 'Skip the user-scope MCP wiring stage (~/.claude.json). Fresh mode only.')
     .option('--mcp-style <style>', 'MCP command style: `npx` (default) or `binary`')
+    .option(
+      '--vaults-dir <path>',
+      'Parent dir holding vaults (default: ~/projects/vaults). Each subdir = one vault. Persisted to config.'
+    )
+    .option('--vault <path>', 'Register an additional vault outside the vaults-dir.')
+    .option(
+      '--vault-slug <slug>',
+      'Override the slug for the --vault explicit add (basename otherwise).'
+    )
+    .option('--no-vault', 'Skip the vault step entirely (no auto-scan, no explicit add).')
     .option('--json', 'JSON output')
     .action(async (opts: SetupOptions) => {
       await runSetup(opts);

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -44,6 +44,14 @@ export interface DaemonConfig {
   agents: DirConfig;
   projects: DirConfig;
   vaults?: Record<string, VaultConfig>;
+  /**
+   * Parent directory holding multiple vaults (one subdirectory = one vault).
+   * Default `~/projects/vaults`. Set during `agentage setup --vaults-dir`
+   * or by editing config.json. Env var AGENTAGE_DEFAULT_VAULTS_DIR
+   * overrides at runtime. Hub heartbeat ships this value as `vaultsDefault`
+   * so the dashboard knows where the user keeps vaults.
+   */
+  vaultsDefault?: string;
   sync: {
     events: SyncEvents;
   };
@@ -66,6 +74,20 @@ export const getConfigDir = (): string => {
 
 export const getDefaultAgentsDir = (): string => join(homedir(), 'agents');
 export const getDefaultProjectsDir = (): string => join(homedir(), 'projects');
+
+/**
+ * Resolve the parent directory holding the user's vaults, with this priority:
+ *   1. AGENTAGE_DEFAULT_VAULTS_DIR (env, runtime override)
+ *   2. config.vaultsDefault (persistent, set by `agentage setup --vaults-dir`)
+ *   3. ~/projects/vaults (built-in default)
+ *
+ * Each subdirectory under this path is treated as one vault during
+ * `agentage setup` auto-registration.
+ */
+export const getDefaultVaultsDir = (config?: DaemonConfig): string =>
+  process.env['AGENTAGE_DEFAULT_VAULTS_DIR'] ||
+  config?.vaultsDefault ||
+  join(homedir(), 'projects', 'vaults');
 
 export const getAgentsDirs = (config: DaemonConfig): string[] => {
   const all = [config.agents.default, ...config.agents.additional];

--- a/src/hub/hub-client.ts
+++ b/src/hub/hub-client.ts
@@ -25,6 +25,7 @@ export interface HubClient {
       daemonVersion: string;
       agentsDefault?: string;
       projectsDefault?: string;
+      vaultsDefault?: string;
       actions?: Array<{
         name: string;
         version: string;

--- a/src/hub/hub-sync.test.ts
+++ b/src/hub/hub-sync.test.ts
@@ -24,6 +24,7 @@ vi.mock('../daemon/logger.js', () => ({
 
 vi.mock('../daemon/config.js', () => ({
   loadConfig: vi.fn(),
+  getDefaultVaultsDir: vi.fn(() => '/tmp/test-vaults-default'),
 }));
 
 vi.mock('../daemon/routes.js', () => ({
@@ -251,6 +252,7 @@ describe('hub-sync', () => {
         daemonVersion: '0.7.1',
         agentsDefault: '/tmp/agents',
         projectsDefault: '/tmp/projects',
+        vaultsDefault: '/tmp/test-vaults-default',
         actions: [],
         resources: {
           cpuUsage: 12.3,

--- a/src/hub/hub-sync.ts
+++ b/src/hub/hub-sync.ts
@@ -1,5 +1,5 @@
 import { platform, arch } from 'node:os';
-import { loadConfig } from '../daemon/config.js';
+import { loadConfig, getDefaultVaultsDir } from '../daemon/config.js';
 import { type AuthState, readAuth, saveAuth } from './auth.js';
 import { createHubClient, type HubClient } from './hub-client.js';
 import { createHubWs, type HubWs } from './hub-ws.js';
@@ -135,6 +135,8 @@ export const createHubSync = (): HubSync => {
       );
     }
 
+    const vaultsDefault = getDefaultVaultsDir(config);
+
     const response = await hubClient.heartbeat(auth.hub.machineId, {
       agents,
       projects,
@@ -142,6 +144,7 @@ export const createHubSync = (): HubSync => {
       daemonVersion: VERSION,
       agentsDefault: config.agents.default,
       projectsDefault: config.projects.default,
+      vaultsDefault,
       actions,
       ...(vaults.length > 0 && { vaults }),
       ...(resources && { resources }),


### PR DESCRIPTION
## Summary

Replaces the earlier prompt-based vault step with **directory-scan auto-registration**, mirroring how \`agents.default\` and \`projects.default\` work — no asking, just sensible defaults. Multi-vault from day 1.

## Behavior

- Setup scans \`getDefaultVaultsDir()\` (default \`~/projects/vaults\`) and registers **every subdirectory** as a vault. Slug = subdir basename. Each subdir = one vault.
- Already-registered subdirs on a re-run are silently re-used (no warning spam). Other per-subdir failures get dim warnings; the loop continues.
- Parent-dir path ships in every heartbeat as \`vaultsDefault\` (next to existing \`agentsDefault\` / \`projectsDefault\`) so the hub knows where vaults live even when none are registered yet.

## Configurability — three layers, env wins

| Source | Description |
|---|---|
| \`AGENTAGE_DEFAULT_VAULTS_DIR\` | Env, runtime override |
| \`config.vaultsDefault\` | Persisted; set via \`--vaults-dir\` flag or hand-edited config.json |
| \`~/projects/vaults\` | Built-in default |

## CLI flags

| Flag | Behavior |
|---|---|
| \`--vaults-dir <path>\` | Parent dir holding vaults; **persisted to config** |
| \`--vault <path>\` | Register an additional explicit vault outside the vaults-dir |
| \`--vault-slug <slug>\` | Override slug for the \`--vault\` explicit add |
| \`--no-vault\` | Skip the vault step entirely |

## Output

CLI summary:
\`\`\`
Agentage configured:
  Machine:    home-pc (3b0c9962)
  Hub:        https://agentage.io
  Agents dir: /home/u/agents
  User:       u@example.com
  Vaults dir: /home/u/projects/vaults
  Vaults:     notes (143), work (12)
\`\`\`

JSON summary:
\`\`\`json
{
  ...,
  "vaults": {
    "defaultDir": "/home/u/projects/vaults",
    "registered": [
      { "slug": "notes", "uuid": "...", "path": "...", "fileCount": 143 },
      { "slug": "work",  "uuid": "...", "path": "...", "fileCount":  12 }
    ]
  }
}
\`\`\`

## Tests (9 new)

- Dir-scan registers every subdirectory
- Dotfiles + non-directories under the parent dir are skipped
- \`already exists\` errors on re-run are silenced (no warning)
- \`--no-vault\` skips the scan entirely
- \`--vault\` adds an extra vault on top of the dir scan
- \`--vaults-dir\` persists to \`config.vaultsDefault\`
- \`--reauth\` skips the step (only fresh mode auto-registers)
- JSON output includes \`vaults.defaultDir\` + \`vaults.registered[]\`
- Absent vaults dir → no action calls, no warning

Plus existing \`hub-sync.test.ts\` extended to assert \`vaultsDefault\` is in the heartbeat payload.

**663/663 tests pass.** Pre-existing 2 \`watcher.test.ts\` flakes confirmed on master, unrelated.

## Pairs with

A follow-up agentage/web PR will accept \`vaultsDefault\` in \`HeartbeatSchema\` + persist on the machine row, so the dashboard can show "where this user keeps vaults" alongside the registered list.

## Test plan

- [x] \`npm run verify\` passes
- [ ] Smoke: \`mkdir -p /tmp/vaults-test/{notes,work} && AGENTAGE_DEFAULT_VAULTS_DIR=/tmp/vaults-test agentage setup --token <t>\` → confirms both subdirs auto-register
- [ ] Smoke: re-run the same command → "already exists" silently skipped (no nag)
- [ ] Smoke: \`agentage setup --token <t> --vaults-dir /tmp/elsewhere\` → config.json gets \`vaultsDefault: "/tmp/elsewhere"\`
- [ ] Confirm next heartbeat in daemon logs / hub shows \`vaultsDefault\` field