### PR TITLE
fix(cli): suppress update-available notice on non-TTY stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Bug Fixes
+- Update-available notice no longer corrupts non-interactive output. The
+  notice is now suppressed when stdout is not a TTY (CI, pipes, `--json`
+  consumers), and respects the `NO_UPDATE_NOTIFIER` environment variable
+  to match the npm convention. Previously the trailing message could get
+  appended to JSON output and break downstream parsers.
+
 ## [0.24.0] - 2026-04-25
 
 ### New Features

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,16 +44,25 @@ registerProjects(program);
 registerSchedules(program);
 registerVaults(program);
 
+// Show the update notice only on an interactive terminal. Appending it to
+// non-TTY stdout (CI, pipes, `--json` consumers) corrupts machine-readable
+// output — the e2e nightly's standalone suite hit exactly this when
+// `latest` advanced past the installed version mid-run. The user can also
+// opt out explicitly with NO_UPDATE_NOTIFIER (matching the npm convention).
+const shouldShowUpdateNotice = (): boolean =>
+  process.stdout.isTTY === true && !process.env['NO_UPDATE_NOTIFIER'];
+
 program.parseAsync().then(async () => {
-  // Show update notice if a newer version is available
-  const result = await updateCheckPromise;
-  if (result?.updateAvailable) {
-    const { default: chalk } = await import('chalk');
-    console.log(
-      chalk.yellow(
-        `\nUpdate available: ${result.currentVersion} → ${result.latestVersion} — run ${chalk.white('agentage update')} to install.`
-      )
-    );
+  if (shouldShowUpdateNotice()) {
+    const result = await updateCheckPromise;
+    if (result?.updateAvailable) {
+      const { default: chalk } = await import('chalk');
+      console.log(
+        chalk.yellow(
+          `\nUpdate available: ${result.currentVersion} → ${result.latestVersion} — run ${chalk.white('agentage update')} to install.`
+        )
+      );
+    }
   }
 
   // Force exit — forked daemon process can keep the event loop alive


### PR DESCRIPTION
## Root cause
The update-available notice in \`src/cli.ts\` was printed unconditionally after every command, including those that emit JSON. Master nightly run [24930173231](https://github.com/agentage/e2e/actions/runs/24930173231) hit this when \`latest\` advanced from 0.23.0 to 0.24.0 mid-run: every standalone \`--json\` test (config Y2/Y3/Y4, tables T2, whoami W2/W3, etc.) failed with:

\`\`\`
SyntaxError: Unexpected non-whitespace character after JSON at position 615 (line 31 column 1)
\`\`\`

Hex-dumping the local repro of cli@0.23.0 with 0.24.0 \`latest\` confirmed the trailing bytes:

\`\`\`
}.}..Update available: 0.23.0 .... 0.24.0 .... run agentage update to install..
\`\`\`

## Fix
- Skip the notice unless \`process.stdout.isTTY === true\`. Pipes and CI no longer get the trailing line.
- Respect \`NO_UPDATE_NOTIFIER=1\` for an explicit opt-out (matches the npm convention).
- Logic moved into a small \`shouldShowUpdateNotice()\` helper to keep the parseAsync callback readable.

Hex-dump after the fix: \`}.}.\` — the JSON closes cleanly when piped.

## Test plan
- [x] \`npm run type-check\` clean.
- [x] \`npm run lint\` clean.
- [x] \`npm test\` — 663/663 passed.
- [x] Manual: built dist, ran \`AGENTAGE_CONFIG_DIR=… node dist/cli.js config list --json\` piped, verified no notice in stdout.
- [ ] After 0.24.1 publishes, dispatch nightly E2E and confirm the standalone JSON suite is green.

## Pairs with
- e2e#42 — patches the docker driver to set \`AGENTAGE_BIND_HOST=0.0.0.0\` (separate cli@0.23 regression from cli#167).