### PR TITLE
feat(daemon): hub command bridge β — invoke-action handler + settings:update

### DIFF
--- a/src/daemon/actions.test.ts
+++ b/src/daemon/actions.test.ts
@@ -27,6 +27,7 @@ describe('action registry bootstrap', () => {
       'agent:install',
       'cli:update',
       'project:addFromOrigin',
+      'settings:update',
       'vault:add',
       'vault:edit',
       'vault:files',

--- a/src/daemon/actions.ts
+++ b/src/daemon/actions.ts
@@ -12,6 +12,7 @@ import { createVaultReadAction } from './actions/vault-read.js';
 import { createVaultReindexAction } from './actions/vault-reindex.js';
 import { createVaultRemoveAction } from './actions/vault-remove.js';
 import { createVaultSearchAction } from './actions/vault-search.js';
+import { createSettingsUpdateAction } from './actions/settings-update.js';
 import type { ShellExec } from './actions/types.js';
 
 const shellExec: ShellExec = (command, options) => shell(command, options);
@@ -40,6 +41,10 @@ export const getActionRegistry = (): ActionRegistry => {
   registry.register(createVaultReadAction({ vaults }));
   registry.register(createVaultSearchAction({ vaults }));
   registry.register(createVaultEditAction({ vaults }));
+
+  // Powers the editable Settings form on /machines/:id once dashboard γ
+  // ships. Default deps read/write ~/.agentage/config.json.
+  registry.register(createSettingsUpdateAction());
 
   registrySingleton = registry;
   return registry;

--- a/src/daemon/actions/index.ts
+++ b/src/daemon/actions/index.ts
@@ -31,4 +31,7 @@ export type { VaultSearchInput, VaultSearchOutput } from './vault-search.js';
 export { createVaultEditAction } from './vault-edit.js';
 export type { VaultEditInput, VaultEditOutput } from './vault-edit.js';
 
+export { createSettingsUpdateAction } from './settings-update.js';
+export type { SettingsUpdateInput, SettingsUpdateOutput } from './settings-update.js';
+
 export type { ActionProgress, ShellExec } from './types.js';

--- a/src/daemon/actions/settings-update.test.ts
+++ b/src/daemon/actions/settings-update.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSettingsUpdateAction } from './settings-update.js';
+import type { DaemonConfig } from '../config.js';
+
+const baseConfig = (): DaemonConfig => ({
+  machine: { id: 'm1', name: 'host' },
+  daemon: { port: 4243 },
+  agents: { default: '/old/agents', additional: [] },
+  projects: { default: '/old/projects', additional: [] },
+  vaultsDefault: '/old/vaults',
+  sync: {
+    events: {
+      state: true,
+      result: true,
+      error: true,
+      input_required: true,
+      'output.llm.delta': true,
+      'output.llm.tool_call': true,
+      'output.llm.usage': true,
+      'output.progress': true,
+    },
+  },
+});
+
+const drain = async <T>(gen: AsyncGenerator<unknown, T, void>): Promise<T> => {
+  while (true) {
+    const next = await gen.next();
+    if (next.done) return next.value;
+  }
+};
+
+const makeCtx = () => ({
+  invocationId: 'inv-1',
+  callerId: 'hub',
+  capabilities: new Set<string>(),
+  signal: new AbortController().signal,
+});
+
+describe('settings:update action', () => {
+  it('writes only the keys provided in input — preserves the rest', async () => {
+    const cfg = baseConfig();
+    const writeSpy = vi.fn();
+    const def = createSettingsUpdateAction({ loadConfig: () => cfg, saveConfig: writeSpy });
+
+    const result = await drain(def.execute(makeCtx(), { agents_default: '/new/agents' }));
+
+    expect(result).toEqual({
+      agents_default: '/new/agents',
+      projects_default: '/old/projects',
+      vaults_default: '/old/vaults',
+    });
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    const written = writeSpy.mock.calls[0][0] as DaemonConfig;
+    expect(written.agents.default).toBe('/new/agents');
+    expect(written.projects.default).toBe('/old/projects');
+    expect(written.vaultsDefault).toBe('/old/vaults');
+    // Sanity: didn't drop unrelated fields.
+    expect(written.machine).toEqual(cfg.machine);
+    expect(written.daemon).toEqual(cfg.daemon);
+  });
+
+  it('updates all three fields when all are provided', async () => {
+    const writeSpy = vi.fn();
+    const def = createSettingsUpdateAction({ loadConfig: baseConfig, saveConfig: writeSpy });
+
+    const result = await drain(
+      def.execute(makeCtx(), {
+        agents_default: '/a',
+        projects_default: '/p',
+        vaults_default: '/v',
+      })
+    );
+
+    expect(result).toEqual({ agents_default: '/a', projects_default: '/p', vaults_default: '/v' });
+    const written = writeSpy.mock.calls[0][0] as DaemonConfig;
+    expect(written.agents.default).toBe('/a');
+    expect(written.projects.default).toBe('/p');
+    expect(written.vaultsDefault).toBe('/v');
+  });
+
+  it('rejects empty input — must include at least one key', () => {
+    const def = createSettingsUpdateAction();
+    expect(() => def.validateInput!({})).toThrow(/at least one of/);
+  });
+
+  it('rejects non-string values for any field', () => {
+    const def = createSettingsUpdateAction();
+    expect(() => def.validateInput!({ agents_default: 123 })).toThrow(/non-empty string/);
+    expect(() => def.validateInput!({ vaults_default: '' })).toThrow(/non-empty string/);
+  });
+
+  it('surfaces saveConfig failure as EXECUTION_FAILED ActionError', async () => {
+    const def = createSettingsUpdateAction({
+      loadConfig: baseConfig,
+      saveConfig: () => {
+        throw new Error('disk full');
+      },
+    });
+
+    await expect(drain(def.execute(makeCtx(), { agents_default: '/x' }))).rejects.toMatchObject({
+      code: 'EXECUTION_FAILED',
+      retryable: true,
+    });
+  });
+});

--- a/src/daemon/actions/settings-update.ts
+++ b/src/daemon/actions/settings-update.ts
@@ -1,0 +1,130 @@
+import { action, ActionError, type ActionDefinition } from '@agentage/core';
+import { loadConfig, saveConfig, type DaemonConfig } from '../config.js';
+import type { ActionProgress } from './types.js';
+
+// settings:update — applies a partial diff to the daemon's persisted config.
+// Three fields are exposed for now (matching what the dashboard's Settings
+// form edits): agents_default, projects_default, vaults_default. All
+// optional; only the keys present in `input` are written. The on-disk
+// config.json is rewritten atomically by saveConfig.
+//
+// Powers the editable Settings form on /machines/:id once γ ships. See
+// work/tasks/daemon-command-bridge for the bridge end-to-end design.
+
+export interface SettingsUpdateInput {
+  agents_default?: string;
+  projects_default?: string;
+  vaults_default?: string;
+}
+
+export interface SettingsUpdateOutput {
+  // Echo the values that ended up persisted, so the dashboard can render
+  // confirmation copy without re-fetching.
+  agents_default: string;
+  projects_default: string;
+  vaults_default: string | null;
+}
+
+const isNonEmptyString = (v: unknown): v is string => typeof v === 'string' && v.length > 0;
+
+const validate = (raw: unknown): SettingsUpdateInput => {
+  if (!raw || typeof raw !== 'object') throw new Error('input must be an object');
+  const r = raw as Record<string, unknown>;
+  const out: SettingsUpdateInput = {};
+  if (r['agents_default'] !== undefined) {
+    if (!isNonEmptyString(r['agents_default'])) {
+      throw new Error('agents_default must be a non-empty string');
+    }
+    out.agents_default = r['agents_default'];
+  }
+  if (r['projects_default'] !== undefined) {
+    if (!isNonEmptyString(r['projects_default'])) {
+      throw new Error('projects_default must be a non-empty string');
+    }
+    out.projects_default = r['projects_default'];
+  }
+  if (r['vaults_default'] !== undefined) {
+    if (!isNonEmptyString(r['vaults_default'])) {
+      throw new Error('vaults_default must be a non-empty string');
+    }
+    out.vaults_default = r['vaults_default'];
+  }
+  if (Object.keys(out).length === 0) {
+    throw new Error(
+      'input must include at least one of: agents_default, projects_default, vaults_default'
+    );
+  }
+  return out;
+};
+
+export interface SettingsUpdateDeps {
+  // Indirection via deps lets tests stub the on-disk read/write without
+  // touching the actual ~/.agentage/config.json on the test runner.
+  loadConfig?: () => DaemonConfig;
+  saveConfig?: (cfg: DaemonConfig) => void;
+}
+
+export const createSettingsUpdateAction = (
+  deps: SettingsUpdateDeps = {}
+): ActionDefinition<SettingsUpdateInput, SettingsUpdateOutput, ActionProgress> =>
+  action({
+    manifest: {
+      name: 'settings:update',
+      version: '1.0',
+      title: 'Update daemon settings',
+      description:
+        'Apply a partial diff to the daemon-side default paths (agents, projects, vaults).',
+      scope: 'machine',
+      capability: 'config.write',
+      idempotent: true,
+    },
+    validateInput: validate,
+    async *execute(_ctx, input): AsyncGenerator<ActionProgress, SettingsUpdateOutput, void> {
+      const read = deps.loadConfig ?? loadConfig;
+      const write = deps.saveConfig ?? saveConfig;
+
+      yield { step: 'read', detail: 'loading current daemon config' };
+      let config: DaemonConfig;
+      try {
+        config = read();
+      } catch (err) {
+        throw new ActionError(
+          'EXECUTION_FAILED',
+          `Failed to load daemon config: ${err instanceof Error ? err.message : String(err)}`,
+          true
+        );
+      }
+
+      // Build the updated config — preserve everything else; only write the
+      // keys present in the input.
+      const next: DaemonConfig = {
+        ...config,
+        agents: {
+          ...config.agents,
+          default: input.agents_default ?? config.agents.default,
+        },
+        projects: {
+          ...config.projects,
+          default: input.projects_default ?? config.projects.default,
+        },
+        vaultsDefault: input.vaults_default ?? config.vaultsDefault,
+      };
+
+      yield { step: 'write', detail: 'persisting config.json' };
+      try {
+        write(next);
+      } catch (err) {
+        throw new ActionError(
+          'EXECUTION_FAILED',
+          `Failed to persist daemon config: ${err instanceof Error ? err.message : String(err)}`,
+          true
+        );
+      }
+
+      return {
+        agents_default: next.agents.default,
+        projects_default: next.projects.default,
+        vaults_default: next.vaultsDefault ?? null,
+      };
+    },
+  });

--- a/src/hub/command-dispatch.test.ts
+++ b/src/hub/command-dispatch.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('../daemon/logger.js', () => ({
+  logInfo: vi.fn(),
+  logError: vi.fn(),
+}));
+
+import type { ActionRegistry, InvokeEvent } from '@agentage/core';
+import { dispatchInvokeAction } from './command-dispatch.js';
+import { resetActionRegistry } from '../daemon/actions.js';
+
+// Stub the registry singleton with a controllable yielder per test by mocking
+// the actions module. Each test resets the singleton, then mocks
+// getActionRegistry to return a fake whose .invoke yields a scripted sequence.
+import type * as ActionsModule from '../daemon/actions.js';
+
+vi.mock('../daemon/actions.js', async (importActual) => {
+  const actual = await importActual<typeof ActionsModule>();
+  return {
+    ...actual,
+    getActionRegistry: vi.fn(),
+  };
+});
+
+import { getActionRegistry } from '../daemon/actions.js';
+
+const mockRegistry = (
+  events: InvokeEvent[] | (() => AsyncGenerator<InvokeEvent>)
+): ActionRegistry => {
+  const invoke =
+    typeof events === 'function'
+      ? events
+      : async function* () {
+          for (const e of events) yield e;
+        };
+  return {
+    register: vi.fn(),
+    list: vi.fn().mockReturnValue([]),
+    get: vi.fn(),
+    invoke: invoke as ActionRegistry['invoke'],
+  };
+};
+
+describe('dispatchInvokeAction', () => {
+  beforeEach(() => {
+    resetActionRegistry();
+    vi.mocked(getActionRegistry).mockReset();
+  });
+
+  it('streams accepted → progress → result through the send callback with monotonic ordinals', async () => {
+    vi.mocked(getActionRegistry).mockReturnValue(
+      mockRegistry([
+        { type: 'accepted', invocationId: 'inv-1' },
+        { type: 'progress', data: { step: 'install' } },
+        { type: 'result', data: { ok: true } },
+      ])
+    );
+    const sent: unknown[] = [];
+
+    await dispatchInvokeAction(
+      { commandId: 'cmd-1', action: 'cli:update', input: { target: 'latest' } },
+      (m) => sent.push(m)
+    );
+
+    expect(sent).toHaveLength(3);
+    expect(sent[0]).toMatchObject({
+      type: 'command_event',
+      commandId: 'cmd-1',
+      ordinal: 0,
+      event: { type: 'accepted', data: { invocationId: 'inv-1' } },
+    });
+    expect(sent[1]).toMatchObject({
+      ordinal: 1,
+      event: { type: 'progress', data: { step: 'install' } },
+    });
+    expect(sent[2]).toMatchObject({
+      ordinal: 2,
+      event: { type: 'result', data: { ok: true } },
+    });
+  });
+
+  it('forwards an error event with code/message/retryable', async () => {
+    vi.mocked(getActionRegistry).mockReturnValue(
+      mockRegistry([
+        {
+          type: 'error',
+          code: 'EXECUTION_FAILED',
+          message: 'boom',
+          retryable: true,
+        },
+      ])
+    );
+    const sent: unknown[] = [];
+
+    await dispatchInvokeAction({ commandId: 'cmd-2', action: 'cli:update', input: {} }, (m) =>
+      sent.push(m)
+    );
+
+    expect(sent[0]).toMatchObject({
+      event: {
+        type: 'error',
+        data: { code: 'EXECUTION_FAILED', message: 'boom', retryable: true },
+      },
+    });
+  });
+
+  it('catches a thrown registry exception and emits a synthetic error frame', async () => {
+    vi.mocked(getActionRegistry).mockReturnValue(
+      mockRegistry(async function* () {
+        throw new Error('registry crashed');
+      })
+    );
+    const sent: Array<{ event: { type: string; data: unknown } }> = [];
+
+    await dispatchInvokeAction({ commandId: 'cmd-3', action: 'cli:update', input: {} }, (m) =>
+      sent.push(m as never)
+    );
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      event: {
+        type: 'error',
+        data: { code: 'EXECUTION_FAILED', message: 'registry crashed', retryable: false },
+      },
+    });
+  });
+});

