### PR TITLE
Release v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.0.2] - 2026-06-26
+
+### New Features
+- Add `setup` and `status` commands as part of the agentage Memory client reboot
+- Add daemon autostart on boot/login (platform-aware configuration)
+- Handle machine tombstoned state (410 response) gracefully in the daemon
+
+### Improvements
+- Route daemon version-mismatch notice and update notice to stderr for cleaner stdout output
+- Reduce update-check cache from 24h to 1h for more timely update notifications
+
 ## [0.0.1] - 2026-06-12
 
 ### Added

--- a/changelog-content.md
+++ b/changelog-content.md
@@ -1,2 +1,8 @@
-- `setup` - browser OAuth 2.1 sign-in (Dynamic Client Registration + PKCE) with a localhost callback.
-- `status` - CLI version, target, sign-in state, and endpoint reachability (`--json` supported).
+### New Features
+- Add `setup` and `status` commands as part of the agentage Memory client reboot
+- Add daemon autostart on boot/login (platform-aware configuration)
+- Handle machine tombstoned state (410 response) gracefully in the daemon
+
+### Improvements
+- Route daemon version-mismatch notice and update notice to stderr for cleaner stdout output
+- Reduce update-check cache from 24h to 1h for more timely update notifications

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/vreshch/projects/agentage/cli/node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentage/cli",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentage/cli",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "latest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentage/cli",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "The agentage CLI - connect this machine to agentage from the terminal",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release v0.0.2

First **publishable** build of the Memory-client CLI. `0.0.1` was unpublished and is permanently burned on npm, so this is the version that ships.

### What's in it
- `agentage setup` (OAuth 2.1 + PKCE + DCR sign-in) and `agentage status` - verified working end-to-end against dev.
- Release-pipeline repairs (#205 `@anthropic-ai/sdk` devDep, #206 live changelog model) that unblock publishing.

### On merge
Merging this (commit subject `Release v0.0.2`) trips the publish gate -> `publish.yml` -> `@agentage/cli@0.0.2` on npm -> `npx @agentage/cli setup` works.

> Note: this PR was created manually because `release-prepare`'s PR-authoring step failed on an **expired `RELEASE_PAT`/`PAT_TOKEN`** (HTTP 401). Rotate that secret to restore the automated release flow.
