### PR TITLE
Release v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.0.3] - 2026-06-27
+
+### Fixed
+
+- `status` now reaches the backend at the dedicated `api.<fqdn>` host (the apex `<fqdn>/api` was retired in the 2026-06-17 subdomain cutover), so production no longer reports the endpoint unreachable.
+- `status` no longer crashes when the bearer maps to no active session (`get-session` returns `200 + null`); it now reports signed-out with a `run: agentage setup` hint.
+
 ## [0.0.2] - 2026-06-26
 
 ### New Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentage/cli",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentage/cli",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentage/cli",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "The agentage CLI - connect this machine to agentage from the terminal",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release v0.0.3

Fixes `agentage status` against **production** by catching the CLI up to the `api.<fqdn>` subdomain cutover, plus a crash guard.

### Fixed (#209)
- `status` endpoint check now hits the dedicated **`api.<fqdn>/api`** host (the apex `<fqdn>/api` was retired 2026-06-17); prod no longer shows the endpoint unreachable.
- `status` no longer crashes on an inactive session (`get-session` 200 + null) - reports signed-out with a setup hint.

### Notes
- Manual release PR (changelog hand-written): the Claude changelog step is blocked by an **ANTHROPIC_API_KEY usage limit** (resets 2026-07-01), and `release-prepare`'s PR-authoring step still 401s on the **expired RELEASE_PAT** (see `tasks/cli-release-pat-rotation`).
- On merge: `Release v0.0.3` trips the publish gate -> `@agentage/cli@0.0.3` on npm.