--- a/src/hub/command-dispatch.ts
+++ b/src/hub/command-dispatch.ts
@@ -1,0 +1,112 @@
+// Daemon-side dispatcher for hub→daemon `invoke-action` requests.
+// Single entry point used by both:
+//   - hub-ws.ts (when an `invoke-action` arrives on the live WS)
+//   - hub-sync.ts (when the heartbeat response carries queued invoke-actions
+//                  that the WS-push branch missed during a flap)
+//
+// Streams `command_event` frames back to the hub via the supplied `send`
+// callback. Each frame carries a per-command monotonic ordinal so the hub
+// can replay deterministically across reconnects (the hub-side schema has a
+// UNIQUE constraint on (command_id, ordinal) per α.1).
+//
+// Full design: work/tasks/daemon-command-bridge
+
+import type { InvokeEvent, InvokeRequest } from '@agentage/core';
+import { logError, logInfo } from '../daemon/logger.js';
+import { getActionRegistry } from '../daemon/actions.js';
+
+export interface InvokeActionCommand {
+  commandId: string;
+  action: string;
+  version?: string;
+  input: unknown;
+  idempotencyKey?: string;
+}
+
+export interface CommandEventEnvelope {
+  type: 'command_event';
+  commandId: string;
+  ordinal: number;
+  event: {
+    type: 'accepted' | 'progress' | 'result' | 'error';
+    data: unknown;
+    timestamp: number;
+  };
+}
+
+const mapInvokeEventToWire = (e: InvokeEvent): CommandEventEnvelope['event'] => {
+  switch (e.type) {
+    case 'accepted':
+      return { type: 'accepted', data: { invocationId: e.invocationId }, timestamp: Date.now() };
+    case 'progress':
+      return { type: 'progress', data: e.data, timestamp: Date.now() };
+    case 'result':
+      return { type: 'result', data: e.data, timestamp: Date.now() };
+    case 'error':
+      return {
+        type: 'error',
+        data: { code: e.code, message: e.message, retryable: e.retryable },
+        timestamp: Date.now(),
+      };
+  }
+};
+
+/**
+ * Run one invoke-action through the local ActionRegistry and stream its
+ * lifecycle events back over `send`. Errors yielded by the registry surface
+ * as `{ event.type: 'error' }` frames; thrown errors (registry contract
+ * violation) are caught and surfaced the same way so the hub-side row never
+ * gets stuck mid-stream.
+ */
+export const dispatchInvokeAction = async (
+  cmd: InvokeActionCommand,
+  send: (msg: unknown) => void
+): Promise<void> => {
+  const registry = getActionRegistry();
+
+  const req: InvokeRequest = {
+    action: cmd.action,
+    version: cmd.version,
+    input: cmd.input,
+    idempotencyKey: cmd.idempotencyKey,
+    // MVP: the hub authenticates the user; daemon trusts the hub. Once
+    // capability gating ships server-side we'll thread the resolved set
+    // through here (see work/tasks/daemon-command-bridge § Open choices).
+    callerId: 'hub',
+    capabilities: ['*'],
+  };
+
+  let ordinal = 0;
+  const emit = (event: CommandEventEnvelope['event']): void => {
+    send({
+      type: 'command_event',
+      commandId: cmd.commandId,
+      ordinal: ordinal++,
+      event,
+    });
+  };
+
+  logInfo(`[command-dispatch] invoking ${cmd.action} (commandId=${cmd.commandId})`);
+
+  try {
+    for await (const event of registry.invoke(req)) {
+      emit(mapInvokeEventToWire(event));
+    }
+  } catch (err) {
+    // Registry.invoke contract: errors yield as `{ type: 'error' }` events.
+    // A thrown exception means the registry itself crashed — surface as a
+    // synthetic error frame so the hub row terminates cleanly.
+    logError(
+      `[command-dispatch] ${cmd.action} threw: ${err instanceof Error ? err.message : String(err)}`
+    );
+    emit({
+      type: 'error',
+      data: {
+        code: 'EXECUTION_FAILED',
+        message: err instanceof Error ? err.message : String(err),
+        retryable: false,
+      },
+      timestamp: Date.now(),
+    });
+  }
+};

