### PR TITLE
fix(pkg): clean dist before build, add homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "npm": ">=10.0.0"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.build.json",
     "type-check": "tsc --noEmit",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
@@ -60,5 +60,6 @@
     "type": "git",
     "url": "https://github.com/agentage/cli.git"
   },
+  "homepage": "https://agentage.io",
   "license": "MIT"
 }

--- a/src/package-guard.test.ts
+++ b/src/package-guard.test.ts
@@ -51,4 +51,16 @@ describe('package guard (R6)', () => {
     ]);
     expect(pkg.bin['agentage']).toBe('./dist/cli.js');
   });
+
+  it('homepage is set to the canonical site URL', () => {
+    const pkg = JSON.parse(readFileSync(PKG, 'utf-8')) as { homepage: string };
+    expect(pkg.homepage).toBe('https://agentage.io');
+  });
+
+  it('build script cleans dist before compiling', () => {
+    const pkg = JSON.parse(readFileSync(PKG, 'utf-8')) as { scripts: Record<string, string> };
+    // rmSync in the build command ensures stale dist files can't ship in a tarball
+    expect(pkg.scripts['build']).toContain('rmSync');
+    expect(pkg.scripts['build']).toContain('tsc');
+  });
 });


### PR DESCRIPTION
## Summary

- **Defect 1 (stale dist):** `npm run build` had no clean step, so a publish from a working copy shipped orphaned agent-runtime files from old `dist/` sub-trees (`hub/`, `discovery/`, `examples/`, `projects/`, `commands/agents*`, `daemon/actions/`). Build now runs `node -e "require('fs').rmSync('dist',{recursive:true,force:true})"` before `tsc` - cross-platform, no new deps.
- **Defect 2 (missing homepage):** Added `"homepage": "https://agentage.io"` per release rules.
- **Regression guard:** Two new assertions in `src/package-guard.test.ts` lock both invariants: `homepage` value and `rmSync` presence in the `build` script.

## Proof

Stale-file test: `touch dist/hub-stale-test.js && npm run build` - file gone after build. `npm pack --dry-run` shows zero `dist/{hub,examples,discovery,projects}` entries; only current CLI files present. `npm run verify` green (205 tests).

## Test plan

- [ ] CI type-check + lint + format + test + build all green
- [ ] `npm pack --dry-run` output contains no legacy sub-tree paths
- [ ] `homepage` visible in packed `package.json`