### PR TITLE
chore(cli): drop update-check TTL 24h → 1h

### DIFF
--- a/src/utils/update-checker.test.ts
+++ b/src/utils/update-checker.test.ts
@@ -59,7 +59,7 @@ describe('update-checker', () => {
     it('queries npm when cache is expired', async () => {
       const cache = {
         latestVersion: '0.1.0',
-        checkedAt: new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(),
+        checkedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
       };
       writeFileSync(join(testDir, 'update-check.json'), JSON.stringify(cache));
 

--- a/src/utils/update-checker.ts
+++ b/src/utils/update-checker.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { getConfigDir } from '../daemon/config.js';
 import { VERSION } from './version.js';
 
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 const NPM_REGISTRY_URL = 'https://registry.npmjs.org/@agentage/cli/latest';
 const CACHE_FILE = 'update-check.json';
 


### PR DESCRIPTION
## Summary

- \`agentage status\` advertises "→ X.Y.Z available" via \`checkForUpdateSafe()\`. The result is cached at \`~/.agentage/update-check.json\` for **24h**, so during release windows users keep seeing the previous version as latest for up to a day (e.g. v0.24.6 shipped 18:53 UTC; \`agentage status\` still printed \`Version: 0.24.5\` afterwards).
- Drop TTL to **1h** — fresh enough to surface a release in the same session, still trivial on the npm registry. Mirrors web#240 for the dashboard's parallel cache.

## Test plan
- [x] \`npx vitest run src/utils/update-checker.test.ts\` — 7/7 green (expired-cache test \`25h\` → \`2h\`).
- [x] \`npm run verify\` — type-check + lint + format + 703/704 tests green (1 unrelated \`ensure-daemon.test.ts\` worker-timeout flake reproduces on \`origin/master\` too).
- [ ] Manual: bust cache (\`rm ~/.agentage/update-check.json\`) → \`agentage status\` shows \`Version: 0.24.6\` (post-publish).