### PR TITLE
chore(cli): route daemon version-mismatch notice to stderr

### DIFF
--- a/src/utils/ensure-daemon.ts
+++ b/src/utils/ensure-daemon.ts
@@ -17,7 +17,10 @@ export const ensureDaemon = async (): Promise<void> => {
   try {
     const health = await get<HealthResponse>('/api/health');
     if (health.version !== VERSION) {
-      console.log(
+      // Route to stderr — this is an operational notice, not command output.
+      // Without this, `--json` / pipe consumers get the yellow string mixed
+      // into their stdout when the daemon is upgraded mid-session.
+      console.error(
         chalk.yellow(
           `Daemon version mismatch (daemon: ${health.version}, cli: ${VERSION}) — restarting...`
         )


### PR DESCRIPTION
## Summary

- `ensureDaemon` printed the daemon-vs-CLI version-mismatch notice via `console.log` (stdout), with no TTY guard
- This leaked into stdout for \`--json\` / pipe consumers when the daemon was on a stale version
- Switch to `console.error` so stdout stays parseable

## Test plan

- [ ] CI green
- [ ] Mismatch notice still visible on TTY
- [ ] `agentage runs list --json | jq` not corrupted by the yellow banner during a daemon upgrade