### PR TITLE
docs(readme): cover full offline Memory client surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 [![CI](https://github.com/agentage/cli/actions/workflows/ci.yml/badge.svg)](https://github.com/agentage/cli/actions/workflows/ci.yml)
 [![npm version](https://badge.fury.io/js/%40agentage%2Fcli.svg)](https://badge.fury.io/js/%40agentage%2Fcli)
 
-The [agentage](https://agentage.io) command-line interface.
+The offline-first terminal client for [agentage](https://agentage.io) Memory.
+
+**One memory. Every AI. Owned by you.** Your memory is plain markdown on your own
+disk. Read and write it from the terminal, serve it to Claude / Cursor / any MCP
+client on this machine, and sync it to a git remote you control. Everything works
+offline; the cloud is optional.
 
 ## Install
 
@@ -13,37 +18,126 @@ npm install -g @agentage/cli
 
 Requires Node.js >= 22.
 
-## Commands
-
-### `agentage setup`
-
-Signs this machine in to your agentage account. Opens a browser for OAuth 2.1
-sign-in (PKCE) and stores the resulting tokens in `~/.agentage/auth.json`
-(mode 0600). No passwords ever touch the terminal.
+## Quickstart
 
 ```bash
-agentage setup               # browser sign-in, then prints status
-agentage setup --no-browser  # print the sign-in URL instead of opening a browser
-agentage setup --reauth      # force a fresh sign-in
-agentage setup --disconnect  # sign out and remove local credentials
+agentage vault add notes --local        # register a vault at ~/vaults/notes
+echo "# My first note" | agentage memory write welcome.md --vault notes
+agentage memory list --vault notes
+agentage memory search "first" --vault notes
+agentage memory read @notes/welcome.md
 ```
 
-### `agentage status`
+No sign-in required. Each vault is a plain folder of `.md` files backed by git; every
+write commits, so nothing is lost and deletes are recoverable from history.
 
-Shows this machine's connection, one line per fact: CLI version, target,
-sign-in state, and endpoint reachability.
+## Memory
+
+Six offline verbs over your local vaults. Reference a document as `@<vault>/<path>`
+or as `<path> --vault <name>`; omit `--vault` to use the default vault. Every verb
+accepts `--json` for machine-readable output.
 
 ```bash
-agentage status
-agentage status --json
+agentage memory search <query...>   # search a vault (git grep); --limit <n>
+agentage memory read <ref>          # print a document
+agentage memory write <ref>         # create or overwrite (--body <text>, or stdin)
+agentage memory edit <ref>          # --old/--new (str_replace), or --body (--append)
+agentage memory list [folder]       # list documents, optionally under a folder
+agentage memory delete <ref>        # delete (recoverable from git history)
 ```
+
+`write` reads the body from `--body` or, when omitted (or `--body -`), from stdin;
+pass `--frontmatter '<json>'` to set YAML frontmatter. Documents larger than 64 KB
+are clamped on read, and the engine refuses to store obvious secrets.
+
+## Connect your AI (MCP)
+
+`agentage mcp` serves your local vaults to any on-machine AI client over stdio, as
+the same frozen six `memory__{search,read,write,edit,list,delete}` tools the cloud
+endpoint exposes. Point a client at it by spawning the command:
+
+```json
+{
+  "mcpServers": {
+    "agentage-memory": {
+      "command": "agentage",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Drop that into your client's MCP config (for example `~/.cursor/mcp.json`, or via
+`claude mcp add`) and the assistant reads and writes the same markdown you do.
+
+Clients that speak Streamable HTTP can instead use the daemon's endpoint at
+`http://127.0.0.1:4243/mcp`. The cloud MCP endpoint, for AI outside this machine, is
+`memory.agentage.io/mcp`.
+
+## Git sync
+
+Register a vault against an external git remote and the daemon keeps it in sync,
+committing and pushing local changes and pulling remote ones on an interval.
+
+```bash
+agentage vault add work --git git@github.com:you/memory.git
+agentage vault list
+agentage vault sync            # sync every git-backed vault now
+agentage vault sync work       # sync just one
+```
+
+Conflicts never lose a write: the remote copy is kept alongside yours as
+`<file>.conflict.md` for you to reconcile.
+
+## The daemon
+
+A small local daemon (loopback only, `127.0.0.1:4243` by default) owns the engine so
+vault writes are serialized and git sync runs in the background. It autostarts on the
+first memory verb; you rarely touch it directly.
+
+```bash
+agentage daemon status         # pid, uptime, version, per-vault sync state
+agentage daemon start          # start it explicitly (idempotent)
+agentage daemon stop           # stop it
+```
+
+To skip the daemon and run verbs in-process, pass `--no-daemon` or set
+`AGENTAGE_NO_DAEMON=1`.
+
+## Cloud account
+
+Sign in to connect this machine to your agentage account. This is optional; the
+memory verbs above work fully offline without it.
+
+```bash
+agentage setup                 # browser OAuth 2.1 sign-in (PKCE), then prints status
+agentage setup --no-browser    # print the sign-in URL instead of opening a browser
+agentage setup --reauth        # force a fresh sign-in
+agentage setup --disconnect    # sign out and remove local credentials
+
+agentage status                # CLI version, target, sign-in state, endpoint (--json)
+```
+
+No passwords touch the terminal; tokens are stored in `~/.agentage/auth.json`
+(mode 0600).
+
+## Update
+
+```bash
+agentage update                # install the latest published version
+agentage update --check        # report whether an update is available, don't install
+```
+
+`status` also surfaces a passive hint when a newer version is available.
 
 ## Environment
 
-| Variable              | Purpose                     | Default       |
-| --------------------- | --------------------------- | ------------- |
-| `AGENTAGE_SITE_FQDN`  | Target host                 | `agentage.io` |
-| `AGENTAGE_CONFIG_DIR` | Credential/config directory | `~/.agentage` |
+| Variable               | Purpose                                                             | Default       |
+| ---------------------- | ------------------------------------------------------------------- | ------------- |
+| `AGENTAGE_CONFIG_DIR`  | Config + credentials dir (`auth.json`, `vaults.json`, daemon state) | `~/.agentage` |
+| `AGENTAGE_DAEMON_PORT` | Local daemon port                                                   | `4243`        |
+| `AGENTAGE_NO_DAEMON`   | Set to `1` to run memory verbs in-process                           | unset         |
+| `AGENTAGE_SITE_FQDN`   | Cloud target host                                                   | `agentage.io` |
 
 ## Development
 


### PR DESCRIPTION
## What

The README predated M1-M4 and documented only `setup` + `status` (the v0.0.3 npm surface). Master has grown into the full offline-first Memory client, so the README now covers the shipped surface.

## Changes

- Lead with what the CLI **is**: the offline-first terminal client for agentage Memory (one memory, every AI, plain markdown you own).
- **Quickstart**: `vault add --local` + the memory verbs, offline, no sign-in.
- **Memory**: the six offline verbs (`search/read/write/edit/list/delete`), `@vault/path` refs, `--vault`, `--json`, stdin body, `--frontmatter`, 64 KB read clamp + secret refusal.
- **Connect your AI (MCP)**: a `mcpServers` config spawning `agentage mcp` (Claude Code / Cursor), plus the daemon Streamable-HTTP endpoint `http://127.0.0.1:4243/mcp`; cloud endpoint noted as `memory.agentage.io/mcp`.
- **Git sync**: `vault add --git <remote>` + `vault sync [name]`, `<file>.conflict.md` conflict handling.
- **The daemon**: `daemon start|stop|status`, loopback `127.0.0.1:4243`, autostart, `--no-daemon` / `AGENTAGE_NO_DAEMON`.
- **Cloud account** (`setup`/`status`) kept, framed as optional.
- **Update**: `update` / `update --check`.
- **Environment** table now includes `AGENTAGE_CONFIG_DIR`, `AGENTAGE_DAEMON_PORT`, `AGENTAGE_NO_DAEMON`, `AGENTAGE_SITE_FQDN`.

## Verification

Every documented command and flag was checked against the built CLI (`node dist/cli.js <cmd> --help`), and the offline quickstart (`vault add` -> `write` via stdin -> `list` -> `search` -> `read @vault/path`) was run end-to-end. `npm run verify` is green (203 tests). No version numbers promised beyond the published `@latest`; public-hygiene clean (no internal hosts, no roadmap, no em dashes).
