### PR TITLE
fix(status): point CLI at api.<fqdn> + null-guard introspection

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -48,10 +48,12 @@ export interface TokenSession {
 // The OAuth introspection endpoint: the only live surface that validates the
 // CLI's bearer token today (backend REST accepts session cookies only).
 export const introspectToken = async (auth: AuthState, links: Links): Promise<TokenSession> => {
-  const body = await authedGet<IntrospectionResponse>(
+  const body = await authedGet<IntrospectionResponse | null>(
     auth,
     links,
     `${links.auth}/api/auth/mcp/get-session`
   );
+  // get-session returns 200 + null when the bearer maps to no active session.
+  if (!body) throw new AuthRequiredError('no active session');
   return { userId: body.userId, expiresAt: body.accessTokenExpiresAt };
 };

--- a/src/lib/origins.test.ts
+++ b/src/lib/origins.test.ts
@@ -31,7 +31,7 @@ describe('links', () => {
   it('derives all service urls from one fqdn', () => {
     expect(links('agentage.io')).toEqual({
       site: 'https://agentage.io',
-      api: 'https://agentage.io/api',
+      api: 'https://api.agentage.io/api',
       auth: 'https://auth.agentage.io',
       mcp: 'https://memory.agentage.io/mcp',
     });

--- a/src/lib/origins.ts
+++ b/src/lib/origins.ts
@@ -2,6 +2,8 @@ export type Env = 'development' | 'production';
 
 export interface Links {
   site: string;
+  // Backend REST base. Dedicated `api.<fqdn>` host (the apex `<fqdn>/api` was
+  // retired in the 2026-06-17 subdomain cutover); mirrors @agentage/shared links().
   api: string;
   auth: string;
   mcp: string;
@@ -36,7 +38,7 @@ export const links = (fqdn: string): Links =>
       }
     : {
         site: `https://${fqdn}`,
-        api: `https://${fqdn}/api`,
+        api: `https://api.${fqdn}/api`,
         auth: `https://auth.${fqdn}`,
         mcp: `https://memory.${fqdn}/mcp`,
       };

--- a/src/lib/status-info.test.ts
+++ b/src/lib/status-info.test.ts
@@ -52,6 +52,17 @@ describe('gatherStatus', () => {
     expect(report.auth).toEqual({ signedIn: true, tokenExpiresAt: '2026-06-12T20:00:00Z' });
   });
 
+  it('treats a 200 + null session as signed-out instead of crashing', async () => {
+    stubFetch({
+      '/health': () => jsonResponse(200, {}),
+      '/get-session': () => jsonResponse(200, null),
+    });
+    const report = await gatherStatus(auth, 'dev.agentage.io');
+    expect(report.auth.signedIn).toBe(false);
+    expect(report.auth.note).toContain('agentage setup');
+    expect(report.auth.note).not.toContain('Cannot read properties');
+  });
+
   it('downgrades to signed-out with a hint when the token is rejected', async () => {
     stubFetch({
       '/health': () => jsonResponse(200, {}),


### PR DESCRIPTION
First real `status` run against **prod** surfaced two bugs. The root cause: the CLI never caught up to the **`api.<fqdn>` subdomain cutover** (`dashboard-api-subdomains`, shipped 2026-06-17).

## endpoint `✗ https://agentage.io/api unreachable`
The cutover moved the backend to a dedicated **`api.<fqdn>`** host and **retired the apex `<fqdn>/api`** (clean break, now 404). `@agentage/shared` `links().api` became `https://api.<host>/api`, but the CLI's `origins.ts` still used `https://<fqdn>/api`.
- Repoint `links.api` -> `https://api.<fqdn>/api`. `api.{dev,}.agentage.io/api/health` -> **200** (verified live); apex -> 404.

## auth `✗ Cannot read properties of null (reading 'userId')`
`get-session` returns **`200 + null`** when the bearer maps to no active session (Better Auth behavior). `introspectToken` did `body.userId` with no guard -> crash.
- Treat null as signed-out -> status shows "session expired - run: agentage setup".

## Verified
- `npm run verify` green (50 tests, incl. a `200 + null` case).
- Built CLI `status` vs **prod** + **dev**: `endpoint ✓ https://api.agentage.io/api reachable` (and `api.dev...`), clean `not signed in`, no crash.
