### PR TITLE
chore: restart versioning at 0.0.1 for the Memory client line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.25.0] - 2026-06-12
+## [0.0.1] - 2026-06-12
+
+> Versioning restarts at 0.0.x: the Memory client is a new product line. Entries
+> below 0.0.1 document the retired agent-runtime CLI (unpublished from npm).
 
 ### Changed
 - **BREAKING - Memory client reboot.** The CLI is now the agentage Memory client.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,10 @@
 # CLAUDE.md - @agentage/cli
 
-Terminal client for agentage Memory. v0.25 reboot: `setup` (OAuth sign-in) + `status` only.
-The pre-0.25 agent-runtime CLI (daemon, run/agents/machines/...) lives in git history only -
-do not resurrect patterns from it.
+Terminal client for agentage Memory. Rebooted 2026-06 with versioning RESTARTED at 0.0.x
+(old npm versions were unpublished; earliest burned slot is 0.1.19 - stay below it until
+the line naturally passes). Commands: `setup` (OAuth sign-in) + `status` only. The old
+agent-runtime CLI (daemon, run/agents/machines/...) lives in git history only - do not
+resurrect patterns from it.
 
 ## Layout
 - `src/cli.ts` - commander entry (excluded from coverage; keep logic out of it)

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 
 The terminal client for [agentage Memory](https://agentage.io) - one memory, every AI, owned by you.
 
-> v0.25 is a reboot: the CLI is now the agentage **Memory client**. All agent-runtime
-> commands from 0.24.x and earlier (daemon, run, agents, machines, ...) were removed.
+> This package was rebooted as the agentage **Memory client** and its versioning
+> restarts at 0.0.x. The old agent-runtime CLI (daemon, run, agents, machines, ...)
+> was removed and unpublished.
 
 ## Install
 

--- a/e2e/status.test.ts
+++ b/e2e/status.test.ts
@@ -3,8 +3,12 @@
  * unauthenticated, against the live deployed target (AGENTAGE_SITE_FQDN,
  * default dev). No credentials needed.
  */
+import { createRequire } from 'node:module';
 import { expect, test } from '@playwright/test';
 import { assertCliBuilt, createCliMachine, statusJson, type CliMachine } from './helpers.js';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json') as { version: string };
 
 let machine: CliMachine;
 
@@ -15,13 +19,10 @@ test.beforeAll(() => {
 
 test.afterAll(() => machine.cleanup());
 
-test('version identifies the memory client line @smoke', async () => {
+test('version matches the package version @smoke', async () => {
   const result = await machine.exec(['--version']);
   expect(result.code, result.stderr).toBe(0);
-  const version = result.stdout.trim();
-  expect(version).toMatch(/^\d+\.\d+\.\d+/);
-  const [major = 0, minor = 0] = version.split('.').map(Number);
-  expect(major > 0 || minor >= 25, `expected the 0.25+ memory client, got ${version}`).toBe(true);
+  expect(result.stdout.trim()).toBe(pkg.version);
 });
 
 test('unauthenticated status degrades with a setup hint @smoke', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentage/cli",
-  "version": "0.25.0",
+  "version": "0.0.1",
   "description": "agentage Memory CLI - connect, clone, and manage your memory from the terminal",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Per product decision: the Memory client line numbers from **0.0.1** (not 0.25.x continuation).

- `package.json` 0.25.0 -> 0.0.1. Safe on npm: the registry's earliest historically published version was 0.1.19, so 0.0.x slots were never burned; the cooldown for the (unpublished) name ends 2026-06-13 18:39 UTC.
- e2e version assertion now checks `--version` == package.json version (was a >=0.25 floor).
- README/CHANGELOG/CLAUDE.md reworded to version-agnostic reboot language.

Verified: `npm run verify` green (49 tests), live e2e 4/4 vs dev with 0.0.1.