### PR TITLE
feat(vault): account vaults - couch-channel provisioning (M1c)

### DIFF
--- a/e2e/account-vault.test.ts
+++ b/e2e/account-vault.test.ts
@@ -1,0 +1,111 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect, test } from '@playwright/test';
+import { assertCliBuilt, createCliMachine } from './helpers.js';
+
+// Account vaults (agentage channel) are offline-first: a no-flag `vault add` writes the local
+// entry and mirror dir with zero network, provisioning the cloud channel only when signed in.
+// Egress is blackholed via unroutable proxies to prove the offline path never reaches out. @p0
+const BLACKHOLE = 'http://127.0.0.1:1';
+const OFFLINE = {
+  http_proxy: BLACKHOLE,
+  https_proxy: BLACKHOLE,
+  HTTP_PROXY: BLACKHOLE,
+  HTTPS_PROXY: BLACKHOLE,
+};
+
+interface AccountEntry {
+  path?: string;
+  origin?: { remote: string }[];
+  type?: string;
+}
+
+test.describe('account vault (offline) @p0', () => {
+  test.beforeAll(() => assertCliBuilt());
+
+  test('no-flag add registers an account vault locally, then reads/writes it, with no network', async () => {
+    const m = createCliMachine(OFFLINE);
+    try {
+      // --path keeps the mirror inside the isolated config dir (default would be the real ~/vaults).
+      const vaultDir = join(m.configDir, 'acct');
+      const add = await m.exec(['vault', 'add', 'acct', '--path', vaultDir]);
+      expect(add.code, add.stderr).toBe(0);
+      // Not signed in and offline: the entry is kept locally with a setup hint, never a crash.
+      expect(add.stdout).toContain('(account)');
+      expect(add.stdout).toContain('registered locally');
+
+      // The entry carries the agentage origin, and the mirror dir was created.
+      const cfg = JSON.parse(readFileSync(join(m.configDir, 'vaults.json'), 'utf-8')) as {
+        default: string;
+        vaults: Record<string, AccountEntry>;
+      };
+      expect(cfg.default).toBe('acct');
+      expect(cfg.vaults.acct!.origin?.[0]?.remote).toBe('agentage');
+      expect(cfg.vaults.acct!.path).toBe(vaultDir);
+      expect(existsSync(vaultDir)).toBe(true);
+
+      // Memory verbs work against it immediately (local git backend, still no network).
+      const write = await m.exec(['memory', 'write', 'notes/a.md', '--body', 'account vault note']);
+      expect(write.code, write.stderr).toBe(0);
+      const read = await m.exec(['memory', 'read', 'notes/a.md']);
+      expect(read.code, read.stderr).toBe(0);
+      expect(read.stdout).toContain('account vault note');
+    } finally {
+      m.cleanup();
+    }
+  });
+
+  test('vault list renders an account vault as type "account"', async () => {
+    const m = createCliMachine(OFFLINE);
+    try {
+      const vaultDir = join(m.configDir, 'acct');
+      expect((await m.exec(['vault', 'add', 'acct', '--path', vaultDir])).code).toBe(0);
+
+      const listed = await m.exec(['vault', 'list', '--json']);
+      expect(listed.code, listed.stderr).toBe(0);
+      const vaults = JSON.parse(listed.stdout) as Record<string, AccountEntry>;
+      expect(vaults.acct!.type).toBe('account');
+      // Backward-compatible: the entry still carries its path.
+      expect(vaults.acct!.path).toBe(vaultDir);
+
+      const human = await m.exec(['vault', 'list']);
+      expect(human.stdout).toContain('account');
+    } finally {
+      m.cleanup();
+    }
+  });
+
+  test('vault remove unregisters an account vault but leaves its files on disk', async () => {
+    const m = createCliMachine(OFFLINE);
+    try {
+      const vaultDir = join(m.configDir, 'acct');
+      expect((await m.exec(['vault', 'add', 'acct', '--path', vaultDir])).code).toBe(0);
+      expect((await m.exec(['memory', 'write', 'keep.md', '--body', 'keep me'])).code).toBe(0);
+
+      const removed = await m.exec(['vault', 'remove', 'acct']);
+      expect(removed.code, removed.stderr).toBe(0);
+      expect(removed.stdout).toContain('files left on disk');
+
+      // The registry entry is gone but the markdown stays.
+      const after = await m.exec(['vault', 'list', '--json']);
+      expect(Object.keys(JSON.parse(after.stdout))).toHaveLength(0);
+      expect(existsSync(join(vaultDir, 'keep.md'))).toBe(true);
+    } finally {
+      m.cleanup();
+    }
+  });
+
+  test('vault sync on an account vault reports it clearly instead of erroring', async () => {
+    const m = createCliMachine(OFFLINE);
+    try {
+      const vaultDir = join(m.configDir, 'acct');
+      expect((await m.exec(['vault', 'add', 'acct', '--path', vaultDir])).code).toBe(0);
+
+      const sync = await m.exec(['vault', 'sync', 'acct']);
+      expect(sync.code, sync.stderr).toBe(0);
+      expect(sync.stdout).toContain('account vault');
+    } finally {
+      m.cleanup();
+    }
+  });
+});

--- a/e2e/vault-offline.test.ts
+++ b/e2e/vault-offline.test.ts
@@ -29,12 +29,20 @@ test.describe('offline vault registry @p0', () => {
     }
   });
 
