### PR TITLE
Release v0.24.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.24.5] - 2026-04-26
+
+### New Features
+- Add redesigned authentication callback pages for improved user experience
+
 ## [0.24.4] - 2026-04-26
 
 ### New Features

--- a/changelog-content.md
+++ b/changelog-content.md
@@ -1,2 +1,2 @@
 ### New Features
-- Add machine name parameter to authentication login flow for better device identification
+- Add redesigned authentication callback pages for improved user experience

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentage/cli",
-  "version": "0.24.4",
+  "version": "0.24.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentage/cli",
-      "version": "0.24.4",
+      "version": "0.24.5",
       "license": "MIT",
       "dependencies": {
         "@agentage/core": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentage/cli",
-  "version": "0.24.4",
+  "version": "0.24.5",
   "description": "Agentage CLI and daemon — control plane for AI agents",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Picks up cli#179 — local /auth/callback page redesign in brand parity with web hub auth pages.