### PR TITLE
fix(hub-ws): pre-register run listeners to close startRun race

### DIFF
--- a/src/hub/hub-ws.ts
+++ b/src/hub/hub-ws.ts
@@ -1,4 +1,5 @@
 import WebSocket from 'ws';
+import type { Run, RunEvent } from '@agentage/core';
 import { logInfo, logError } from '../daemon/logger.js';
 import { getAgents } from '../daemon/routes.js';
 import {
@@ -63,51 +64,88 @@ export const createHubWs = (
       return;
     }
 
+    // Listeners must be attached BEFORE awaiting startRun. run-manager fires
+    // its first state transition ('submitted' → 'working') and may stream
+    // result/completed events synchronously inside startRun for fast agents
+    // (e.g. shell echo). If we wait for startRun to resolve before subscribing,
+    // those terminal events are missed and the hub's runs row is stuck at
+    // 'working' forever. See e2e#46.
+    //
+    // Because we don't yet know the localRunId at subscription time, we buffer
+    // any events received before startRun resolves and replay them once the id
+    // is known.
+    const TERMINAL_STATES = ['completed', 'failed', 'canceled'];
+    const unsubs: Array<() => void> = [];
+    let localRunId: string | null = null;
+    const pendingEvents: Array<{ eventRunId: string; event: RunEvent }> = [];
+    const pendingStates: Run[] = [];
+
+    const cleanupRunListeners = (): void => {
+      for (const fn of unsubs) fn();
+      unsubs.length = 0;
+    };
+
+    unsubs.push(
+      onRunEvent((eventRunId, event) => {
+        if (localRunId === null) {
+          pendingEvents.push({ eventRunId, event });
+          return;
+        }
+        if (eventRunId === localRunId) {
+          send({ type: 'run_event', runId: msg.runId ?? localRunId, event });
+        }
+      })
+    );
+
+    unsubs.push(
+      onRunStateChange((run) => {
+        if (localRunId === null) {
+          pendingStates.push(run);
+          return;
+        }
+        if (run.id === localRunId) {
+          send({
+            type: 'run_state',
+            runId: msg.runId ?? localRunId,
+            state: run.state,
+            error: run.error,
+            stats: run.stats,
+          });
+          if (TERMINAL_STATES.includes(run.state)) cleanupRunListeners();
+        }
+      })
+    );
+
+    eventUnsubscribers.push(cleanupRunListeners);
+
     try {
-      const localRunId = await startRun(agent, msg.input.task, msg.input.config, msg.input.context);
+      localRunId = await startRun(agent, msg.input.task, msg.input.config, msg.input.context);
       // Use hub's runId for all messages back to hub, local ID for matching events
       const hubRunId = msg.runId ?? localRunId;
       send({ type: 'execute_accepted', requestId: msg.requestId, runId: hubRunId });
 
-      // Subscribe to run events and stream to hub
-      // Match by localRunId (what run-manager emits), send with hubRunId (what hub expects)
-      const TERMINAL_STATES = ['completed', 'failed', 'canceled'];
-      const unsubs: Array<() => void> = [];
-
-      const cleanupRunListeners = (): void => {
-        for (const fn of unsubs) fn();
-        unsubs.length = 0;
-      };
-
-      unsubs.push(
-        onRunEvent((eventRunId, event) => {
-          if (eventRunId === localRunId) {
-            send({ type: 'run_event', runId: hubRunId, event });
-          }
-        })
-      );
-
-      unsubs.push(
-        onRunStateChange((run) => {
-          if (run.id === localRunId) {
-            send({
-              type: 'run_state',
-              runId: hubRunId,
-              state: run.state,
-              error: run.error,
-              stats: run.stats,
-            });
-
-            // Unsubscribe on terminal state to prevent listener accumulation
-            if (TERMINAL_STATES.includes(run.state)) {
-              cleanupRunListeners();
-            }
-          }
-        })
-      );
-
-      eventUnsubscribers.push(cleanupRunListeners);
+      // Drain anything that arrived before localRunId was known.
+      for (const { eventRunId, event } of pendingEvents) {
+        if (eventRunId === localRunId) {
+          send({ type: 'run_event', runId: hubRunId, event });
+        }
+      }
+      pendingEvents.length = 0;
+      for (const run of pendingStates) {
+        if (run.id === localRunId) {
+          send({
+            type: 'run_state',
+            runId: hubRunId,
+            state: run.state,
+            error: run.error,
+            stats: run.stats,
+          });
+          if (TERMINAL_STATES.includes(run.state)) cleanupRunListeners();
+        }
+      }
+      pendingStates.length = 0;
     } catch (err) {
+      cleanupRunListeners();
       send({
         type: 'execute_rejected',
         requestId: msg.requestId,


### PR DESCRIPTION
## Summary

Closes the listener-registration race in \`src/hub/hub-ws.ts\` that caused hub-dispatched runs to get stuck at \`working\` forever for fast agents.

Root cause discovered while triaging [e2e#46](https://github.com/agentage/e2e/issues/46) (SCH-2 scheduler E2E test): \`handleExecute\` awaited \`startRun\` **before** attaching its \`onRunEvent\` / \`onRunStateChange\` listeners. \`run-manager\` fires the first state transition (\`submitted\` → \`working\`) and may stream the entire \`result\` / \`completed\` sequence synchronously inside \`startRun\` for shell-style agents — by the time the hub listeners attached, terminal state had already been emitted and was lost.

## Symptom

\`runScheduleNow\` (or any hub-WS-dispatched run) returned a runId successfully, but the runs row never advanced past \`working\`. Manual \`agentage run\` was unaffected — it uses the daemon's local SSE/HTTP channel, not the hub WS path.

## Fix

Attach \`onRunEvent\` / \`onRunStateChange\` listeners **before** awaiting \`startRun\`. Because \`localRunId\` is not known yet at subscription time, events that arrive in the brief window between subscription and \`startRun\` resolution are buffered, then replayed against \`localRunId\` once it is known. Non-matching buffered events are discarded.

## Tests

- \`hub-ws.test.ts\` smoke tests pass (2/2)
- Full unit suite: 662 passed (1 unrelated \`ensure-daemon.test.ts\` flake, tracked separately)
- **The load-bearing regression guard is e2e SCH-2** — currently \`test.fixme\`'d (e2e#45). After this lands and cli@0.24.2 publishes, e2e SCH-2 should be un-\`fixme\`'d in a follow-up PR.

## Risk

The fix touches the hub→daemon execute path that all hub-dispatched runs flow through. If the buffer/replay logic has a bug, runs could be double-emitted (replayed plus live), spam the hub, or get cleaned up early. I checked:

- \`cleanupRunListeners()\` only fires on terminal state, after the matching \`localRunId\` filter — safe.
- Replay loop sends each buffered event at most once and clears the buffer.
- Non-matching events buffered during the window (from other concurrent runs) are filtered out at replay time and discarded.

## Test plan

- [x] \`npm run type-check\` clean
- [x] \`npm test\` 662 passing
- [ ] PR validation green
- [ ] After release: e2e nightly with \`SCH-2\` un-\`fixme\`'d passes both drivers