-  test('vault add without --local/--git fails clearly', async () => {
+  test('vault add without --local/--git is the account path (registered locally, no network)', async () => {
     const machine = createCliMachine();
     try {
-      const res = await machine.exec(['vault', 'add', 'acct']);
-      expect(res.code).not.toBe(0);
-      expect(res.stderr + res.stdout).toMatch(/--local|--git/);
+      // --path keeps the mirror in the isolated config dir; no auth + offline stays exit 0.
+      const res = await machine.exec([
+        'vault',
+        'add',
+        'acct',
+        '--path',
+        join(machine.configDir, 'acct'),
+      ]);
+      expect(res.code, res.stderr).toBe(0);
+      expect(res.stdout).toContain('(account)');
+      expect(res.stdout).toContain('registered locally');
     } finally {
       machine.cleanup();
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
-        "@agentage/memory-core": "^0.1.3",
+        "@agentage/memory-core": "^0.2.0",
         "@agentage/server-memory": "^0.0.3",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chalk": "latest",
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@agentage/memory-core": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@agentage/memory-core/-/memory-core-0.1.3.tgz",
-      "integrity": "sha512-BFzh/VoP5zm9j7CwazCRJRyqHT6PzImbaDqmKi8Iay3QX6TKYmWCIg1pXxy02yuJdSou4NR6FX5r8ezVSmBhhA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@agentage/memory-core/-/memory-core-0.2.0.tgz",
+      "integrity": "sha512-ZeKu4jIi4T3O02SjVBLoGzVRMR1/xfhkCsUAy06yRQ2bf9oFtRL7VcATJ7/nBP7zy1Bp/5R+DUsKOkrSkl5lVA==",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.7.0",
@@ -64,6 +64,20 @@
       },
       "bin": {
         "agentage-server-memory": "dist/bin/server-memory.js"
+      },
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.0.0"
+      }
+    },
+    "node_modules/@agentage/server-memory/node_modules/@agentage/memory-core": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@agentage/memory-core/-/memory-core-0.1.3.tgz",
+      "integrity": "sha512-BFzh/VoP5zm9j7CwazCRJRyqHT6PzImbaDqmKi8Iay3QX6TKYmWCIg1pXxy02yuJdSou4NR6FX5r8ezVSmBhhA==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.7.0",
+        "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=22.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prepublishOnly": "npm run verify"
   },
   "dependencies": {
-    "@agentage/memory-core": "^0.1.3",
+    "@agentage/memory-core": "^0.2.0",
     "@agentage/server-memory": "^0.0.3",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chalk": "latest",

--- a/src/commands/vault-sync.test.ts
+++ b/src/commands/vault-sync.test.ts
@@ -43,6 +43,24 @@ describe('runVaultSync', () => {
     expect(logs.join()).toContain('No git-synced vaults');
   });
 
+  it('reports an account vault clearly and never attempts a git sync', async () => {
+    const runViaDaemon = vi.fn(async () => result());
+    const runInProcess = vi.fn(async () => result());
+    const { deps, logs } = makeDeps({
+      loadConfig: () => ({
+        version: 1,
+        vaults: { acct: { path: '/tmp/acct', origin: [{ remote: 'agentage' }] } },
+      }),
+      daemonPort: async () => 4243,
+      runViaDaemon,
+      runInProcess,
+    });
+    await runVaultSync('acct', deps);
+    expect(logs.join()).toContain("Vault 'acct' is an account vault");
+    expect(runViaDaemon).not.toHaveBeenCalled();
+    expect(runInProcess).not.toHaveBeenCalled();
+  });
+
   it('runs in-process when the daemon is down', async () => {
     const runInProcess = vi.fn(async (_t: SyncTarget) => result({ committed: true }));
     const { deps, logs } = makeDeps({ daemonPort: async () => null, runInProcess });

--- a/src/commands/vault-sync.ts
+++ b/src/commands/vault-sync.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { type VaultsConfig } from '@agentage/memory-core';
+import { isAccountVault, type VaultsConfig } from '@agentage/memory-core';
 import { health, syncRun } from '../lib/daemon-client.js';
 import { daemonDisabled } from '../lib/daemon-pref.js';
 import { loadVaultsConfig } from '../lib/vaults.js';
@@ -38,13 +38,21 @@ export const runVaultSync = async (
   name: string | undefined,
   deps: VaultSyncDeps
 ): Promise<void> => {
-  const targets = syncTargets(deps.loadConfig()).filter((t) => !name || t.vault === name);
+  const config = deps.loadConfig();
+  const targets = syncTargets(config).filter((t) => !name || t.vault === name);
   if (targets.length === 0) {
-    deps.log(
-      name
-        ? `No git origin configured for vault '${name}'.`
-        : 'No git-synced vaults. Add one with `agentage vault add <name> --git <remote>`.'
-    );
+    const entry = name ? config.vaults?.[name] : undefined;
+    if (entry && isAccountVault(entry))
+      // The account channel is not a git remote, so `vault sync` never touches it.
+      deps.log(
+        `Vault '${name}' is an account vault - not a git remote, so \`vault sync\` skips it.`
+      );
+    else
+      deps.log(
+        name
+          ? `No git origin configured for vault '${name}'.`
+          : 'No git-synced vaults. Add one with `agentage vault add <name> --git <remote>`.'
+      );
     return;
   }
   const port = await deps.daemonPort();

--- a/src/commands/vault.test.ts
+++ b/src/commands/vault.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import type { VaultsConfig } from '@agentage/memory-core';
+import { type ProvisionResult } from '../lib/provision.js';
 import { runVaultAdd, runVaultList, runVaultRemove, type VaultDeps } from './vault.js';
 
-const makeDeps = (initial: VaultsConfig = { version: 1, vaults: {} }) => {
+const makeDeps = (
+  initial: VaultsConfig = { version: 1, vaults: {} },
+  provision: ProvisionResult = { status: 'provisioned', message: "Provisioned account vault 'x'." }
+) => {
   let config = initial;
   const logs: string[] = [];
   const ensured: string[] = [];
+  const provisioned: string[] = [];
   const deps: VaultDeps = {
     load: () => ({ config, source: null }),
     save: (c) => {
@@ -13,31 +18,36 @@ const makeDeps = (initial: VaultsConfig = { version: 1, vaults: {} }) => {
       return '/tmp/vaults.json';
     },
     ensureDir: (p) => ensured.push(p),
+    provision: async (name) => {
+      provisioned.push(name);
+      return provision;
+    },
     log: (m) => logs.push(m),
   };
-  return { deps, logs, ensured, get: () => config };
+  return { deps, logs, ensured, provisioned, get: () => config };
 };
 
 describe('vault add', () => {
-  it('registers a --local vault, creates its dir, sets the default', () => {
+  it('registers a --local vault, creates its dir, sets the default', async () => {
     const h = makeDeps();
-    runVaultAdd('scratch', { local: '/tmp/scratch' }, h.deps);
+    await runVaultAdd('scratch', { local: '/tmp/scratch' }, h.deps);
     expect(h.get().vaults?.scratch).toEqual({ path: '/tmp/scratch', mcp: ['local'] });
     expect(h.get().default).toBe('scratch');
     expect(h.ensured).toEqual(['/tmp/scratch']);
+    expect(h.provisioned).toEqual([]);
     expect(h.logs.join()).toContain("Added vault 'scratch'");
   });
 
-  it('defaults the --local path to ~/vaults/<name> when no value is given', () => {
+  it('defaults the --local path to ~/vaults/<name> when no value is given', async () => {
     const h = makeDeps();
-    runVaultAdd('notes', { local: true }, h.deps);
+    await runVaultAdd('notes', { local: true }, h.deps);
     expect(h.get().vaults?.notes).toMatchObject({ path: '~/vaults/notes' });
     expect(h.ensured).toEqual(['~/vaults/notes']);
   });
 
-  it('registers a --git vault as a local working copy synced to an origin', () => {
+  it('registers a --git vault as a local working copy synced to an origin', async () => {
     const h = makeDeps();
-    runVaultAdd('work', { git: 'git@github.com:me/w.git' }, h.deps);
+    await runVaultAdd('work', { git: 'git@github.com:me/w.git' }, h.deps);
     expect(h.get().vaults?.work).toEqual({
       path: '~/vaults/work',
       origin: [{ remote: 'git@github.com:me/w.git' }],
@@ -45,36 +55,93 @@ describe('vault add', () => {
     });
     // The working copy dir is created so the daemon has somewhere to commit/push from.
     expect(h.ensured).toEqual(['~/vaults/work']);
+    expect(h.provisioned).toEqual([]);
     expect(h.logs.join()).toContain('(git)');
   });
 
-  it('rejects add with no flag', () => {
+  it('with no flag registers an account vault, writes the entry, then provisions', async () => {
     const h = makeDeps();
-    expect(() => runVaultAdd('acct', {}, h.deps)).toThrow(/--local .* --git/);
+    await runVaultAdd('acct', {}, h.deps);
+    // The local entry is written (path + agentage origin) before provisioning is attempted.
+    expect(h.get().vaults?.acct).toEqual({
+      path: '~/vaults/acct',
+      origin: [{ remote: 'agentage' }],
+    });
+    expect(h.get().default).toBe('acct');
+    expect(h.ensured).toEqual(['~/vaults/acct']);
+    expect(h.provisioned).toEqual(['acct']);
+    expect(h.logs.join()).toContain('(account)');
+    expect(h.logs.join()).toContain("Provisioned account vault 'x'.");
   });
 
-  it('rejects --local and --git together', () => {
+  it('an account vault honors --path for its local mirror dir', async () => {
     const h = makeDeps();
-    expect(() => runVaultAdd('x', { local: true, git: 'g' }, h.deps)).toThrow(/one of/);
+    await runVaultAdd('acct', { path: '/data/acct' }, h.deps);
+    expect(h.get().vaults?.acct).toEqual({
+      path: '/data/acct',
+      origin: [{ remote: 'agentage' }],
+    });
+    expect(h.ensured).toEqual(['/data/acct']);
   });
 
-  it('rejects a duplicate name', () => {
+  it('surfaces the provisioning message even when the channel is disabled', async () => {
+    const h = makeDeps(
+      { version: 1, vaults: {} },
+      {
+        status: 'disabled',
+        message: "Vault 'acct' registered locally. Account sync is not enabled.",
+      }
+    );
+    await runVaultAdd('acct', {}, h.deps);
+    // Provisioning is never fatal: the entry stands and the calm one-liner is printed.
+    expect(h.get().vaults?.acct).toBeDefined();
+    expect(h.logs.join()).toContain('Account sync is not enabled');
+  });
+
+  it('rejects --path combined with --local/--git', async () => {
     const h = makeDeps();
-    runVaultAdd('a', { local: '/tmp/a' }, h.deps);
-    expect(() => runVaultAdd('a', { local: '/tmp/a2' }, h.deps)).toThrow(/already exists/);
+    await expect(runVaultAdd('x', { path: '/p', local: true }, h.deps)).rejects.toThrow(/--path/);
+  });
+
+  it('rejects --local and --git together', async () => {
+    const h = makeDeps();
+    await expect(runVaultAdd('x', { local: true, git: 'g' }, h.deps)).rejects.toThrow(/one of/);
+  });
+
+  it('rejects a duplicate name', async () => {
+    const h = makeDeps();
+    await runVaultAdd('a', { local: '/tmp/a' }, h.deps);
+    await expect(runVaultAdd('a', { local: '/tmp/a2' }, h.deps)).rejects.toThrow(/already exists/);
+  });
+
+  it('rejects an invalid name', async () => {
+    const h = makeDeps();
+    await expect(runVaultAdd('bad name', {}, h.deps)).rejects.toThrow(/invalid vault name/);
   });
 });
 
 describe('vault remove', () => {
-  it('removes the vault and reassigns the default', () => {
+  it('removes the vault and reassigns the default', async () => {
     const h = makeDeps();
-    runVaultAdd('a', { local: '/tmp/a' }, h.deps);
-    runVaultAdd('b', { local: '/tmp/b' }, h.deps);
+    await runVaultAdd('a', { local: '/tmp/a' }, h.deps);
+    await runVaultAdd('b', { local: '/tmp/b' }, h.deps);
     h.logs.length = 0;
     runVaultRemove('a', h.deps);
     expect(Object.keys(h.get().vaults ?? {})).toEqual(['b']);
     expect(h.get().default).toBe('b');
     expect(h.logs.join()).toContain("Default vault is now 'b'");
+  });
+
+  it('removes an account vault without touching any server', async () => {
+    const h = makeDeps();
+    await runVaultAdd('acct', {}, h.deps);
+    h.logs.length = 0;
+    h.provisioned.length = 0;
+    runVaultRemove('acct', h.deps);
+    expect(h.get().vaults).toEqual({});
+    // Remove is purely local: it never re-enters the provisioning path.
+    expect(h.provisioned).toEqual([]);
+    expect(h.logs.join()).toContain('files left on disk');
   });
 
   it('throws when the vault is absent', () => {
@@ -90,21 +157,27 @@ describe('vault list', () => {
     expect(h.logs.join()).toContain('No vaults registered');
   });
 
-  it('prints one line per vault and marks the default', () => {
+  it('prints one line per vault and marks the default', async () => {
     const h = makeDeps();
-    runVaultAdd('a', { local: '/tmp/a' }, h.deps);
-    runVaultAdd('b', { git: 'g@h:x.git' }, h.deps);
+    await runVaultAdd('a', { local: '/tmp/a' }, h.deps);
+    await runVaultAdd('b', { git: 'g@h:x.git' }, h.deps);
     h.logs.length = 0;
     runVaultList({}, h.deps);
     expect(h.logs).toHaveLength(2);
     expect(h.logs[0]).toContain('(default)');
   });
 
-  it('emits the vaults map with --json', () => {
+  it('emits the vaults map with --json, annotating an honest type', async () => {
     const h = makeDeps();
-    runVaultAdd('a', { local: '/tmp/a' }, h.deps);
+    await runVaultAdd('a', { local: '/tmp/a' }, h.deps);
+    await runVaultAdd('acct', {}, h.deps);
     h.logs.length = 0;
     runVaultList({ json: true }, h.deps);
-    expect(Object.keys(JSON.parse(h.logs[0] ?? '{}'))).toEqual(['a']);
+    const out = JSON.parse(h.logs[0] ?? '{}') as Record<string, { path?: string; type?: string }>;
+    expect(Object.keys(out)).toEqual(['a', 'acct']);
+    // Backward-compatible: entries keep their fields; type is added on top.
+    expect(out.a!.path).toBe('/tmp/a');
+    expect(out.a!.type).toBe('local');
+    expect(out.acct!.type).toBe('account');
   });
 });

--- a/src/commands/vault.ts
+++ b/src/commands/vault.ts
@@ -1,7 +1,18 @@
 import chalk from 'chalk';
 import { type Command } from 'commander';
-import { type VaultEntry, type VaultsConfig } from '@agentage/memory-core';
-import { addVault, ensureVaultDir, formatVaultLine, removeVault } from '../lib/vault-registry.js';
+import { isAccountVault, type VaultEntry, type VaultsConfig } from '@agentage/memory-core';
+import {
+  addVault,
+  ensureVaultDir,
+  formatVaultLine,
+  removeVault,
+  vaultType,
+} from '../lib/vault-registry.js';
+import {
+  defaultProvisionDeps,
+  provisionAccountVault,
+  type ProvisionResult,
+} from '../lib/provision.js';
 import { loadVaultsConfig, saveVaultsConfig, type LoadedVaults } from '../lib/vaults.js';
 import { defaultVaultSyncDeps, runVaultSync } from './vault-sync.js';
 
@@ -9,6 +20,7 @@ export interface VaultDeps {
   load: () => LoadedVaults;
   save: (config: VaultsConfig) => string;
   ensureDir: (path: string) => void;
+  provision: (name: string) => Promise<ProvisionResult>;
   log: (msg: string) => void;
 }
 
@@ -16,6 +28,7 @@ const defaultDeps: VaultDeps = {
   load: loadVaultsConfig,
   save: saveVaultsConfig,
   ensureDir: ensureVaultDir,
+  provision: (name) => provisionAccountVault(name, defaultProvisionDeps()),
   log: (msg) => console.log(msg),
 };
 
@@ -23,11 +36,15 @@ export interface VaultAddOptions {
   // `--local [path]`: true when the flag is present without a value.
   local?: string | boolean;
   git?: string;
+  // `--path <dir>`: a custom local mirror dir for the account vault (no --local/--git).
+  path?: string;
 }
 
 const buildEntry = (name: string, opts: VaultAddOptions): VaultEntry => {
   const hasLocal = opts.local !== undefined;
   if (hasLocal && opts.git) throw new Error('choose one of --local or --git, not both');
+  if (opts.path !== undefined && (hasLocal || opts.git))
+    throw new Error('--path applies only to an account vault (drop --local and --git)');
   // A --git vault is a local working copy that syncs to an external git remote (path + origin);
   // the daemon commits/pushes and pulls it per its interval.
   if (opts.git) return { path: `~/vaults/${name}`, origin: [{ remote: opts.git }], mcp: ['local'] };
@@ -35,22 +52,25 @@ const buildEntry = (name: string, opts: VaultAddOptions): VaultEntry => {
     const path = typeof opts.local === 'string' ? opts.local : `~/vaults/${name}`;
     return { path, mcp: ['local'] };
   }
-  throw new Error('a vault needs --local [path] (a local folder) or --git <remote>');
+  // No --local/--git: an account vault - a local mirror synced to the account (agentage) channel.
+  return { path: opts.path ?? `~/vaults/${name}`, origin: [{ remote: 'agentage' }] };
 };
 
-export const runVaultAdd = (
+export const runVaultAdd = async (
   name: string,
   opts: VaultAddOptions,
   deps: VaultDeps = defaultDeps
-): void => {
+): Promise<void> => {
   const entry = buildEntry(name, opts);
   const config = addVault(deps.load().config, name, entry);
   if (entry.path) deps.ensureDir(entry.path);
   deps.save(config);
-  const kind = entry.path ? (entry.origin?.length ? 'git' : 'local') : 'remote';
+  const kind = vaultType(entry);
   const where = entry.path ?? entry.origin?.[0]?.remote ?? '';
-  const via = entry.path && entry.origin?.length ? ` <- ${entry.origin[0]!.remote}` : '';
+  const via = kind === 'git' && entry.origin?.length ? ` <- ${entry.origin[0]!.remote}` : '';
   deps.log(chalk.green(`Added vault '${name}' (${kind}) -> ${where}${via}`));
+  // Offline-first: the local entry is saved first; provisioning the account channel is never fatal.
+  if (isAccountVault(entry)) deps.log((await deps.provision(name)).message);
 };
 
 export const runVaultRemove = (name: string, deps: VaultDeps = defaultDeps): void => {
@@ -67,11 +87,15 @@ export const runVaultList = (opts: { json?: boolean }, deps: VaultDeps = default
   const vaults = config.vaults ?? {};
   const names = Object.keys(vaults);
   if (opts.json) {
-    deps.log(JSON.stringify(vaults, null, 2));
+    // Backward-compatible: still the name-keyed map, each entry annotated with its honest type.
+    const out = Object.fromEntries(
+      names.map((n) => [n, { ...vaults[n]!, type: vaultType(vaults[n]!) }])
+    );
+    deps.log(JSON.stringify(out, null, 2));
     return;
   }
   if (names.length === 0) {
-    deps.log('No vaults registered. Add one with `agentage vault add <name> --local`.');
+    deps.log('No vaults registered. Add one with `agentage vault add <name>`.');
     return;
   }
   for (const name of names) {
@@ -89,6 +113,12 @@ const guard = (fn: () => void): void => {
   }
 };
 
+const guardAsync = (fn: () => Promise<void>): Promise<void> =>
+  fn().catch((err: unknown) => {
+    console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+    process.exitCode = 1;
+  });
+
 export const registerVault = (program: Command): void => {
   const vault = program.command('vault').description('Manage local memory vaults');
 
@@ -100,10 +130,11 @@ export const registerVault = (program: Command): void => {
 
   vault
     .command('add <name>')
-    .description('Register a new vault (files stay on disk)')
+    .description('Register a vault (account by default; --local or --git for a self-hosted one)')
     .option('--local [path]', 'a local folder (default ~/vaults/<name>)')
     .option('--git <remote>', 'a vault synced to an external git remote')
-    .action((name: string, opts: VaultAddOptions) => guard(() => runVaultAdd(name, opts)));
+    .option('--path <dir>', 'account vault local mirror dir (default ~/vaults/<name>)')
+    .action((name: string, opts: VaultAddOptions) => guardAsync(() => runVaultAdd(name, opts)));
 
   vault
     .command('remove <name>')

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { authedGet, AuthRequiredError, introspectToken } from './api.js';
+import { authedGet, authedPost, AuthRequiredError, introspectToken } from './api.js';
 import { readAuth, type AuthState } from './config.js';
 import { links } from './origins.js';
 
@@ -78,6 +78,59 @@ describe('authedGet', () => {
   it('surfaces non-auth errors with the status code', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(500, {})));
     await expect(authedGet(makeAuth(), target, 'https://x.example/x')).rejects.toThrow('500');
+  });
+});
+
+describe('authedPost', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'agentage-api-'));
+    process.env['AGENTAGE_CONFIG_DIR'] = dir;
+  });
+
+  afterEach(() => {
+    delete process.env['AGENTAGE_CONFIG_DIR'];
+    rmSync(dir, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+  });
+
+  it('sends the bearer token, a JSON body, and returns the raw response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(201, { ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+    const res = await authedPost(makeAuth(), target, 'https://x.example/api/memories', {
+      name: 'acct',
+      channel: 'couch',
+    });
+    expect(res.status).toBe(201);
+    expect(fetchMock).toHaveBeenCalledWith('https://x.example/api/memories', {
+      method: 'POST',
+      headers: { authorization: 'Bearer old-token', 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'acct', channel: 'couch' }),
+    });
+  });
+
+  it('refreshes once on 401, persists the new tokens, and retries the POST', async () => {
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url.includes('/token'))
+        return Promise.resolve(jsonResponse(200, { access_token: 'new-token', expires_in: 60 }));
+      const bearer = (init?.headers as Record<string, string> | undefined)?.['authorization'];
+      return Promise.resolve(
+        bearer === 'Bearer new-token' ? jsonResponse(201, { ok: true }) : jsonResponse(401, {})
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const auth = makeAuth();
+    const res = await authedPost(auth, target, 'https://x.example/api/memories', { name: 'a' });
+    expect(res.status).toBe(201);
+    expect(auth.tokens.accessToken).toBe('new-token');
+    expect(readAuth()?.tokens.accessToken).toBe('new-token');
+  });
+
+  it('returns a non-2xx response without throwing so the caller can branch', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(403, { error: { code: 'X' } })));
+    const res = await authedPost(makeAuth(), target, 'https://x.example/api/memories', {});
+    expect(res.status).toBe(403);
   });
 });
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -35,6 +35,28 @@ export const authedGet = async <T>(auth: AuthState, links: Links, url: string): 
   return (await res.json()) as T;
 };
 
+// A bearer POST with the same refresh-once dance as authedGet. Unlike authedGet it returns the
+// raw Response (never throws on a non-2xx): callers branch on the status codes themselves.
+export const authedPost = async (
+  auth: AuthState,
+  links: Links,
+  url: string,
+  body: unknown
+): Promise<Response> => {
+  const call = (): Promise<Response> =>
+    fetch(url, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${auth.tokens.accessToken}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+  let res = await call();
+  if (res.status === 401 && (await tryRefresh(auth, links))) res = await call();
+  return res;
+};
+
 interface IntrospectionResponse {
   userId?: string;
   accessTokenExpiresAt?: string;

--- a/src/lib/provision.test.ts
+++ b/src/lib/provision.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+import { type AuthState } from './config.js';
+import { links } from './origins.js';
+import { provisionAccountVault, type ProvisionDeps } from './provision.js';
+
+const target = links('dev.agentage.io');
+
+const auth: AuthState = {
+  siteFqdn: 'dev.agentage.io',
+  clientId: 'c1',
+  tokens: { accessToken: 'tok', refreshToken: 'rt' },
+};
+
+const jsonResponse = (status: number, body: unknown = {}): Response =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+
+const makeDeps = (
+  over: Partial<ProvisionDeps> = {}
+): { deps: ProvisionDeps; post: ReturnType<typeof vi.fn> } => {
+  const post = vi.fn(async () => jsonResponse(201));
+  const deps: ProvisionDeps = {
+    readAuth: () => auth,
+    links: () => target,
+    post,
+    ...over,
+  };
+  return { deps, post };
+};
+
+describe('provisionAccountVault', () => {
+  it('POSTs {name, channel:"couch"} to <api>/memories when signed in', async () => {
+    const { deps, post } = makeDeps();
+    await provisionAccountVault('acct', deps);
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith(auth, target, `${target.api}/memories`, {
+      name: 'acct',
+      channel: 'couch',
+    });
+  });
+
+  it('201 -> provisioned', async () => {
+    const { deps } = makeDeps({ post: vi.fn(async () => jsonResponse(201)) });
+    const res = await provisionAccountVault('acct', deps);
+    expect(res.status).toBe('provisioned');
+    expect(res.message).toContain("Provisioned account vault 'acct'");
+  });
+
+  it('200 -> exists (idempotent, already on the channel)', async () => {
+    const { deps } = makeDeps({ post: vi.fn(async () => jsonResponse(200)) });
+    const res = await provisionAccountVault('acct', deps);
+    expect(res.status).toBe('exists');
+    expect(res.message).toContain('already provisioned');
+  });
+
+  it('403 CHANNEL_DISABLED -> disabled, kept locally', async () => {
+    const post = vi.fn(async () => jsonResponse(403, { error: { code: 'CHANNEL_DISABLED' } }));
+    const { deps } = makeDeps({ post });
+    const res = await provisionAccountVault('acct', deps);
+    expect(res.status).toBe('disabled');
+    expect(res.message).toContain('registered locally');
+    expect(res.message).toContain('not enabled');
+  });
+
+  it('409 CHANNEL_CONFLICT -> conflict, kept locally, no retry on another channel', async () => {
+    const post = vi.fn(async () => jsonResponse(409, { error: { code: 'CHANNEL_CONFLICT' } }));
+    const { deps } = makeDeps({ post });
+    const res = await provisionAccountVault('acct', deps);
+    expect(res.status).toBe('conflict');
+    expect(res.message).toContain('another channel');
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts a top-level error code envelope too', async () => {
+    const post = vi.fn(async () => jsonResponse(403, { code: 'CHANNEL_DISABLED' }));
+    const { deps } = makeDeps({ post });
+    expect((await provisionAccountVault('acct', deps)).status).toBe('disabled');
+  });
+
+  it('401 -> unauthenticated, kept locally with a setup hint', async () => {
+    const { deps } = makeDeps({ post: vi.fn(async () => jsonResponse(401)) });
+    const res = await provisionAccountVault('acct', deps);
+    expect(res.status).toBe('unauthenticated');
+    expect(res.message).toContain('agentage setup');
+  });
+
+  it('no auth.json -> unauthenticated without any network call', async () => {
+    const post = vi.fn(async () => jsonResponse(201));
+    const { deps } = makeDeps({ readAuth: () => null, post });
+    const res = await provisionAccountVault('acct', deps);
+    expect(res.status).toBe('unauthenticated');
+    expect(res.message).toContain('agentage setup');
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('network failure -> offline, kept locally, will provision when online', async () => {
+    const post = vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+    const { deps } = makeDeps({ post });
+    const res = await provisionAccountVault('acct', deps);
+    expect(res.status).toBe('offline');
+    expect(res.message).toContain('when online');
+  });
+
+  it('an unexpected status stays non-fatal (offline)', async () => {
+    const { deps } = makeDeps({ post: vi.fn(async () => jsonResponse(500)) });
+    expect((await provisionAccountVault('acct', deps)).status).toBe('offline');
+  });
+});

--- a/src/lib/provision.ts
+++ b/src/lib/provision.ts
@@ -1,0 +1,93 @@
+import { authedPost } from './api.js';
+import { readAuth, type AuthState } from './config.js';
+import { links as buildLinks, siteFqdn, type Links } from './origins.js';
+
+// Provision an account vault's cloud channel. Offline-first: this is NEVER fatal to the local
+// registration - the caller keeps the local entry whatever happens here, and the daemon sync
+// loop re-provisions idempotently later.
+
+export type ProvisionStatus =
+  'provisioned' | 'exists' | 'disabled' | 'conflict' | 'unauthenticated' | 'offline';
+
+export interface ProvisionResult {
+  status: ProvisionStatus;
+  message: string;
+}
+
+export interface ProvisionDeps {
+  readAuth: () => AuthState | null;
+  links: () => Links;
+  post: (auth: AuthState, links: Links, url: string, body: unknown) => Promise<Response>;
+}
+
+export const defaultProvisionDeps = (): ProvisionDeps => ({
+  readAuth,
+  links: () => buildLinks(siteFqdn()),
+  post: authedPost,
+});
+
+// The API error envelope carries the code as `error.code` (or a top-level `code`); read it best
+// effort - a non-JSON body just yields undefined and the caller falls back to non-fatal.
+const errorCode = async (res: Response): Promise<string | undefined> => {
+  try {
+    const body = (await res.json()) as { error?: { code?: string }; code?: string };
+    return body.error?.code ?? body.code;
+  } catch {
+    return undefined;
+  }
+};
+
+const registeredLocally = (name: string, tail: string): string =>
+  `Vault '${name}' registered locally${tail}`;
+
+export const provisionAccountVault = async (
+  name: string,
+  deps: ProvisionDeps = defaultProvisionDeps()
+): Promise<ProvisionResult> => {
+  const auth = deps.readAuth();
+  if (!auth) {
+    return {
+      status: 'unauthenticated',
+      message: registeredLocally(name, ' - run `agentage setup` to sync.'),
+    };
+  }
+
+  const links = deps.links();
+  let res: Response;
+  try {
+    res = await deps.post(auth, links, `${links.api}/memories`, { name, channel: 'couch' });
+  } catch {
+    return {
+      status: 'offline',
+      message: registeredLocally(name, ' - will provision when online.'),
+    };
+  }
+
+  if (res.status === 201)
+    return { status: 'provisioned', message: `Provisioned account vault '${name}'.` };
+  if (res.status === 200)
+    return { status: 'exists', message: `Account vault '${name}' already provisioned.` };
+  if (res.status === 401)
+    return {
+      status: 'unauthenticated',
+      message: registeredLocally(name, ' - run `agentage setup` to sync.'),
+    };
+
+  const code = await errorCode(res);
+  if (res.status === 403 && code === 'CHANNEL_DISABLED')
+    return {
+      status: 'disabled',
+      message: registeredLocally(name, '. Account sync is not enabled on this server.'),
+    };
+  if (res.status === 409 && code === 'CHANNEL_CONFLICT')
+    return {
+      status: 'conflict',
+      message: registeredLocally(
+        name,
+        `. A memory named '${name}' already exists on another channel - not syncing.`
+      ),
+    };
+
+  // Any other status stays non-fatal: keep the local entry, let the daemon retry later.
+  return { status: 'offline', message: registeredLocally(name, ' - will provision when online.') };
+};

--- a/src/lib/vault-registry.test.ts
+++ b/src/lib/vault-registry.test.ts
@@ -4,7 +4,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { VaultsConfig } from '@agentage/memory-core';
-import { addVault, ensureVaultDir, formatVaultLine, removeVault } from './vault-registry.js';
+import {
+  addVault,
+  ensureVaultDir,
+  formatVaultLine,
+  removeVault,
+  vaultType,
+} from './vault-registry.js';
 
 const base = (): VaultsConfig => ({ version: 1, vaults: {} });
 
@@ -62,6 +68,21 @@ describe('removeVault', () => {
   });
 });
 
+describe('vaultType', () => {
+  it('classifies an agentage-origin entry as account', () => {
+    expect(vaultType({ path: '~/vaults/acct', origin: [{ remote: 'agentage' }] })).toBe('account');
+  });
+
+  it('classifies a path with an external origin as git', () => {
+    expect(vaultType({ path: '~/w', origin: [{ remote: 'git@h:me/w.git' }] })).toBe('git');
+  });
+
+  it('classifies a bare path as local and an origin-only entry as remote', () => {
+    expect(vaultType({ path: '/tmp/a' })).toBe('local');
+    expect(vaultType({ origin: [{ remote: 'git@h:me/r.git' }] })).toBe('remote');
+  });
+});
+
 describe('formatVaultLine', () => {
   it('labels a local vault', () => {
     expect(formatVaultLine('a', { path: '/tmp/a' })).toContain('local');
@@ -71,6 +92,12 @@ describe('formatVaultLine', () => {
     const line = formatVaultLine('work', { origin: [{ remote: 'git@github.com:me/w.git' }] });
     expect(line).toContain('remote');
     expect(line).toContain('git@github.com:me/w.git');
+  });
+
+  it('labels an account vault by type and does not echo the agentage channel as a git remote', () => {
+    const line = formatVaultLine('acct', { path: '/tmp/acct', origin: [{ remote: 'agentage' }] });
+    expect(line).toContain('account');
+    expect(line).not.toContain('<- agentage');
   });
 });
 

--- a/src/lib/vault-registry.ts
+++ b/src/lib/vault-registry.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync } from 'node:fs';
 import {
   expandPath,
+  isAccountVault,
   validateConfig,
   type VaultEntry,
   type VaultsConfig,
@@ -8,7 +9,18 @@ import {
 import { isValidVaultName } from './vaults.schema.js';
 
 // Offline registry operations over the unified vaults.json (object map keyed by name). No
-// network, no provisioning: local (--local) and git-origin (--git) entries only.
+// network here: account (agentage channel), local (--local) and git-origin (--git) entries.
+
+export type VaultType = 'account' | 'git' | 'local' | 'remote';
+
+// The human-facing type of an entry: an agentage origin is an account vault (local mirror +
+// cloud channel); otherwise a path with an external origin is git, a bare path is local, and an
+// origin without a path is remote.
+export const vaultType = (entry: VaultEntry): VaultType => {
+  if (isAccountVault(entry)) return 'account';
+  if (entry.path) return entry.origin?.length ? 'git' : 'local';
+  return 'remote';
+};
 
 // A local vault's markdown directory is created on `vault add` (~ is expanded).
 export const ensureVaultDir = (path: string): void => {
@@ -17,9 +29,10 @@ export const ensureVaultDir = (path: string): void => {
 };
 
 export const formatVaultLine = (name: string, entry: VaultEntry): string => {
-  const kind = entry.path ? (entry.origin?.length ? 'git' : 'local') : 'remote';
+  const kind = vaultType(entry);
   const where = entry.path ? expandPath(entry.path) : (entry.origin?.[0]?.remote ?? '');
-  const remote = entry.path && entry.origin?.length ? `  <- ${entry.origin[0]!.remote}` : '';
+  // Only an external git remote is worth echoing; the account channel is implied by the type.
+  const remote = kind === 'git' && entry.origin?.length ? `  <- ${entry.origin[0]!.remote}` : '';
   return `${name.padEnd(16)} ${kind.padEnd(8)} ${where}${remote}`;
 };
 

--- a/src/lib/vaults.schema.test.ts
+++ b/src/lib/vaults.schema.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { isValidVaultName, VAULTS_SCHEMA_URL } from './vaults.schema.js';
+import { isValidVaultName, VAULT_NAME_PATTERN, VAULTS_SCHEMA_URL } from './vaults.schema.js';
 
 describe('vaults.schema', () => {
   it('pins the public $schema url', () => {
     expect(VAULTS_SCHEMA_URL).toBe('https://agentage.io/schemas/vaults.schema.json');
+  });
+
+  it('re-exports the memory-core name allowlist pattern', () => {
+    expect(VAULT_NAME_PATTERN).toBe('^[A-Za-z0-9_-]{1,64}$');
+    expect(new RegExp(VAULT_NAME_PATTERN).test('scratch')).toBe(true);
   });
 
   it('accepts allowlist-safe names', () => {

--- a/src/lib/vaults.schema.ts
+++ b/src/lib/vaults.schema.ts
@@ -1,6 +1,6 @@
 // The vaults.json format is owned by @agentage/memory-core (validateConfig / VaultsConfig).
-// This module keeps only the two CLI-surface pieces memory-core does not: the editor-tooling
-// $schema pointer written on create, and the vault-name allowlist enforced at `vault add`.
+// This module keeps the one CLI-surface piece memory-core does not: the editor-tooling $schema
+// pointer written on create. Name validation re-exports memory-core's single source of truth.
 
 // The public JSON Schema location (served by the landing). Written into the file on create so
 // editors get autocomplete + inline validation; accepted-and-ignored on load. A fixed
@@ -8,7 +8,5 @@
 export const VAULTS_SCHEMA_URL = 'https://agentage.io/schemas/vaults.schema.json';
 
 // ADR-013 AA-4: every name stays a valid cloud path segment (`<sub>/<name>.git`). memory-core's
-// schema accepts any string key, so the CLI guards the name at the add surface.
-const VAULT_NAME_RE = /^[A-Za-z0-9_-]{1,64}$/;
-
-export const isValidVaultName = (name: string): boolean => VAULT_NAME_RE.test(name);
+// schema accepts any string key, so the CLI guards the name at the add surface with its allowlist.
+export { isValidVaultName, VAULT_NAME_PATTERN } from '@agentage/memory-core';

--- a/src/sync/planner.test.ts
+++ b/src/sync/planner.test.ts
@@ -77,6 +77,16 @@ describe('syncTargets', () => {
   it('skips blank remotes', () => {
     expect(syncTargets(cfg({ v: { path: '/tmp/v', origin: [{ remote: '   ' }] } }))).toEqual([]);
   });
+
+  it('never picks up an account (agentage-origin) vault, even with a local path', () => {
+    const config = cfg({
+      acct: { path: '/tmp/acct', origin: [{ remote: 'agentage' }] },
+      work: { path: '/tmp/work', origin: [{ remote: 'git@h:me/w.git' }] },
+    });
+    // The account vault is filtered out of both the on-demand targets and the auto loop.
+    expect(syncTargets(config).map((t) => t.vault)).toEqual(['work']);
+    expect(autoSyncTargets(config).map((t) => t.vault)).toEqual(['work']);
+  });
 });
 
 describe('autoSyncTargets', () => {


### PR DESCRIPTION
## M1c - account vaults with couch-channel provisioning

Makes `agentage vault add <name>` (no `--local`/`--git`) the **account vault** path: a local mirror plus the agentage cloud channel. Offline-first - the local entry is written first and provisioning is never fatal to the local registration.

### What changed
- **Bumped `@agentage/memory-core` to `^0.2.0`** (targeted; lock touches only memory-core + the expected nested `server-memory/node_modules/@agentage/memory-core@0.1.3` subtree). Uses its `isAccountVault`, `isValidVaultName`, `VAULT_NAME_PATTERN`.
- **Account add:** no-flag `vault add <name>` writes `{ path, origin: [{ remote: "agentage" }] }`, creates the local mirror dir (default `~/vaults/<name>`, or `--path <dir>`), then attempts provisioning. `--local`/`--git` behavior is byte-identical. First vault still becomes default.
- **`authedPost(auth, links, url, body)`** in `src/lib/api.ts` - bearer + refresh-once (mirrors `authedGet`), returns the raw `Response` so callers branch on status.
- **Provisioning** (`src/lib/provision.ts`): `POST {api}/api/memories` with `{"name","channel":"couch"}`. Branches (all non-fatal, exit 0): `201` provisioned, `200` already exists, `403 CHANNEL_DISABLED` account sync off, `409 CHANNEL_CONFLICT` name on another channel (never retried on a different channel), `401`/no `auth.json` not signed in (no network call made), network failure -> will provision when online.
- **`vault list`:** account vaults render as type `account`; `--json` stays backward-compatible (name-keyed map) with an honest `type` added per entry.
- **`vault remove`:** unchanged - local unregister, files stay, never calls the server (test added for account entries).
- **`vault sync <account>`:** reports it clearly ("account vault - not a git remote") instead of a misleading "no git origin"; the sync planner already excludes the `agentage` remote (unit test added proving an account vault is never picked up by the git loop).

### Tests
- Unit (mock/injected deps) for every provisioning branch, the add flow (entry written before provisioning, dir created, name validation), `authedPost`, `vaultType`, account list `--json`, account remove, and account sync exclusion. 263 unit tests pass; coverage 85/78/76/87 (thresholds 65/70/70/70).
- E2E `e2e/account-vault.test.ts` (`@p0`, egress blackholed): no-flag add -> exit 0, agentage-origin entry + mirror dir written, memory write/read works immediately, output mentions local registration; list shows type account; remove keeps files; sync reports clearly. Ran 3x clean; full offline set (10 files) green.

### Hygiene
Zero new deps (R6 - fetch is built-in). No version/CHANGELOG changes (release-prepare owns those). Public-safe strings only.
