### PR TITLE
fix(hub): treat refresh-token 400 as terminal and surface authExpired

### DIFF
--- a/src/daemon/routes.actions.test.ts
+++ b/src/daemon/routes.actions.test.ts
@@ -21,6 +21,7 @@ vi.mock('../hub/hub-sync.js', () => ({
   getHubSync: () => ({
     isConnected: () => false,
     isConnecting: () => false,
+    isAuthExpired: () => false,
     start: vi.fn(),
     stop: vi.fn(),
     triggerHeartbeat: vi.fn().mockResolvedValue(undefined),

--- a/src/daemon/routes.test.ts
+++ b/src/daemon/routes.test.ts
@@ -96,6 +96,7 @@ describe('daemon routes', () => {
     mockGetHubSync.mockReturnValue({
       isConnected: () => false,
       isConnecting: () => false,
+      isAuthExpired: () => false,
       start: vi.fn(),
       stop: vi.fn(),
       triggerHeartbeat: vi.fn().mockResolvedValue(undefined),

--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -53,6 +53,7 @@ export const createRoutes = (): Router => {
       machineId: config.machine.id,
       hubConnected: hubSync.isConnected(),
       hubConnecting: hubSync.isConnecting(),
+      authExpired: hubSync.isAuthExpired(),
       hubUrl: auth?.hub?.url ?? null,
       userEmail: auth?.user?.email ?? null,
     });

--- a/src/hub/hub-client.test.ts
+++ b/src/hub/hub-client.test.ts
@@ -12,6 +12,7 @@ vi.mock('../daemon/logger.js', () => ({
 import { saveAuth } from './auth.js';
 import { createHubClient, type HubClient } from './hub-client.js';
 import { type AuthState } from './auth.js';
+import { AuthExpiredError } from './token-refresh.js';
 
 const mockSaveAuth = vi.mocked(saveAuth);
 
@@ -259,12 +260,63 @@ describe('hub-client', () => {
       expect(fetchMock).toHaveBeenCalledTimes(4);
     });
 
-    it('does not refresh when no refresh_token', async () => {
+    it('throws AuthExpiredError when no refresh_token is available', async () => {
       auth = makeAuth({ session: { access_token: 'tk', refresh_token: '', expires_at: 0 } });
       client = createHubClient('https://hub.test', auth);
 
       mockFetchError('Unauthorized', 401);
 
+      await expect(client.getMachines()).rejects.toBeInstanceOf(AuthExpiredError);
+    });
+
+    it('throws AuthExpiredError when refresh endpoint returns terminal status', async () => {
+      const fetchMock = vi
+        .fn()
+        // Initial request → 401
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          json: async () => ({ success: false, error: 'Unauthorized' }),
+        })
+        // Health check (refresh path)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            success: true,
+            data: { supabaseUrl: 'https://supabase.test', supabaseAnonKey: 'key' },
+          }),
+        })
+        // Token refresh → 400 (terminal)
+        .mockResolvedValueOnce({ ok: false, status: 400 });
+
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(client.getMachines()).rejects.toBeInstanceOf(AuthExpiredError);
+    });
+
+    it('returns false (transient) when refresh endpoint returns 5xx', async () => {
+      const fetchMock = vi
+        .fn()
+        // Initial request → 401
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          json: async () => ({ success: false, error: 'Unauthorized' }),
+        })
+        // Health check (refresh path)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            success: true,
+            data: { supabaseUrl: 'https://supabase.test', supabaseAnonKey: 'key' },
+          }),
+        })
+        // Token refresh → 503 (transient)
+        .mockResolvedValueOnce({ ok: false, status: 503 });
+
+      vi.stubGlobal('fetch', fetchMock);
+
+      // Refresh fails non-terminally → original 401 error surfaces (not AuthExpiredError)
       await expect(client.getMachines()).rejects.toThrow('Hub API error (401)');
     });
   });

