### PR TITLE
feat(setup): pass machine_name to /auth/login URL

### DIFF
--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -694,3 +694,32 @@ describe('setup command', () => {
     });
   });
 });
+
+describe('buildAuthUrl', () => {
+  it('builds bare URL with cli_port only when machineName missing', async () => {
+    const { buildAuthUrl } = await import('./setup.js');
+    expect(buildAuthUrl('https://agentage.io', 4243, undefined)).toBe(
+      'https://agentage.io/login?cli_port=4243'
+    );
+  });
+
+  it('appends URL-encoded machine_name when provided', async () => {
+    const { buildAuthUrl } = await import('./setup.js');
+    expect(buildAuthUrl('https://agentage.io', 4243, 'vreshch-laptop')).toBe(
+      'https://agentage.io/login?cli_port=4243&machine_name=vreshch-laptop'
+    );
+  });
+
+  it('URL-encodes spaces and special chars in machine_name', async () => {
+    const { buildAuthUrl } = await import('./setup.js');
+    const url = buildAuthUrl('https://agentage.io', 4243, "Bob's Mac Mini");
+    expect(url).toContain('machine_name=Bob%27s+Mac+Mini');
+  });
+
+  it('omits machine_name when empty string', async () => {
+    const { buildAuthUrl } = await import('./setup.js');
+    expect(buildAuthUrl('https://agentage.io', 4243, '')).toBe(
+      'https://agentage.io/login?cli_port=4243'
+    );
+  });
+});

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -144,7 +144,21 @@ const confirmConnect = async (config: DaemonConfig): Promise<boolean> => {
   }
 };
 
-const doAuthBrowser = async (hubUrl: string, machineId: string): Promise<void> => {
+export const buildAuthUrl = (
+  hubUrl: string,
+  port: number,
+  machineName: string | undefined
+): string => {
+  const params = new URLSearchParams({ cli_port: String(port) });
+  if (machineName) params.set('machine_name', machineName);
+  return `${hubUrl}/login?${params.toString()}`;
+};
+
+const doAuthBrowser = async (
+  hubUrl: string,
+  machineId: string,
+  machineName: string | undefined
+): Promise<void> => {
   console.log('Opening browser for authentication...');
 
   const authPromise = startCallbackServer(hubUrl);
@@ -157,7 +171,7 @@ const doAuthBrowser = async (hubUrl: string, machineId: string): Promise<void> =
     return;
   }
 
-  const authUrl = `${hubUrl}/login?cli_port=${port}`;
+  const authUrl = buildAuthUrl(hubUrl, port, machineName);
 
   try {
     await open(authUrl);
@@ -487,7 +501,7 @@ export const runSetup = async (opts: SetupOptions): Promise<void> => {
     if (opts.token) {
       doAuthToken(opts.token, hubUrl, config.machine.id);
     } else {
-      await doAuthBrowser(hubUrl, config.machine.id);
+      await doAuthBrowser(hubUrl, config.machine.id, config.machine.name);
     }
     userEmail = readAuth()?.user?.email ?? null;
   }


### PR DESCRIPTION
## Goal

Companion to https://github.com/agentage/web/pull/219 — that PR adds `?machine_name=` rendering to `/auth/login` (with sanitization). This 1-fn CLI change makes the param actually flow.

## Changes

`src/commands/setup.ts`

- Extract `buildAuthUrl(hubUrl, port, machineName)` — exported for unit testability.
- Append `&machine_name=<config.machine.name>` to the OAuth handoff URL (URL-encoded via `URLSearchParams`).
- Pass `config.machine.name` through `doAuthBrowser`'s third parameter from the existing call site.

## Backwards compatibility

| | new web | old web |
|---|---|---|
| **new CLI** (this PR) | renders machine name in heading | extra param ignored harmlessly |
| **old CLI** | fallback heading (param absent) | unchanged |

All four cells safe — web treats `machine_name` as optional and rejects via charset whitelist if invalid, so even a future CLI bug emitting weird chars won't break the page.

## Testing

- 4 new unit tests for `buildAuthUrl`: bare URL, machine_name happy-path, URL-encoding (`Bob's Mac Mini` → `Bob%27s+Mac+Mini`), empty-string fallback.
- Full `setup.test.ts` suite passes (34/34).
- `npm run verify`: lint, format:check, type-check, build, vitest all green.

## Merge order

PR-A (web) first, then this. Both are independently safe, but A-first means CLI users immediately see the cleaner page and B-second flips on the personalized heading.

## Related

- Web PR: https://github.com/agentage/web/pull/219
- Vault spec: `work/tasks/setup-flow-ux-overhaul.md`