### PR TITLE
Release v0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.24.1] - 2026-04-25
+
+### Bug Fixes
+- Fix update notification appearing when CLI output is redirected or piped to other commands
+
 ## [Unreleased]
 
 ### Bug Fixes

--- a/changelog-content.md
+++ b/changelog-content.md
@@ -1,3 +1,2 @@
-### New Features
-- Add automatic vault registration from ~/projects/vaults directory during setup
-- Add heartbeat monitoring for parent directories
+### Bug Fixes
+- Fix update notification appearing when CLI output is redirected or piped to other commands

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentage/cli",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentage/cli",
-      "version": "0.24.0",
+      "version": "0.24.1",
       "license": "MIT",
       "dependencies": {
         "@agentage/core": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentage/cli",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Agentage CLI and daemon — control plane for AI agents",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release v0.24.1

Patch release covering two stability fixes that landed on master after v0.24.0:

### Bug Fixes
- **Update notice no longer corrupts `--json` output** (#171). The "Update available" banner is now suppressed when stdout is not a TTY (CI, pipes, `--json` consumers) and respects `NO_UPDATE_NOTIFIER`. Caused mid-run nightly failures when `latest` advanced past the installed version.

### Checklist
- [x] Review the changelog
- [x] Verify version numbers are correct
- [ ] Merge when ready to release

---

Once merged, this will automatically:
1. Create a git tag `v0.24.1`
2. Trigger the publish workflow
3. Publish to npm with provenance

> Note: the `Prepare Release` workflow pushed this branch but its `gh pr create` step failed with HTTP 401 (RELEASE_PAT looks expired). Branch + commit are already correct; this PR was opened manually.