### PR TITLE
Release v0.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.24.2] - 2026-04-25
+
+### Bug Fixes
+- Fix race condition in agent run initialization that could cause missed status updates
+
 ## [0.24.1] - 2026-04-25
 
 ### Bug Fixes

--- a/changelog-content.md
+++ b/changelog-content.md
@@ -1,2 +1,2 @@
 ### Bug Fixes
-- Fix update notification appearing when CLI output is redirected or piped to other commands
+- Fix race condition in agent run initialization that could cause missed status updates

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentage/cli",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentage/cli",
-      "version": "0.24.1",
+      "version": "0.24.2",
       "license": "MIT",
       "dependencies": {
         "@agentage/core": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentage/cli",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Agentage CLI and daemon — control plane for AI agents",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release v0.24.2

Patch release: closes the hub-WS listener race that caused hub-dispatched runs to get stuck at \`working\` for fast agents.

### Bug Fixes
- **hub-ws: pre-register run listeners to close startRun race** (#173). Listeners are now attached before \`startRun\` is awaited; events arriving in the brief window before \`localRunId\` is known are buffered and replayed. Fixes hub-dispatched runs (e.g. \`runScheduleNow\`, scheduled triggers) that previously never reached terminal state for shell-style agents. Diagnosed via e2e#46.

### Checklist
- [x] Review the changelog
- [x] Verify version numbers are correct
- [ ] Merge when ready to release

---

Once merged, this will automatically:
1. Create a git tag \`v0.24.2\`
2. Trigger the publish workflow
3. Publish to npm with provenance

> Note: the Prepare Release workflow's \`gh pr create\` step 401'd again (RELEASE_PAT still expired — same blocker as #172). This PR was opened manually. Please rotate RELEASE_PAT in agentage/cli secrets.