--- a/src/hub/hub-sync.ts
+++ b/src/hub/hub-sync.ts
@@ -180,15 +180,50 @@ export const createHubSync = (): HubSync => {
     if (response.pendingCommands && Array.isArray(response.pendingCommands)) {
       for (const cmd of response.pendingCommands as Array<{
         type: string;
-        runId: string;
+        runId?: string;
         payload?: string;
+        commandId?: string;
+        action?: string;
+        version?: string;
+        input?: unknown;
+        idempotencyKey?: string;
       }>) {
-        if (cmd.type === 'cancel') {
+        if (cmd.type === 'cancel' && cmd.runId) {
           cancelRun(cmd.runId);
           logInfo(`Processed pending cancel for run ${cmd.runId}`);
-        } else if (cmd.type === 'input' && cmd.payload) {
+        } else if (cmd.type === 'input' && cmd.runId && cmd.payload) {
           sendInput(cmd.runId, cmd.payload);
           logInfo(`Processed pending input for run ${cmd.runId}`);
+        } else if (cmd.type === 'invoke-action' && cmd.commandId && cmd.action) {
+          // Heartbeat-drain (hub α.4): the WS-push branch missed this row
+          // because the WS was flapping when the user clicked. Hub already
+          // marked it 'accepted' on its side, so we just need to execute
+          // and stream events back. If the WS isn't open right now we
+          // still execute (events get dropped on the floor — hub row
+          // ends up stuck 'accepted', operator-visible). Once the WS
+          // reconnects, future events from this same dispatch flow back
+          // normally. Acceptable for MVP — see daemon-command-bridge §
+          // open follow-ups.
+          if (!hubWs?.isConnected()) {
+            logWarn(
+              `[hub-sync] Skipping invoke-action ${cmd.commandId}: WS not connected (will surface as stuck 'accepted' on hub)`
+            );
+            continue;
+          }
+          hubWs
+            .invokeAction({
+              commandId: cmd.commandId,
+              action: cmd.action,
+              version: cmd.version,
+              input: cmd.input,
+              idempotencyKey: cmd.idempotencyKey,
+            })
+            .catch((err) => {
+              logError(
+                `[hub-sync] invoke-action ${cmd.commandId} dispatch failed: ${err instanceof Error ? err.message : String(err)}`
+              );
+            });
+          logInfo(`Processed pending invoke-action ${cmd.action} (commandId=${cmd.commandId})`);
         }
       }
     }

--- a/src/hub/hub-ws.ts
+++ b/src/hub/hub-ws.ts
@@ -10,6 +10,7 @@ import {
   onRunStateChange,
   onRunStarted,
 } from '../daemon/run-manager.js';
+import { dispatchInvokeAction, type InvokeActionCommand } from './command-dispatch.js';
 
 interface WsExecuteRequest {
   type: 'execute';
@@ -30,12 +31,26 @@ interface WsSendInput {
   text: string;
 }
 
-type HubMessage = WsExecuteRequest | WsCancel | WsSendInput;
+interface WsInvokeAction {
+  type: 'invoke-action';
+  commandId: string;
+  action: string;
+  version?: string;
+  input: unknown;
+  idempotencyKey?: string;
+}
+
+type HubMessage = WsExecuteRequest | WsCancel | WsSendInput | WsInvokeAction;
 
 export interface HubWs {
   connect: () => void;
   disconnect: () => void;
   isConnected: () => boolean;
+  // Heartbeat-drained invoke-actions (hub-sync.ts) reuse the same dispatch
+  // path so the per-WS `send` closure routes command_event frames back over
+  // the live WS. No-op-equivalent when the WS isn't open — caller checks
+  // isConnected() before delegating.
+  invokeAction: (cmd: InvokeActionCommand) => Promise<void>;
 }
 
 export const createHubWs = (
@@ -174,6 +189,14 @@ export const createHubWs = (
           sendInput(msg.runId, msg.text);
           logInfo(`Hub sent input for run ${msg.runId}`);
           break;
+
+        case 'invoke-action':
+          dispatchInvokeAction(msg, send).catch((err) => {
+            logError(
+              `Invoke-action handler error: ${err instanceof Error ? err.message : String(err)}`
+            );
+          });
+          break;
       }
     } catch {
       logError('[hub-ws] Failed to parse message from hub');
@@ -262,6 +285,8 @@ export const createHubWs = (
     },
 
     isConnected: () => connected,
+
+    invokeAction: (cmd) => dispatchInvokeAction(cmd, send),
   };
 
   function cleanup(): void {


### PR DESCRIPTION
## Summary

Daemon side of the hub→daemon command bridge. Web side already landed in \`agentage/web\` #229–#232 (α.1–α.4). After this PR merges and the next CLI release ships to npm, the bridge is end-to-end:

\`\`\`
dashboard POST /api/machines/:id/commands
  → hub persists machine_commands at state='queued' (α.2)
  → hub WS-pushes invoke-action OR heartbeat-drains it (α.3 + α.4)
  → daemon executes via ActionRegistry, streams command_event back (THIS PR)
  → hub maps events to machine_command_events + state transitions (α.3)
  → dashboard Realtime sees lifecycle queued → accepted → running → succeeded
\`\`\`

## What's wired

### Dispatcher — \`src/hub/command-dispatch.ts\` (new)

Single entry point used by both the live-WS path (hub-ws.ts) and the heartbeat-drain path (hub-sync.ts). Calls \`getActionRegistry().invoke({ action, version, input, idempotencyKey, callerId, capabilities })\` and streams yielded \`InvokeEvent\`s back as \`command_event\` frames with **monotonic per-command ordinals** — the hub schema's \`UNIQUE (command_id, ordinal)\` makes a redelivery a no-op rather than a dup row. Wraps registry-thrown exceptions in a synthetic \`{ code: 'EXECUTION_FAILED', retryable: false }\` frame so the hub-side row never gets stuck mid-stream.

### WS handler — \`src/hub/hub-ws.ts\`

\`+WsInvokeAction\` case in \`handleMessage\`; \`+invokeAction()\` method on the \`HubWs\` interface for the heartbeat-drain caller to reuse the closure-scoped \`send\` (so command_event frames flow over the same WS the user opened).

### Heartbeat — \`src/hub/hub-sync.ts\`

\`pendingCommands\` now also handles \`invoke-action\` items returned by hub α.4. Skipped when WS is closed (logged) — future work can queue + replay locally if it becomes a real pattern.

### New action — \`src/daemon/actions/settings-update.ts\`

Applies a partial diff to the daemon's persisted config: \`agents_default\` / \`projects_default\` / \`vaults_default\`. Powers the editable Settings form on \`/machines/:id\` once dashboard γ ships. Idempotent (partial-update friendly).

## Tests

9 new specs, **703 / 703 vitest green** locally.

- \`settings:update\`: writes only provided keys; preserves rest; rejects empty/non-string input; surfaces \`saveConfig\` failure as \`EXECUTION_FAILED\`.
- \`dispatchInvokeAction\`: streams \`accepted → progress → result\` with monotonic ordinals; forwards error events with \`code\`/\`retryable\`; catches thrown registry exceptions as synthetic error frames.
- Action registry list updated to include \`'settings:update'\`.

## Test plan

- [ ] CI green — type-check, lint, format, build, vitest.
- [ ] Local: 703/703 vitest green.
- [ ] Manual smoke after the next CLI release ships:
  1. \`agentage daemon stop && agentage setup\` against dev.agentage.io.
  2. \`curl -X POST <hub>/api/machines/<id>/commands -d '{"action":"settings:update","input":{"agents_default":"/tmp/agents"}}'\`
  3. Check \`~/.agentage/config.json\` — \`agents.default\` should be \`/tmp/agents\` within seconds.
  4. Check the dashboard (γ once it ships, or query supabase directly): \`machine_commands\` row at \`state='succeeded'\`, \`machine_command_events\` rows accepted → progress → result.

## Risk

Medium-low. New WS message type and new action are additive. The dispatcher is exception-safe (registry crashes surface as error frames, not unhandled rejections). The heartbeat-drain path skips when WS is closed (logged), which can leave hub-side rows stuck \`accepted\` — operator-visible, never silently dropped. Acceptable for MVP.

## Refs

- \`work/tasks/daemon-command-bridge\` — full design
- agentage/web #229 (α.1), #230 (α.2), #231 (α.3), #232 (α.4) — hub stack this completes
- Next: agentage/web γ — dashboard layout (gated on this PR + CLI release)