--- a/src/hub/hub-client.ts
+++ b/src/hub/hub-client.ts
@@ -1,5 +1,6 @@
 import { type AuthState, saveAuth } from './auth.js';
 import { logInfo, logWarn } from '../daemon/logger.js';
+import { AuthExpiredError, isTerminalRefreshStatus } from './token-refresh.js';
 
 export interface HubClient {
   register: (machineData: {
@@ -96,7 +97,9 @@ export interface HubClient {
 }
 
 const refreshAccessToken = async (hubUrl: string, auth: AuthState): Promise<boolean> => {
-  if (!auth.session.refresh_token) return false;
+  if (!auth.session.refresh_token) {
+    throw new AuthExpiredError('no_refresh_token');
+  }
 
   try {
     const healthRes = await fetch(`${hubUrl}/api/health`);
@@ -114,7 +117,12 @@ const refreshAccessToken = async (hubUrl: string, auth: AuthState): Promise<bool
       body: JSON.stringify({ refresh_token: auth.session.refresh_token }),
     });
 
-    if (!res.ok) return false;
+    if (!res.ok) {
+      if (isTerminalRefreshStatus(res.status)) {
+        throw new AuthExpiredError(`status_${res.status}`);
+      }
+      return false;
+    }
 
     const data = (await res.json()) as {
       access_token: string;
@@ -129,7 +137,8 @@ const refreshAccessToken = async (hubUrl: string, auth: AuthState): Promise<bool
 
     logInfo('Token refreshed successfully');
     return true;
-  } catch {
+  } catch (err) {
+    if (err instanceof AuthExpiredError) throw err;
     logWarn('Token refresh failed');
     return false;
   }

--- a/src/hub/hub-sync.test.ts
+++ b/src/hub/hub-sync.test.ts
@@ -17,9 +17,18 @@ vi.mock('./reconnection.js', () => ({
   createReconnector: vi.fn(),
 }));
 
+vi.mock('./token-refresh.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof TokenRefreshModule>();
+  return {
+    ...actual,
+    refreshTokenIfNeeded: vi.fn().mockResolvedValue({ ok: true }),
+  };
+});
+
 vi.mock('../daemon/logger.js', () => ({
   logInfo: vi.fn(),
   logWarn: vi.fn(),
+  logError: vi.fn(),
 }));
 
 vi.mock('../daemon/config.js', () => ({
@@ -70,11 +79,13 @@ vi.mock('../daemon/metrics.js', () => ({
 import { readAuth } from './auth.js';
 import { createHubClient } from './hub-client.js';
 import { createHubWs } from './hub-ws.js';
-import { createReconnector } from './reconnection.js';
+import { createReconnector, type ReconnectorOptions } from './reconnection.js';
 import { loadConfig } from '../daemon/config.js';
 import { getAgents } from '../daemon/routes.js';
 import { cancelRun, sendInput, getRuns } from '../daemon/run-manager.js';
 import { loadProjects } from '../projects/projects.js';
+import type * as TokenRefreshModule from './token-refresh.js';
+import { AuthExpiredError, refreshTokenIfNeeded } from './token-refresh.js';
 import { createHubSync, resetHubSync, getHubSync } from './hub-sync.js';
 
 const mockLoadProjects = vi.mocked(loadProjects);
@@ -111,6 +122,7 @@ describe('hub-sync', () => {
   let mockWs: { connect: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> };
   let mockReconnector: { start: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> };
   let capturedOnConnect: (() => void) | undefined;
+  let capturedReconnectorOpts: ReconnectorOptions | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -140,9 +152,11 @@ describe('hub-sync', () => {
       capturedOnConnect = onConnect;
       return mockWs as unknown as ReturnType<typeof createHubWs>;
     });
-    mockCreateReconnector.mockReturnValue(
-      mockReconnector as unknown as ReturnType<typeof createReconnector>
-    );
+    capturedReconnectorOpts = undefined;
+    mockCreateReconnector.mockImplementation((opts) => {
+      capturedReconnectorOpts = opts;
+      return mockReconnector as unknown as ReturnType<typeof createReconnector>;
+    });
     mockLoadConfig.mockReturnValue({ ...testConfig, sync: { events: {} } } as unknown as ReturnType<
       typeof loadConfig
     >);
@@ -445,6 +459,79 @@ describe('hub-sync', () => {
 
       // Should not throw
       await sync.triggerHeartbeat();
+    });
+  });
+
+  describe('auth expired', () => {
+    it('marks authExpired when initial connection throws AuthExpiredError', async () => {
+      mockReadAuth.mockReturnValue(testAuth);
+      mockHubClient.register.mockRejectedValue(new AuthExpiredError('status_400'));
+
+      const sync = createHubSync();
+      await sync.start();
+
+      expect(sync.isAuthExpired()).toBe(true);
+      expect(sync.isConnected()).toBe(false);
+      expect(sync.isConnecting()).toBe(false);
+      // Reconnector must NOT be started — the error is non-recoverable
+      expect(mockReconnector.start).not.toHaveBeenCalled();
+    });
+
+    it('reconnector onError returns { stop: true } for AuthExpiredError', async () => {
+      mockReadAuth.mockReturnValue(testAuth);
+      const sync = createHubSync();
+      await sync.start();
+      capturedOnConnect?.();
+
+      expect(capturedReconnectorOpts).toBeDefined();
+
+      const result = capturedReconnectorOpts!.onError?.(new AuthExpiredError('status_403'));
+
+      expect(result).toEqual({ stop: true });
+      expect(sync.isAuthExpired()).toBe(true);
+      expect(sync.isConnected()).toBe(false);
+      expect(mockReconnector.stop).toHaveBeenCalled();
+    });
+
+    it('reconnector onError returns void for transient errors', async () => {
+      mockReadAuth.mockReturnValue(testAuth);
+      const sync = createHubSync();
+      await sync.start();
+      capturedOnConnect?.();
+
+      const result = capturedReconnectorOpts!.onError?.(new Error('timeout'));
+
+      expect(result).toBeUndefined();
+      expect(sync.isAuthExpired()).toBe(false);
+    });
+
+    it('isAuthExpired defaults to false', async () => {
+      mockReadAuth.mockReturnValue(null);
+      const sync = createHubSync();
+      await sync.start();
+      expect(sync.isAuthExpired()).toBe(false);
+    });
+
+    it('stops heartbeat loop when refreshTokenIfNeeded returns terminal', async () => {
+      mockReadAuth.mockReturnValue(testAuth);
+      vi.mocked(refreshTokenIfNeeded).mockResolvedValueOnce({
+        ok: false,
+        terminal: true,
+        reason: 'status_400',
+      });
+
+      const sync = createHubSync();
+      await sync.start();
+      capturedOnConnect?.();
+
+      // Advance fake timer to fire scheduled heartbeat
+      await vi.advanceTimersByTimeAsync(30_000);
+      // Yield microtasks so the async heartbeat handler completes
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(sync.isAuthExpired()).toBe(true);
+      expect(sync.isConnected()).toBe(false);
     });
   });
 

--- a/src/hub/hub-sync.ts
+++ b/src/hub/hub-sync.ts
@@ -4,7 +4,7 @@ import { type AuthState, readAuth, saveAuth } from './auth.js';
 import { createHubClient, type HubClient } from './hub-client.js';
 import { createHubWs, type HubWs } from './hub-ws.js';
 import { createReconnector, type Reconnector } from './reconnection.js';
-import { logInfo, logWarn } from '../daemon/logger.js';
+import { logError, logInfo, logWarn } from '../daemon/logger.js';
 import { getAgents } from '../daemon/routes.js';
 import { cancelRun, sendInput, getRuns } from '../daemon/run-manager.js';
 import { getScheduler } from '../daemon/scheduler.js';
@@ -14,7 +14,7 @@ import { getVaultRegistry } from '../vaults/instance.js';
 
 import { collectMachineMetrics } from '../daemon/metrics.js';
 import { VERSION } from '../utils/version.js';
-import { refreshTokenIfNeeded } from './token-refresh.js';
+import { AuthExpiredError, refreshTokenIfNeeded } from './token-refresh.js';
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
 
@@ -23,6 +23,7 @@ export interface HubSync {
   stop: () => Promise<void>;
   isConnected: () => boolean;
   isConnecting: () => boolean;
+  isAuthExpired: () => boolean;
   triggerHeartbeat: () => Promise<void>;
 }
 
@@ -33,6 +34,20 @@ export const createHubSync = (): HubSync => {
   let reconnector: Reconnector | null = null;
   let connected = false;
   let connecting = false;
+  let authExpired = false;
+
+  const markAuthExpired = (err: AuthExpiredError): void => {
+    if (authExpired) return;
+    authExpired = true;
+    connected = false;
+    connecting = false;
+    if (heartbeatTimer) {
+      clearTimeout(heartbeatTimer);
+      heartbeatTimer = null;
+    }
+    reconnector?.stop();
+    logError(`[hub-sync] ${err.message}`);
+  };
 
   const connectAll = async (auth: AuthState): Promise<void> => {
     const config = loadConfig();
@@ -185,9 +200,16 @@ export const createHubSync = (): HubSync => {
     const scheduleNext = (): void => {
       heartbeatTimer = setTimeout(async () => {
         try {
-          await refreshTokenIfNeeded();
+          const refresh = await refreshTokenIfNeeded();
+          if (!refresh.ok && refresh.terminal) {
+            throw new AuthExpiredError(refresh.reason);
+          }
           await sendHeartbeat(auth);
         } catch (err) {
+          if (err instanceof AuthExpiredError) {
+            markAuthExpired(err);
+            return; // do not reschedule — terminal
+          }
           logWarn(`Heartbeat failed: ${err instanceof Error ? err.message : String(err)}`);
         }
         // Schedule next heartbeat AFTER current one finishes (no overlap)
@@ -212,9 +234,14 @@ export const createHubSync = (): HubSync => {
           startHeartbeat(auth);
         },
         onError: (err) => {
+          if (err instanceof AuthExpiredError) {
+            markAuthExpired(err);
+            return { stop: true };
+          }
           logWarn(
             `Hub connection failed: ${err instanceof Error ? err.message : String(err)}. Retrying...`
           );
+          return undefined;
         },
       });
 
@@ -223,6 +250,10 @@ export const createHubSync = (): HubSync => {
         startHeartbeat(auth);
         logInfo(`Connected to hub at ${auth.hub.url}`);
       } catch (err) {
+        if (err instanceof AuthExpiredError) {
+          markAuthExpired(err);
+          return;
+        }
         logWarn(
           `Initial hub connection failed: ${err instanceof Error ? err.message : String(err)}. Will retry.`
         );
@@ -267,6 +298,7 @@ export const createHubSync = (): HubSync => {
 
     isConnected: () => connected,
     isConnecting: () => connecting,
+    isAuthExpired: () => authExpired,
 
     triggerHeartbeat: async () => {
       const auth = readAuth();

--- a/src/hub/reconnection.test.ts
+++ b/src/hub/reconnection.test.ts
@@ -33,4 +33,45 @@ describe('Reconnection', () => {
     // Should not throw or call onReconnect after stop
     expect(true).toBe(true);
   });
+
+  test('terminates retry loop when onError returns { stop: true }', async () => {
+    const onReconnect = vi.fn().mockRejectedValue(new Error('terminal'));
+    const onError = vi.fn(() => ({ stop: true }) as { stop: boolean });
+    const reconnector = createReconnector({
+      onReconnect,
+      onError,
+      initialDelayMs: 5,
+    });
+
+    reconnector.start();
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+    // Wait long enough that a retry would have fired if not stopped
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    reconnector.stop();
+  });
+
+  test('keeps retrying when onError returns void', async () => {
+    let calls = 0;
+    const onReconnect = vi.fn(async () => {
+      calls += 1;
+      if (calls < 3) throw new Error('transient');
+    });
+    const onError = vi.fn();
+    const reconnector = createReconnector({
+      onReconnect,
+      onError,
+      initialDelayMs: 5,
+    });
+
+    reconnector.start();
+
+    await vi.waitFor(() => expect(onReconnect).toHaveBeenCalledTimes(3), { timeout: 1000 });
+    expect(onError).toHaveBeenCalledTimes(2);
+
+    reconnector.stop();
+  });
 });

--- a/src/hub/reconnection.ts
+++ b/src/hub/reconnection.ts
@@ -8,7 +8,9 @@ export interface ReconnectorOptions {
   initialDelayMs?: number;
   maxDelayMs?: number;
   onReconnect: () => Promise<void>;
-  onError?: (err: unknown) => void;
+  // Return `{ stop: true }` to terminate the retry loop (non-recoverable error,
+  // e.g. expired refresh token). Returning void/undefined keeps retrying.
+  onError?: (err: unknown) => { stop?: boolean } | void;
 }
 
 export const createReconnector = (opts: ReconnectorOptions): Reconnector => {
@@ -28,7 +30,12 @@ export const createReconnector = (opts: ReconnectorOptions): Reconnector => {
       currentDelay = initialDelay;
       running = false;
     } catch (err) {
-      opts.onError?.(err);
+      const result = opts.onError?.(err);
+      if (result?.stop) {
+        stopped = true;
+        running = false;
+        return;
+      }
       timer = setTimeout(() => {
         attempt();
       }, currentDelay);

--- a/src/hub/token-refresh.test.ts
+++ b/src/hub/token-refresh.test.ts
@@ -12,7 +12,12 @@ vi.mock('../daemon/logger.js', () => ({
 
 import { readAuth, saveAuth, type AuthState } from './auth.js';
 import { logWarn } from '../daemon/logger.js';
-import { isTokenExpiringSoon, refreshTokenIfNeeded } from './token-refresh.js';
+import {
+  AuthExpiredError,
+  isTerminalRefreshStatus,
+  isTokenExpiringSoon,
+  refreshTokenIfNeeded,
+} from './token-refresh.js';
 
 const mockReadAuth = vi.mocked(readAuth);
 const mockSaveAuth = vi.mocked(saveAuth);
@@ -72,27 +77,30 @@ describe('refreshTokenIfNeeded', () => {
     vi.unstubAllGlobals();
   });
 
-  it('returns early when readAuth returns null', async () => {
+  it('returns ok when readAuth returns null', async () => {
     mockReadAuth.mockReturnValue(null);
 
-    await refreshTokenIfNeeded();
+    const result = await refreshTokenIfNeeded();
 
+    expect(result).toEqual({ ok: true });
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('returns early when token is not expiring soon', async () => {
+  it('returns ok when token is not expiring soon', async () => {
     mockReadAuth.mockReturnValue(makeAuth({ expires_at: nowSecs() + 600 }));
 
-    await refreshTokenIfNeeded();
+    const result = await refreshTokenIfNeeded();
 
+    expect(result).toEqual({ ok: true });
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('warns and returns when expiring soon but refresh_token is missing', async () => {
+  it('returns terminal when expiring soon but refresh_token is missing', async () => {
     mockReadAuth.mockReturnValue(makeAuth({ expires_at: nowSecs() + 100, refresh_token: '' }));
 
-    await refreshTokenIfNeeded();
+    const result = await refreshTokenIfNeeded();
 
+    expect(result).toEqual({ ok: false, terminal: true, reason: 'no_refresh_token' });
     expect(mockFetch).not.toHaveBeenCalled();
     expect(mockLogWarn).toHaveBeenCalledWith(expect.stringContaining('no refresh token available'));
   });
@@ -121,8 +129,9 @@ describe('refreshTokenIfNeeded', () => {
         }),
       });
 
-    await refreshTokenIfNeeded();
+    const result = await refreshTokenIfNeeded();
 
+    expect(result).toEqual({ ok: true });
     expect(mockFetch).toHaveBeenNthCalledWith(1, `${auth.hub.url}/api/health`);
     expect(mockFetch).toHaveBeenNthCalledWith(
       2,
@@ -143,17 +152,32 @@ describe('refreshTokenIfNeeded', () => {
     );
   });
 
-  it('returns without crashing when health fetch throws', async () => {
+  it('classifies network error as transient', async () => {
     mockReadAuth.mockReturnValue(makeAuth({ expires_at: nowSecs() + 100 }));
 
     mockFetch.mockRejectedValueOnce(new Error('network error'));
 
-    await expect(refreshTokenIfNeeded()).resolves.toBeUndefined();
+    const result = await refreshTokenIfNeeded();
+    expect(result).toEqual({
+      ok: false,
+      terminal: false,
+      reason: expect.stringContaining('network'),
+    });
     expect(mockSaveAuth).not.toHaveBeenCalled();
     expect(mockLogWarn).toHaveBeenCalledWith(expect.stringContaining('network error'));
   });
 
-  it('logs warning and returns when token endpoint returns non-ok', async () => {
+  it.each([
+    [400, true],
+    [401, true],
+    [403, true],
+    [404, true],
+    [408, false],
+    [429, false],
+    [500, false],
+    [502, false],
+    [503, false],
+  ])('classifies status %i as terminal=%s', async (status, terminal) => {
     const auth = makeAuth({ expires_at: nowSecs() + 100 });
     mockReadAuth.mockReturnValue(auth);
 
@@ -168,34 +192,57 @@ describe('refreshTokenIfNeeded', () => {
           },
         }),
       })
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 401,
-      });
+      .mockResolvedValueOnce({ ok: false, status });
 
-    await refreshTokenIfNeeded();
+    const result = await refreshTokenIfNeeded();
 
+    expect(result).toEqual({ ok: false, terminal, reason: `status_${status}` });
     expect(mockSaveAuth).not.toHaveBeenCalled();
-    expect(mockLogWarn).toHaveBeenCalledWith(expect.stringContaining('401'));
+    expect(mockLogWarn).toHaveBeenCalledWith(expect.stringContaining(String(status)));
   });
 
-  it('catches and logs network errors without crashing', async () => {
-    mockReadAuth.mockReturnValue(makeAuth({ expires_at: nowSecs() + 100 }));
-
-    mockFetch.mockRejectedValue(new Error('connection refused'));
-
-    await expect(refreshTokenIfNeeded()).resolves.toBeUndefined();
-    expect(mockSaveAuth).not.toHaveBeenCalled();
-    expect(mockLogWarn).toHaveBeenCalledWith(expect.stringContaining('connection refused'));
-  });
-
-  it('catches and logs non-Error thrown values without crashing', async () => {
+  it('classifies non-Error thrown values as transient', async () => {
     mockReadAuth.mockReturnValue(makeAuth({ expires_at: nowSecs() + 100 }));
 
     mockFetch.mockRejectedValue('string error');
 
-    await expect(refreshTokenIfNeeded()).resolves.toBeUndefined();
+    const result = await refreshTokenIfNeeded();
+    expect(result).toEqual({
+      ok: false,
+      terminal: false,
+      reason: expect.stringContaining('string error'),
+    });
     expect(mockSaveAuth).not.toHaveBeenCalled();
     expect(mockLogWarn).toHaveBeenCalledWith(expect.stringContaining('string error'));
+  });
+});
+
+describe('isTerminalRefreshStatus', () => {
+  it.each([
+    [400, true],
+    [401, true],
+    [403, true],
+    [404, true],
+    [408, false],
+    [429, false],
+    [499, true],
+    [500, false],
+    [502, false],
+    [503, false],
+    [504, false],
+  ])('status %i → terminal=%s', (status, expected) => {
+    expect(isTerminalRefreshStatus(status)).toBe(expected);
+  });
+});
+
+describe('AuthExpiredError', () => {
+  it('exposes reason and is instanceof Error', () => {
+    const err = new AuthExpiredError('status_400');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AuthExpiredError);
+    expect(err.reason).toBe('status_400');
+    expect(err.message).toContain('status_400');
+    expect(err.message).toContain('agentage setup --reauth');
+    expect(err.name).toBe('AuthExpiredError');
   });
 });

--- a/src/hub/token-refresh.ts
+++ b/src/hub/token-refresh.ts
@@ -3,21 +3,41 @@ import { logInfo, logWarn } from '../daemon/logger.js';
 
 const TOKEN_REFRESH_THRESHOLD_S = 300; // 5 minutes
 
+export type RefreshResult = { ok: true } | { ok: false; terminal: boolean; reason: string };
+
+export class AuthExpiredError extends Error {
+  readonly reason: string;
+  constructor(reason: string) {
+    super(`Auth expired (${reason}). Run 'agentage setup --reauth' to reconnect.`);
+    this.name = 'AuthExpiredError';
+    this.reason = reason;
+  }
+}
+
+// HTTP status codes from the Supabase token endpoint that indicate the
+// refresh_token itself is invalid/revoked — non-recoverable without re-auth.
+// 408/429/5xx are transient and should keep retrying.
+export const isTerminalRefreshStatus = (status: number): boolean => {
+  if (status === 408 || status === 429) return false;
+  if (status >= 500) return false;
+  return status >= 400;
+};
+
 export const isTokenExpiringSoon = (auth: AuthState): boolean => {
   if (!auth.session.expires_at) return false;
   const now = Math.floor(Date.now() / 1000);
   return auth.session.expires_at - now < TOKEN_REFRESH_THRESHOLD_S;
 };
 
-export const refreshTokenIfNeeded = async (): Promise<void> => {
+export const refreshTokenIfNeeded = async (): Promise<RefreshResult> => {
   const auth = readAuth();
-  if (!auth) return;
+  if (!auth) return { ok: true };
 
-  if (!isTokenExpiringSoon(auth)) return;
+  if (!isTokenExpiringSoon(auth)) return { ok: true };
 
   if (!auth.session.refresh_token) {
     logWarn('[token-refresh] Token expiring soon but no refresh token available');
-    return;
+    return { ok: false, terminal: true, reason: 'no_refresh_token' };
   }
 
   logInfo('[token-refresh] Token expiring soon, refreshing...');
@@ -39,8 +59,9 @@ export const refreshTokenIfNeeded = async (): Promise<void> => {
     });
 
     if (!res.ok) {
+      const terminal = isTerminalRefreshStatus(res.status);
       logWarn(`[token-refresh] Refresh request failed with status ${res.status}`);
-      return;
+      return { ok: false, terminal, reason: `status_${res.status}` };
     }
 
     const data = (await res.json()) as {
@@ -55,7 +76,10 @@ export const refreshTokenIfNeeded = async (): Promise<void> => {
     saveAuth(auth);
 
     logInfo('[token-refresh] Token refreshed successfully');
+    return { ok: true };
   } catch (err) {
-    logWarn(`[token-refresh] Failed: ${err instanceof Error ? err.message : String(err)}`);
+    const message = err instanceof Error ? err.message : String(err);
+    logWarn(`[token-refresh] Failed: ${message}`);
+    return { ok: false, terminal: false, reason: `network: ${message}` };
   }
 };


### PR DESCRIPTION
## Summary

Daemon now stops retrying when the hub's refresh-token endpoint returns a non-recoverable status (400/401/403), surfacing `authExpired` so the user — and the dashboard — get an actionable signal instead of a silent "machine offline" loop.

**Root cause** (observed locally on 2026-04-26): refresh-token 400 was treated identically to 5xx. Heartbeat + reconnect retried every ~30 s forever. Daemon log filled with WARN spam, dashboard showed generic "offline", no actionable signal anywhere. To recover, the user has to run `agentage setup --reauth` — but nothing tells them that.

## What changed

| File | Change |
|---|---|
| `src/hub/token-refresh.ts` | Returns typed `RefreshResult { ok, terminal, reason }`; classify 400/401/403 terminal, 408/429/5xx transient. New `AuthExpiredError` carries `Run 'agentage setup --reauth' to reconnect.` text |
| `src/hub/hub-client.ts` | `refreshAccessToken` throws `AuthExpiredError` on terminal status or missing refresh token; transient stays `return false` |
| `src/hub/hub-sync.ts` | Catches `AuthExpiredError` → stops heartbeat timer, stops reconnector, sets `authExpired=true`, ERROR log. Adds `isAuthExpired()` to interface |
| `src/hub/reconnection.ts` | `onError` may return `{ stop: true }` to terminate the loop |
| `src/daemon/routes.ts` | `/api/health` now exposes `authExpired: boolean` |

## Behavioral diff

**Before** (current production):
```
[WARN] [token-refresh] Refresh request failed with status 400
[WARN] Heartbeat failed: Hub API error (401): Invalid or expired token
[WARN] Hub connection failed: ... Retrying...
   ↳ repeats every 30 s forever; daemon_status: { hubConnected: false, hubConnecting: true }
```

**After**:
```
[ERROR] [hub-sync] Auth expired (status_400). Run 'agentage setup --reauth' to reconnect.
   ↳ heartbeat + reconnect loops halted; daemon_status: { hubConnected: false, hubConnecting: false, authExpired: true }
```

`/api/health` payload gains:
```diff
  hubConnected: false,
  hubConnecting: false,
+ authExpired: true,
```

## Out of scope (separate PRs)

- `agentage/web` — dashboard renders the new `authExpired` state distinctly on machine cards
- `agentage/desktop` — tray notification on transition to authExpired
- `agentage/mcp` — shim's `daemon_status` schema bump to expose the field
- Auto-recovery on auth.json mtime change (currently requires daemon restart after `setup --reauth`)

## Test plan

- [x] `npm run verify`: type-check + lint + format + build all green
- [x] Vitest: 18/18 in `hub-client.test.ts`, all new + existing tests green in `token-refresh.test.ts` (status classification across 400/401/403/404/408/429/500/502/503), `hub-sync.test.ts` (initial-fail AuthExpiredError, reconnector onError returns `{stop:true}`, heartbeat-loop terminates), `reconnection.test.ts` (terminal-stop honored)
- [x] Pre-existing `discovery/watcher.test.ts` flakes are present on master too — not introduced by this PR
- [ ] Manual: verify on local daemon after `agentage setup --reauth` that `daemon_status` reports `authExpired: false` and stays connected

## Acceptance

- **Where:** `daemon_status` MCP tool / `GET ~daemon~/api/health` (or this PR diff)
- **Area:** `cli/src/hub/{token-refresh,hub-client,hub-sync,reconnection}.ts`, `cli/src/daemon/routes.ts`
- **Change:** refresh-token 400 → daemon halts loops, surfaces `authExpired:true`, ERROR-logs the reauth command (was: silent WARN loop, "offline" forever)
- **Verify:** revoke a refresh token (or wait for one to expire), tail `~/.agentage/daemon.log` — expect a single ERROR with `Run 'agentage setup --reauth' to reconnect`, then no further heartbeat/connection retries; `curl localhost:4243/api/health | jq` returns `authExpired: true`