### PR TITLE
Release v0.24.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.24.4] - 2026-04-26
+
+### New Features
+- Add machine name parameter to authentication login flow for better device identification
+
 ## [0.24.3] - 2026-04-26
 
 ### Bug Fixes

--- a/changelog-content.md
+++ b/changelog-content.md
@@ -1,2 +1,2 @@
-### Bug Fixes
-- Fix authentication token refresh handling to properly detect expired credentials and surface auth errors
+### New Features
+- Add machine name parameter to authentication login flow for better device identification

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentage/cli",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentage/cli",
-      "version": "0.24.3",
+      "version": "0.24.4",
       "license": "MIT",
       "dependencies": {
         "@agentage/core": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentage/cli",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "description": "Agentage CLI and daemon — control plane for AI agents",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release v0.24.4

Patch release picking up:
- **feat(setup):** pass `machine_name` to `/auth/login` URL — pairs with web hub redesign so `agentage setup --reauth` shows "Connecting · `<name>`" pill on the login page (#177)

Once merged, the publish workflow auto-tags `v0.24.4` and publishes to npm.