### PR TITLE
feat(daemon): handle MACHINE_TOMBSTONED 410

### DIFF
--- a/src/hub/hub-client.ts
+++ b/src/hub/hub-client.ts
@@ -2,6 +2,21 @@ import { type AuthState, saveAuth } from './auth.js';
 import { logInfo, logWarn } from '../daemon/logger.js';
 import { AuthExpiredError, isTerminalRefreshStatus } from './token-refresh.js';
 
+/**
+ * Hub returned 410 Gone with `code: MACHINE_TOMBSTONED` — the operator
+ * disconnected this machine_id (DELETE /api/machines/:id wrote a tombstone
+ * row that the hub's register() now refuses). The daemon should stop
+ * retrying register/heartbeat for this id; recovery is `agentage setup`
+ * which issues a fresh machine_id.
+ */
+export class MachineTombstonedError extends Error {
+  readonly code = 'MACHINE_TOMBSTONED';
+  constructor(message: string) {
+    super(message);
+    this.name = 'MachineTombstonedError';
+  }
+}
+
 export interface HubClient {
   register: (machineData: {
     id: string;
@@ -171,13 +186,27 @@ export const createHubClient = (hubUrl: string, auth: AuthState): HubClient => {
       }
     }
 
-    const json = (await res.json()) as { success: boolean; data?: unknown; error?: unknown };
+    const json = (await res.json()) as {
+      success: boolean;
+      data?: unknown;
+      error?: { code?: string; message?: string } | unknown;
+    };
 
     if (!res.ok || !json.success) {
-      const errMsg =
+      const errObj =
         typeof json.error === 'object' && json.error !== null
-          ? ((json.error as { message?: string }).message ?? 'Unknown error')
-          : String(json.error ?? 'Request failed');
+          ? (json.error as { code?: string; message?: string })
+          : null;
+      const errMsg = errObj?.message ?? String(json.error ?? 'Request failed');
+
+      // 410 + MACHINE_TOMBSTONED — hub has marked this machine_id as
+      // permanently disconnected. Surface as a typed error so hub-sync
+      // can stop retrying and clear the local id.
+      // See agentage/web#228 + work/tasks/machine-disconnect-tombstone.
+      if (res.status === 410 && errObj?.code === 'MACHINE_TOMBSTONED') {
+        throw new MachineTombstonedError(errMsg);
+      }
+
       throw new Error(`Hub API error (${res.status}): ${errMsg}`);
     }
 

--- a/src/hub/hub-sync.test.ts
+++ b/src/hub/hub-sync.test.ts
@@ -5,9 +5,13 @@ vi.mock('./auth.js', () => ({
   saveAuth: vi.fn(),
 }));
 
-vi.mock('./hub-client.js', () => ({
-  createHubClient: vi.fn(),
-}));
+vi.mock('./hub-client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof HubClientModule>();
+  return {
+    ...actual,
+    createHubClient: vi.fn(),
+  };
+});
 
 vi.mock('./hub-ws.js', () => ({
   createHubWs: vi.fn(),
@@ -76,8 +80,8 @@ vi.mock('../daemon/metrics.js', () => ({
   }),
 }));
 
-import { readAuth } from './auth.js';
-import { createHubClient } from './hub-client.js';
+import { readAuth, saveAuth } from './auth.js';
+import { createHubClient, MachineTombstonedError } from './hub-client.js';
 import { createHubWs } from './hub-ws.js';
 import { createReconnector, type ReconnectorOptions } from './reconnection.js';
 import { loadConfig } from '../daemon/config.js';
@@ -85,6 +89,7 @@ import { getAgents } from '../daemon/routes.js';
 import { cancelRun, sendInput, getRuns } from '../daemon/run-manager.js';
 import { loadProjects } from '../projects/projects.js';
 import type * as TokenRefreshModule from './token-refresh.js';
+import type * as HubClientModule from './hub-client.js';
 import { AuthExpiredError, refreshTokenIfNeeded } from './token-refresh.js';
 import { createHubSync, resetHubSync, getHubSync } from './hub-sync.js';
 
@@ -491,6 +496,28 @@ describe('hub-sync', () => {
       expect(sync.isAuthExpired()).toBe(true);
       expect(sync.isConnected()).toBe(false);
       expect(mockReconnector.stop).toHaveBeenCalled();
+    });
+
+    it('marks tombstoned when initial register throws MachineTombstonedError', async () => {
+      // Hub returned 410 MACHINE_TOMBSTONED — the operator disconnected this
+      // machine_id earlier. Daemon must stop retrying + clear local id so
+      // `agentage setup` is the operator's clear next step.
+      mockReadAuth.mockReturnValue(testAuth);
+      mockHubClient.register.mockRejectedValue(
+        new MachineTombstonedError('Machine has been disconnected')
+      );
+
+      const sync = createHubSync();
+      await sync.start();
+
+      expect(sync.isAuthExpired()).toBe(false);
+      expect(sync.isConnected()).toBe(false);
+      expect(sync.isConnecting()).toBe(false);
+      // Reconnector must NOT be started — the id is permanently dead.
+      expect(mockReconnector.start).not.toHaveBeenCalled();
+      // saveAuth called with cleared machineId — `agentage setup` rewrites it.
+      const lastSaveAuthCall = vi.mocked(saveAuth).mock.calls.at(-1);
+      expect(lastSaveAuthCall?.[0].hub.machineId).toBe('');
     });
 
     it('reconnector onError returns void for transient errors', async () => {

--- a/src/hub/hub-sync.ts
+++ b/src/hub/hub-sync.ts
@@ -1,7 +1,7 @@
 import { platform, arch } from 'node:os';
 import { loadConfig, getDefaultVaultsDir } from '../daemon/config.js';
 import { type AuthState, readAuth, saveAuth } from './auth.js';
-import { createHubClient, type HubClient } from './hub-client.js';
+import { createHubClient, type HubClient, MachineTombstonedError } from './hub-client.js';
 import { createHubWs, type HubWs } from './hub-ws.js';
 import { createReconnector, type Reconnector } from './reconnection.js';
 import { logError, logInfo, logWarn } from '../daemon/logger.js';
@@ -35,6 +35,7 @@ export const createHubSync = (): HubSync => {
   let connected = false;
   let connecting = false;
   let authExpired = false;
+  let tombstoned = false;
 
   const markAuthExpired = (err: AuthExpiredError): void => {
     if (authExpired) return;
@@ -49,18 +50,55 @@ export const createHubSync = (): HubSync => {
     logError(`[hub-sync] ${err.message}`);
   };
 
+  // Hub returned 410 MACHINE_TOMBSTONED — this machine_id has been
+  // permanently disconnected on the hub side (agentage/web#228 tombstone).
+  // Stop the reconnect loop; the local config still holds the dead id, so
+  // wipe auth.hub.machineId so a follow-up `agentage daemon start` fails
+  // fast with a clear "run agentage setup" path. Mirrors markAuthExpired's
+  // shape — same terminal-state effect.
+  const markTombstoned = (err: MachineTombstonedError, auth: AuthState | null): void => {
+    if (tombstoned) return;
+    tombstoned = true;
+    connected = false;
+    connecting = false;
+    if (heartbeatTimer) {
+      clearTimeout(heartbeatTimer);
+      heartbeatTimer = null;
+    }
+    reconnector?.stop();
+    if (auth) {
+      auth.hub.machineId = '';
+      saveAuth(auth);
+    }
+    logError(
+      `[hub-sync] ${err.message} (Run \`agentage setup\` to register this host with a fresh machine_id.)`
+    );
+  };
+
   const connectAll = async (auth: AuthState): Promise<void> => {
     const config = loadConfig();
 
     hubClient = createHubClient(auth.hub.url, auth);
 
-    const result = await hubClient.register({
-      id: config.machine.id,
-      name: config.machine.name,
-      platform: platform(),
-      arch: arch(),
-      daemonVersion: VERSION,
-    });
+    let result: { machineId: string };
+    try {
+      result = await hubClient.register({
+        id: config.machine.id,
+        name: config.machine.name,
+        platform: platform(),
+        arch: arch(),
+        daemonVersion: VERSION,
+      });
+    } catch (err) {
+      if (err instanceof MachineTombstonedError) {
+        markTombstoned(err, auth);
+        // Don't rethrow — caller treats this as an unrecoverable
+        // "this id is dead, stop trying" state, same shape as
+        // AuthExpiredError. The reconnect loop is already stopped.
+        return;
+      }
+      throw err;
+    }
 
     // Save machineId in auth
     auth.hub.machineId = result.machineId;


### PR DESCRIPTION
## Summary

Closes the daemon-side half of agentage/web#228 (tombstone fix).

When the operator clicks Disconnect on \`/machines/:id\`, the hub deletes the machines row **and** inserts a tombstone row keyed on machine_id. Subsequent \`register()\` calls from this daemon get \`410 Gone\` with \`code: MACHINE_TOMBSTONED\`. Without this PR, the daemon kept retrying forever, spamming logs and never picking up the operator's intent — operator had to manually \`agentage daemon stop\`.

## Changes

### \`hub-client.ts\`
\`+MachineTombstonedError\` typed exception. Thrown when a request returns \`410\` + \`code: MACHINE_TOMBSTONED\` in the JSON body.

### \`hub-sync.ts\`
\`+markTombstoned\` terminal-state handler (mirrors \`markAuthExpired\`'s shape). Stops the reconnector, clears the heartbeat timer, and wipes \`auth.hub.machineId\` so a follow-up \`agentage daemon start\` fails fast with a clear "run agentage setup" path.

\`+try/catch\` around \`hubClient.register()\` in \`connectAll\`: typed \`MachineTombstonedError\` → \`markTombstoned\` + return; everything else rethrows so \`AuthExpiredError\` still hits the existing handler in \`start()\`.

## Tests

1 new spec, **704 / 704** vitest green.

- \`marks tombstoned when initial register throws MachineTombstonedError\` — also asserts \`saveAuth\` was called with cleared machineId.
- Existing test mock for \`./hub-client.js\` extended to **spread** actual exports (was: only mocked \`createHubClient\`, broke \`instanceof MachineTombstonedError\` lookup at runtime; surfaced as a regression on the existing AuthExpiredError test).

## Test plan

- [ ] CI green — type-check, lint, format, build, vitest.
- [ ] Manual after merge + next CLI release:
  1. Set up daemon against dev hub: \`agentage setup\`.
  2. Click Disconnect on dashboard for that machine. Hub writes tombstone.
  3. Daemon's next reconnect cycle hits the new code. Expected log:
     \`[hub-sync] Machine has been disconnected ... (Run \\\`agentage setup\\\` to register this host with a fresh machine_id.)\`
  4. Daemon stops retrying. \`~/.agentage/auth.json\` shows \`machineId: ""\`.
  5. \`agentage setup\` again — fresh registration, new machine_id.

## Refs

- agentage/web#228 — hub-side tombstone (\`machine_tombstones\` table + register-time gate). This PR is its companion daemon handler.
- \`work/tasks/machine-disconnect-tombstone\` — full design + acceptance.