### PR TITLE
Release v0.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,10 @@
     "typescript": "latest",
     "vitest": "latest"
   },
+  "keywords": [
+    "cli",
+    "agentage"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/agentage/cli.git"


### PR DESCRIPTION
Publish @agentage/cli@0.0.1 to npm.

Adds `keywords` metadata field. The merge commit from this release/ branch will pass the publish workflow's release gate and trigger npm publish.

---
_Generated by [Claude Code](https://claude.ai/code/session_0192oerTmwbjf1svpRhBp3Eh)_