### PR TITLE
Release v0.24.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.24.6] - 2026-04-26
+
+### New Features
+- Add hub command bridge with invoke-action handler and settings update functionality
+
 ## [0.24.5] - 2026-04-26
 
 ### New Features

--- a/changelog-content.md
+++ b/changelog-content.md
@@ -1,2 +1,2 @@
 ### New Features
-- Add redesigned authentication callback pages for improved user experience
+- Add hub command bridge with invoke-action handler and settings update functionality

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentage/cli",
-  "version": "0.24.5",
+  "version": "0.24.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentage/cli",
-      "version": "0.24.5",
+      "version": "0.24.6",
       "license": "MIT",
       "dependencies": {
         "@agentage/core": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentage/cli",
-  "version": "0.24.5",
+  "version": "0.24.6",
   "description": "Agentage CLI and daemon — control plane for AI agents",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release v0.24.6

This release ships the daemon-side **hub command bridge** (β).

### What's new

- Daemon WS handler for \`invoke-action\` messages — executes against the local \`ActionRegistry\` and streams \`command_event\` frames back to the hub (#181)
- New \`settings:update\` action — applies a partial diff to \`~/.agentage/config.json\` (\`agents_default\` / \`projects_default\` / \`vaults_default\`)
- Heartbeat-drain support — picks up queued \`machine_commands\` rows that the WS-push branch missed during a flap

Together with agentage/web #229–#236, this completes the hub→daemon command bridge end-to-end. Once npm publishes this release, the \`/machines/:id\` Settings form Save and Commands panel Run buttons actually execute against any locally-installed or managed daemon (was: rows sat at \`state='queued'\` indefinitely).

### Auto-prepared by

\`release-prepare.yml\` workflow created the branch + version bump. PR creation failed with 401 due to the auth token issue (RELEASE_PAT rotated). Opening manually so the auto-merge → tag → npm publish chain still fires.

### Refs

- agentage/cli #181 (β daemon side)
- agentage/web #229–#236 (hub side)
- \`work/tasks/daemon-command-bridge\` — full bridge design