### PR TITLE
chore(cli): route update notice to stderr

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,7 +57,11 @@ program.parseAsync().then(async () => {
     const result = await updateCheckPromise;
     if (result?.updateAvailable) {
       const { default: chalk } = await import('chalk');
-      console.log(
+      // Route to stderr — the update notice is meta-information, not command
+      // output. Even with the TTY guard above, keeping stdout pure means
+      // consumers that capture stdout (e.g. `agentage status | jq`) never
+      // see this string in their pipeline.
+      console.error(
         chalk.yellow(
           `\nUpdate available: ${result.currentVersion} → ${result.latestVersion} — run ${chalk.white('agentage update')} to install.`
         )


### PR DESCRIPTION
## Summary

- `cli.ts` printed the \"Update available\" notice via `console.log` (stdout), TTY-guarded
- The surrounding comment already calls out stdout-pollution as a problem for \`--json\` consumers
- Routes to `console.error` (stderr) so stdout stays clean regardless of TTY state

## Test plan

- [ ] CI green
- [ ] `agentage status --json | jq` still produces clean stdout when an update is available