### PR TITLE
fix(release): update changelog model to claude-sonnet-4-6

### DIFF
--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -103,7 +103,7 @@ async function generateChangelog(commits, version) {
   const client = new Anthropic();
 
   const message = await client.messages.create({
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     max_tokens: 1024,
     messages: [
       {


### PR DESCRIPTION
## Why
After #205 fixed the missing dependency, `release-prepare`'s changelog step still
failed — the pinned model `claude-sonnet-4-20250514` reached **end-of-life on
2026-06-15** and the API now returns `404 not_found_error` for it.

## What
- Point the changelog generator at the current Sonnet: `claude-sonnet-4-6`.
- `messages.create` shape is unchanged; one-line swap.

Unblocks: re-run `release-prepare` -> `0.0.2` PR (Claude-generated changelog) -> merge -> publish.
