### PR TITLE
feat(sync): couch account sync in the daemon (M5)

### DIFF
--- a/e2e/account-vault.test.ts
+++ b/e2e/account-vault.test.ts
@@ -95,15 +95,17 @@ test.describe('account vault (offline) @p0', () => {
     }
   });
 
-  test('vault sync on an account vault reports it clearly instead of erroring', async () => {
+  test('vault sync on an offline, signed-out account vault pauses instead of erroring', async () => {
     const m = createCliMachine(OFFLINE);
     try {
       const vaultDir = join(m.configDir, 'acct');
       expect((await m.exec(['vault', 'add', 'acct', '--path', vaultDir])).code).toBe(0);
 
+      // Not signed in: the couch cycle pauses with zero network, never a crash (exit 0).
       const sync = await m.exec(['vault', 'sync', 'acct']);
       expect(sync.code, sync.stderr).toBe(0);
-      expect(sync.stdout).toContain('account vault');
+      expect(sync.stdout).toContain('acct (account)');
+      expect(sync.stdout).toContain('paused (signed out)');
     } finally {
       m.cleanup();
     }

--- a/e2e/couch-sync.test.ts
+++ b/e2e/couch-sync.test.ts
@@ -9,14 +9,14 @@
  */
 import { execFile, execFileSync } from 'node:child_process';
 import { createHash, createHmac, randomUUID } from 'node:crypto';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { createServer as netServer, type AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
-import { encodeFile } from '@agentage/memory-core';
+import { CouchSync, createCouchState, encodeFile, type FetchLike } from '@agentage/memory-core';
 import { expect, test } from '@playwright/test';
 import { createCliMachine, freePort, type CliMachine } from './helpers.js';
 
@@ -194,6 +194,7 @@ interface Stub {
   port: number;
   requests(): number;
   setDb(db: string): void;
+  setTokenFail(fail: boolean): void;
   stop(): Promise<void>;
 }
 
@@ -201,6 +202,7 @@ const startStub = async (couch: Couch): Promise<Stub> => {
   const port = await freeTcpPort();
   let db = '';
   let count = 0;
+  let tokenFail = false;
   const handle = (req: IncomingMessage, res: ServerResponse): void => {
     count += 1;
     const url = (req.url ?? '').split('?')[0] ?? '';
@@ -217,11 +219,15 @@ const startStub = async (couch: Couch): Promise<Stub> => {
         couch_vaults: [{ vault: VAULT, db }],
         ttl: 60,
       });
-    if (req.method === 'POST' && url === '/account/couch-token')
+    if (req.method === 'POST' && url === '/account/couch-token') {
+      if (tokenFail) return send(401, { error: 'unauthorized' });
+      // expSec 61 = the client cache lapses after ~1s (60s skew), so a test can force a re-mint;
+      // the JWT itself stays valid for an hour.
       return send(200, {
         success: true,
-        data: { jwt: mintJwt(couch.jwtSecret), db, sub: SUB, expSec: 3600 },
+        data: { jwt: mintJwt(couch.jwtSecret), db, sub: SUB, expSec: 61 },
       });
+    }
     if (req.method === 'POST' && url === '/api/memories') return send(200, { success: true });
     send(404, { error: 'not found' });
   };
@@ -232,6 +238,9 @@ const startStub = async (couch: Couch): Promise<Stub> => {
     requests: () => count,
     setDb: (d) => {
       db = d;
+    },
+    setTokenFail: (f) => {
+      tokenFail = f;
     },
     stop: () => new Promise((resolve) => server.close(() => resolve())),
   };
@@ -410,6 +419,81 @@ test.describe('couch account sync (hermetic) @couch', () => {
 
       await sleep(400); // let any fire-and-forget push settle
       expect(stub.requests(), 'signed-out sync must make zero network calls').toBe(before);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('a signed-out delete tombstones after sign-in; a fresh replica never resurrects it', async () => {
+    const db = await createDb(couch);
+    stub.setDb(db);
+    const { m, cleanup } = await bootMachine(stub, { signedIn: true });
+    try {
+      // Two synced docs: keep.md stays, del.md is deleted while signed out.
+      expect((await m.exec(['memory', 'write', 'notes/keep.md', '--body', 'stays'])).code).toBe(0);
+      expect((await m.exec(['memory', 'write', 'notes/del.md', '--body', 'doomed'])).code).toBe(0);
+      expect((await m.exec(['vault', 'sync', VAULT])).code).toBe(0);
+      await waitFor(async () => (await getDoc(couch, db, 'f:notes/del.md')).status === 200);
+
+      // Signed out: the delete succeeds locally and queues a durable deletion, no tombstone yet.
+      rmSync(join(m.configDir, 'auth.json'));
+      const del = await m.exec(['memory', 'delete', 'notes/del.md']);
+      expect(del.code, del.stderr).toBe(0);
+      await sleep(500); // let the fire-and-forget enqueue persist
+      expect((await getDoc(couch, db, 'f:notes/del.md')).status).toBe(200);
+
+      // Sign back in and sync: the queued deletion becomes the couch tombstone.
+      fakeAuth(m, stub.port);
+      expect((await m.exec(['vault', 'sync', VAULT])).code).toBe(0);
+      await waitFor(async () => (await getDoc(couch, db, 'f:notes/del.md')).status === 404);
+
+      // A fresh second replica replaying the feed from cursor 0 pulls keep.md but never del.md.
+      const files = new Map<string, string>();
+      const store = {
+        listMarkdown: async () => [...files.keys()],
+        read: async (p: string) => files.get(p) ?? null,
+        write: async (p: string, b: string) => void files.set(p, b),
+        remove: async (p: string) => void files.delete(p),
+      };
+      const state = await createCouchState({ load: async () => null, save: async () => {} });
+      const fetchLike: FetchLike = (url, init) => fetch(url, init as RequestInit);
+      const replica = new CouchSync(
+        store,
+        { endpoint: couch.url, db },
+        fetchLike,
+        async () => mintJwt(couch.jwtSecret),
+        () => {},
+        state
+      );
+      await replica.pullOnce();
+      expect(files.has('notes/keep.md'), 'replica pulled live content').toBe(true);
+      expect(files.has('notes/del.md'), 'deleted doc must not resurrect').toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('a delete during a token-endpoint outage converges once tokens recover', async () => {
+    const db = await createDb(couch);
+    stub.setDb(db);
+    const { m, cleanup } = await bootMachine(stub, { signedIn: true });
+    try {
+      expect((await m.exec(['memory', 'write', 'notes/q.md', '--body', 'target'])).code).toBe(0);
+      expect((await m.exec(['vault', 'sync', VAULT])).code).toBe(0);
+      await waitFor(async () => (await getDoc(couch, db, 'f:notes/q.md')).status === 200);
+
+      // Let the daemon's short-lived token cache lapse, then 401 every mint during the delete.
+      await sleep(1200);
+      stub.setTokenFail(true);
+      const del = await m.exec(['memory', 'delete', 'notes/q.md']);
+      expect(del.code, del.stderr).toBe(0);
+      await sleep(500); // the live tombstone fails against the 401 and self-queues
+      expect((await getDoc(couch, db, 'f:notes/q.md')).status).toBe(200);
+
+      // Token endpoint recovers: the next cycle drains the queued deletion.
+      stub.setTokenFail(false);
+      expect((await m.exec(['vault', 'sync', VAULT])).code).toBe(0);
+      await waitFor(async () => (await getDoc(couch, db, 'f:notes/q.md')).status === 404);
     } finally {
       await cleanup();
     }

--- a/e2e/couch-sync.test.ts
+++ b/e2e/couch-sync.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Hermetic couch account-sync tier: drives the REAL built CLI + daemon end to end against a REAL
+ * couchdb:3.4 container and a node:http stub for discovery/token/provision. Nothing here touches a
+ * deployed stack. Gated on docker: without it the whole tier skips (with a reason). @couch
+ *
+ * The couch JWT recipe (proven in a prior spike): the jwt handler must be in the config AT STARTUP
+ * (a runtime PUT does not engage it); the hmac key can then be set at runtime. The stub mints a
+ * REAL HS256 token couch must accept - that proves the production auth mode, not a bypass.
+ */
+import { execFile, execFileSync } from 'node:child_process';
+import { createHash, createHmac, randomUUID } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { createServer as netServer, type AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { encodeFile } from '@agentage/memory-core';
+import { expect, test } from '@playwright/test';
+import { createCliMachine, freePort, type CliMachine } from './helpers.js';
+
+const run = promisify(execFile);
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+// The couch user id: the JWT `sub`, and the only member of every per-test db.
+const SUB = 'cli-couch-e2e';
+const VAULT = 'acct';
+
+const dockerAvailable = (): boolean => {
+  try {
+    execFileSync('docker', ['info'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+};
+const DOCKER = dockerAvailable();
+
+const freeTcpPort = (): Promise<number> =>
+  new Promise((resolve, reject) => {
+    const srv = netServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const port = (srv.address() as AddressInfo).port;
+      srv.close((err) => (err ? reject(err) : resolve(port)));
+    });
+  });
+
+// --- couchdb:3.4 harness (adapted from web/packages/couch-bridge/test/couch-harness.ts) --------
+const IMAGE = 'couchdb:3.4';
+const ADMIN_USER = 'admin';
+const ADMIN_PASS = 'm5-admin-pw';
+const LOCAL_INI = [
+  '[chttpd]',
+  'authentication_handlers = {chttpd_auth, jwt_authentication_handler}, ' +
+    '{chttpd_auth, cookie_authentication_handler}, {chttpd_auth, default_authentication_handler}',
+  '',
+  '[jwt_auth]',
+  'required_claims = exp',
+  '',
+].join('\n');
+
+interface Couch {
+  url: string;
+  adminAuth: string;
+  jwtSecret: string;
+  stop(): Promise<void>;
+}
+
+const waitUp = async (url: string): Promise<void> => {
+  const deadline = Date.now() + 60_000;
+  for (;;) {
+    try {
+      if ((await fetch(`${url}/_up`)).ok) return;
+    } catch {
+      // not listening yet
+    }
+    if (Date.now() > deadline) throw new Error(`couch not up at ${url}`);
+    await sleep(250);
+  }
+};
+
+const startCouch = async (): Promise<Couch> => {
+  const port = await freeTcpPort();
+  const name = `cli-couch-it-${randomUUID().slice(0, 8)}`;
+  const dir = await mkdtemp(join(tmpdir(), 'cli-couch-it-'));
+  const ini = join(dir, 'zz-agentage.ini');
+  await writeFile(ini, LOCAL_INI, 'utf8');
+  const stop = async (): Promise<void> => {
+    await run('docker', ['rm', '-f', name]).catch(() => {});
+    await rm(dir, { recursive: true, force: true });
+  };
+  try {
+    // create + cp + start: a ro bind mount trips the image entrypoint's chown -R.
+    await run('docker', [
+      'create',
+      '--name',
+      name,
+      '-p',
+      `127.0.0.1:${port}:5984`,
+      '-e',
+      `COUCHDB_USER=${ADMIN_USER}`,
+      '-e',
+      `COUCHDB_PASSWORD=${ADMIN_PASS}`,
+      IMAGE,
+    ]);
+    await run('docker', ['cp', ini, `${name}:/opt/couchdb/etc/local.d/zz-agentage.ini`]);
+    await run('docker', ['start', name]);
+
+    const url = `http://127.0.0.1:${port}`;
+    const adminAuth = 'Basic ' + Buffer.from(`${ADMIN_USER}:${ADMIN_PASS}`).toString('base64');
+    await waitUp(url);
+    for (const db of ['_users', '_replicator']) {
+      const res = await fetch(`${url}/${db}`, {
+        method: 'PUT',
+        headers: { Authorization: adminAuth },
+      });
+      if (!res.ok && res.status !== 412) throw new Error(`system db ${db} failed (${res.status})`);
+    }
+    const jwtSecret = `m5-secret-${randomUUID()}`;
+    const res = await fetch(`${url}/_node/_local/_config/jwt_keys/hmac%3A_default`, {
+      method: 'PUT',
+      headers: { Authorization: adminAuth, 'Content-Type': 'application/json' },
+      body: JSON.stringify(Buffer.from(jwtSecret).toString('base64')),
+    });
+    if (!res.ok) throw new Error(`jwt key set failed (${res.status})`);
+    return { url, adminAuth, jwtSecret, stop };
+  } catch (e) {
+    await stop();
+    throw e;
+  }
+};
+
+// A fresh per-test db whose only member is the JWT subject - proves the real member-scoped auth.
+const createDb = async (couch: Couch): Promise<string> => {
+  const db = `mem_${randomUUID().replace(/-/g, '').slice(0, 16)}`;
+  const create = await fetch(`${couch.url}/${db}`, {
+    method: 'PUT',
+    headers: { Authorization: couch.adminAuth },
+  });
+  if (!create.ok) throw new Error(`create db failed (${create.status})`);
+  const sec = await fetch(`${couch.url}/${db}/_security`, {
+    method: 'PUT',
+    headers: { Authorization: couch.adminAuth, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      admins: { names: [], roles: [] },
+      members: { names: [SUB], roles: [] },
+    }),
+  });
+  if (!sec.ok) throw new Error(`_security failed (${sec.status})`);
+  return db;
+};
+
+const b64url = (s: string): string => Buffer.from(s).toString('base64url');
+
+// A real HS256 JWT (kid _default) couch validates against hmac:_default = base64(secret).
+const mintJwt = (secret: string, ttlSec = 3600): string => {
+  const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT', kid: '_default' }));
+  const payload = b64url(JSON.stringify({ sub: SUB, exp: Math.floor(Date.now() / 1000) + ttlSec }));
+  const sig = createHmac('sha256', secret).update(`${header}.${payload}`).digest('base64url');
+  return `${header}.${payload}.${sig}`;
+};
+
+const docUrl = (couch: Couch, db: string, id: string): string =>
+  `${couch.url}/${db}/${encodeURIComponent(id)}`;
+
+const getDoc = async (
+  couch: Couch,
+  db: string,
+  id: string
+): Promise<{ status: number; json: Record<string, unknown> }> => {
+  const res = await fetch(docUrl(couch, db, id), { headers: { Authorization: couch.adminAuth } });
+  return {
+    status: res.status,
+    json: (await res.json().catch(() => ({}))) as Record<string, unknown>,
+  };
+};
+
+// Insert a proper file+leaf doc pair with the content-addressed shape, replicated-style.
+const putFile = async (couch: Couch, db: string, path: string, content: string): Promise<void> => {
+  const { leaves, fileDoc } = await encodeFile(path, content);
+  const rev = `1-${createHash('md5').update(JSON.stringify(fileDoc.leaves)).digest('hex')}`;
+  const res = await fetch(`${couch.url}/${db}/_bulk_docs`, {
+    method: 'POST',
+    headers: { Authorization: couch.adminAuth, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ new_edits: false, docs: [...leaves, { ...fileDoc, _rev: rev }] }),
+  });
+  if (!res.ok) throw new Error(`_bulk_docs failed (${res.status})`);
+};
+
+// --- discovery / token / provision stub (a single server, all origins collapse onto it) --------
+interface Stub {
+  port: number;
+  requests(): number;
+  setDb(db: string): void;
+  stop(): Promise<void>;
+}
+
+const startStub = async (couch: Couch): Promise<Stub> => {
+  const port = await freeTcpPort();
+  let db = '';
+  let count = 0;
+  const handle = (req: IncomingMessage, res: ServerResponse): void => {
+    count += 1;
+    const url = (req.url ?? '').split('?')[0] ?? '';
+    const send = (code: number, body: unknown): void => {
+      res.writeHead(code, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(body));
+    };
+    if (req.method === 'GET' && url === '/.well-known/agentage-sync')
+      return send(200, {
+        git_endpoint: `http://127.0.0.1:${port}/git`,
+        vaults: [],
+        couch_endpoint: couch.url,
+        couch_token_url: `http://127.0.0.1:${port}/account/couch-token`,
+        couch_vaults: [{ vault: VAULT, db }],
+        ttl: 60,
+      });
+    if (req.method === 'POST' && url === '/account/couch-token')
+      return send(200, {
+        success: true,
+        data: { jwt: mintJwt(couch.jwtSecret), db, sub: SUB, expSec: 3600 },
+      });
+    if (req.method === 'POST' && url === '/api/memories') return send(200, { success: true });
+    send(404, { error: 'not found' });
+  };
+  const server = createServer(handle);
+  await new Promise<void>((resolve) => server.listen(port, '127.0.0.1', resolve));
+  return {
+    port,
+    requests: () => count,
+    setDb: (d) => {
+      db = d;
+    },
+    stop: () => new Promise((resolve) => server.close(() => resolve())),
+  };
+};
+
+// --- machine helpers ----------------------------------------------------------------------------
+const fakeAuth = (m: CliMachine, stubPort: number): void =>
+  writeFileSync(
+    join(m.configDir, 'auth.json'),
+    JSON.stringify({
+      siteFqdn: `127.0.0.1:${stubPort}`,
+      clientId: 'stub-client',
+      tokens: { accessToken: 'stub-oauth-bearer', expiresAt: Date.now() + 3_600_000 },
+    })
+  );
+
+// Pin the account origin to interval 0 (manual-only) so no background timer races assertions.
+const setManual = (m: CliMachine): void => {
+  const p = join(m.configDir, 'vaults.json');
+  const cfg = JSON.parse(readFileSync(p, 'utf8')) as {
+    vaults: Record<string, { origin: { remote: string; interval?: number }[] }>;
+  };
+  cfg.vaults[VAULT]!.origin[0]!.interval = 0;
+  writeFileSync(p, JSON.stringify(cfg, null, 2));
+};
+
+interface Machine {
+  m: CliMachine;
+  vaultDir: string;
+  cleanup(): Promise<void>;
+}
+
+// A CLI machine wired to the stub, an account vault added + the daemon started.
+const bootMachine = async (stub: Stub, opts: { signedIn: boolean }): Promise<Machine> => {
+  const daemonPort = await freePort();
+  const m = createCliMachine({
+    AGENTAGE_SITE_FQDN: `127.0.0.1:${stub.port}`,
+    AGENTAGE_NO_DAEMON: '',
+    AGENTAGE_DAEMON_PORT: String(daemonPort),
+  });
+  if (opts.signedIn) fakeAuth(m, stub.port);
+  const vaultDir = join(m.configDir, VAULT);
+  const add = await m.exec(['vault', 'add', VAULT, '--path', vaultDir]);
+  expect(add.code, add.stderr).toBe(0);
+  setManual(m);
+  const start = await m.exec(['daemon', 'start']);
+  expect(start.code, start.stderr).toBe(0);
+  return {
+    m,
+    vaultDir,
+    cleanup: async () => {
+      await m.exec(['daemon', 'stop']).catch(() => {});
+      m.cleanup();
+    },
+  };
+};
+
+const waitFor = async (predicate: () => Promise<boolean>, ms = 15_000): Promise<void> => {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await sleep(200);
+  }
+  throw new Error('waitFor: condition not met in time');
+};
+
+test.describe('couch account sync (hermetic) @couch', () => {
+  test.skip(!DOCKER, 'docker unavailable - couch account-sync tier skipped');
+  test.describe.configure({ timeout: 90_000 });
+
+  let couch: Couch;
+  let stub: Stub;
+
+  test.beforeAll(async () => {
+    if (!DOCKER) return;
+    couch = await startCouch();
+    stub = await startStub(couch);
+  });
+  test.afterAll(async () => {
+    await stub?.stop();
+    await couch?.stop();
+  });
+
+  test('sync-on-save pushes a write to couch; status shows the couch vault', async () => {
+    const db = await createDb(couch);
+    stub.setDb(db);
+    const { m, vaultDir, cleanup } = await bootMachine(stub, { signedIn: true });
+    try {
+      const body = 'account note pushed over the couch channel';
+      expect((await m.exec(['memory', 'write', 'notes/x.md', '--body', body])).code).toBe(0);
+
+      // The engine stored the serialized doc on disk; the couch leaf is content-addressed off it.
+      const onDisk = readFileSync(join(vaultDir, 'notes/x.md'), 'utf8');
+      const { fileDoc, leaves } = await encodeFile('notes/x.md', onDisk);
+      const leaf = leaves[0]!;
+      await waitFor(async () => (await getDoc(couch, db, fileDoc._id)).status === 200);
+      const stored = await getDoc(couch, db, fileDoc._id);
+      expect(stored.json['path']).toBe('notes/x.md');
+      expect(stored.json['leaves']).toEqual(fileDoc.leaves);
+      const storedLeaf = await getDoc(couch, db, leaf._id);
+      expect(storedLeaf.status).toBe(200);
+      expect(storedLeaf.json['data']).toBe(leaf.data);
+
+      const status = await m.exec(['daemon', 'status']);
+      expect(status.stdout).toContain('couch sync');
+      expect(status.stdout).toContain(VAULT);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('a file inserted into couch pulls to disk, commits, and reads back', async () => {
+    const db = await createDb(couch);
+    stub.setDb(db);
+    const { m, vaultDir, cleanup } = await bootMachine(stub, { signedIn: true });
+    try {
+      await putFile(couch, db, 'notes/y.md', 'pulled from couch into the mirror\n');
+
+      const sync = await m.exec(['vault', 'sync', VAULT]);
+      expect(sync.code, sync.stderr).toBe(0);
+
+      const disk = join(vaultDir, 'notes/y.md');
+      expect(existsSync(disk), sync.stdout).toBe(true);
+      expect(readFileSync(disk, 'utf8')).toContain('pulled from couch');
+      const gitLog = await run('git', ['-C', vaultDir, 'log', '--oneline']);
+      expect(gitLog.stdout).toContain('sync: couch');
+      const read = await m.exec(['memory', 'read', 'notes/y.md']);
+      expect(read.stdout).toContain('pulled from couch');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('deletes propagate both directions', async () => {
+    const db = await createDb(couch);
+    stub.setDb(db);
+    const { m, vaultDir, cleanup } = await bootMachine(stub, { signedIn: true });
+    try {
+      // CLI delete -> couch tombstone.
+      expect((await m.exec(['memory', 'write', 'notes/z.md', '--body', 'delete me'])).code).toBe(0);
+      expect((await m.exec(['vault', 'sync', VAULT])).code).toBe(0);
+      await waitFor(async () => (await getDoc(couch, db, 'f:notes/z.md')).status === 200);
+      expect((await m.exec(['memory', 'delete', 'notes/z.md'])).code).toBe(0);
+      await waitFor(async () => (await getDoc(couch, db, 'f:notes/z.md')).status === 404);
+
+      // Couch tombstone -> local file removed.
+      await putFile(couch, db, 'notes/w.md', 'temporary, soon removed by couch\n');
+      expect((await m.exec(['vault', 'sync', VAULT])).code).toBe(0);
+      expect(existsSync(join(vaultDir, 'notes/w.md'))).toBe(true);
+      const cur = await getDoc(couch, db, 'f:notes/w.md');
+      await fetch(`${docUrl(couch, db, 'f:notes/w.md')}?rev=${cur.json['_rev'] as string}`, {
+        method: 'DELETE',
+        headers: { Authorization: couch.adminAuth },
+      });
+      expect((await m.exec(['vault', 'sync', VAULT])).code).toBe(0);
+      expect(existsSync(join(vaultDir, 'notes/w.md'))).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('signed out: sync pauses, CRUD still works, zero couch requests', async () => {
+    const db = await createDb(couch);
+    stub.setDb(db);
+    const { m, cleanup } = await bootMachine(stub, { signedIn: false });
+    try {
+      const before = stub.requests();
+      expect(
+        (await m.exec(['memory', 'write', 'notes/s.md', '--body', 'works offline'])).code
+      ).toBe(0);
+      expect((await m.exec(['memory', 'read', 'notes/s.md'])).stdout).toContain('works offline');
+
+      const sync = await m.exec(['vault', 'sync', VAULT]);
+      expect(sync.code, sync.stderr).toBe(0);
+      expect(sync.stdout).toContain('paused (signed out)');
+
+      await sleep(400); // let any fire-and-forget push settle
+      expect(stub.requests(), 'signed-out sync must make zero network calls').toBe(before);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
-        "@agentage/memory-core": "^0.3.0",
+        "@agentage/memory-core": "^0.3.1",
         "@agentage/server-memory": "^0.0.3",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chalk": "latest",
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@agentage/memory-core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@agentage/memory-core/-/memory-core-0.3.0.tgz",
-      "integrity": "sha512-AUVOImejMPKTo6E0yVWiaIYschKSi0kSay+oZyXDzIyqeFTbTQvKlCV8mIkv6WqoSaTSUIYmRcwkOpCXM8GIrA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@agentage/memory-core/-/memory-core-0.3.1.tgz",
+      "integrity": "sha512-GBP+DCBLf1E/WTr8lbj3j3lq1aW+gCFIJsaSgJxSH7y8b30wts76UEMHzYskJeeofFRvpwnUEN/9sIEnNWYz5Q==",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
-        "@agentage/memory-core": "^0.2.0",
+        "@agentage/memory-core": "^0.3.0",
         "@agentage/server-memory": "^0.0.3",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chalk": "latest",
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@agentage/memory-core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@agentage/memory-core/-/memory-core-0.2.0.tgz",
-      "integrity": "sha512-ZeKu4jIi4T3O02SjVBLoGzVRMR1/xfhkCsUAy06yRQ2bf9oFtRL7VcATJ7/nBP7zy1Bp/5R+DUsKOkrSkl5lVA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@agentage/memory-core/-/memory-core-0.3.0.tgz",
+      "integrity": "sha512-AUVOImejMPKTo6E0yVWiaIYschKSi0kSay+oZyXDzIyqeFTbTQvKlCV8mIkv6WqoSaTSUIYmRcwkOpCXM8GIrA==",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prepublishOnly": "npm run verify"
   },
   "dependencies": {
-    "@agentage/memory-core": "^0.3.0",
+    "@agentage/memory-core": "^0.3.1",
     "@agentage/server-memory": "^0.0.3",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chalk": "latest",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prepublishOnly": "npm run verify"
   },
   "dependencies": {
-    "@agentage/memory-core": "^0.2.0",
+    "@agentage/memory-core": "^0.3.0",
     "@agentage/server-memory": "^0.0.3",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chalk": "latest",

--- a/src/commands/daemon-cmd.ts
+++ b/src/commands/daemon-cmd.ts
@@ -62,6 +62,23 @@ const statusAction = async (): Promise<void> => {
       console.log(`  ${v.vault.padEnd(16)} ${cadence.padEnd(12)} ${state}`);
     }
   }
+  if (sync?.couch && sync.couch.length > 0) {
+    console.log('couch sync');
+    for (const v of sync.couch) {
+      const cadence = v.intervalSeconds > 0 ? `every ${v.intervalSeconds}s` : 'manual';
+      const state = v.paused
+        ? `paused: ${v.paused}`
+        : v.running
+          ? 'running'
+          : v.lastError
+            ? `error: ${v.lastError}`
+            : v.lastSync
+              ? `ok ${v.lastSync}`
+              : 'scheduled';
+      const pending = v.pendingCount > 0 ? `  ${v.pendingCount} pending` : '';
+      console.log(`  ${v.vault.padEnd(16)} ${cadence.padEnd(12)} ${state}${pending}`);
+    }
+  }
 };
 
 export const registerDaemon = (program: Command): void => {

--- a/src/commands/vault-sync.test.ts
+++ b/src/commands/vault-sync.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { type VaultsConfig } from '@agentage/memory-core';
 import { type SyncResult } from '../sync/cycle.js';
+import { type CouchSyncResult } from '../sync/couch/manager.js';
 import { type SyncTarget } from '../sync/planner.js';
 import { runVaultSync, type VaultSyncDeps } from './vault-sync.js';
 
@@ -14,16 +15,34 @@ const result = (over: Partial<SyncResult> = {}): SyncResult => ({
   ...over,
 });
 
+const couchResult = (over: Partial<CouchSyncResult> = {}): CouchSyncResult => ({
+  vault: 'acct',
+  channel: 'couch',
+  ok: true,
+  committed: false,
+  pulled: false,
+  pendingCount: 0,
+  ...over,
+});
+
+const gitConfig = (): VaultsConfig => ({
+  version: 1,
+  vaults: { v: { path: '/tmp/v', origin: [{ remote: 'git@h:v.git', interval: 0 }] } },
+});
+
+const acctConfig = (): VaultsConfig => ({
+  version: 1,
+  vaults: { acct: { path: '/tmp/acct', origin: [{ remote: 'agentage' }] } },
+});
+
 const makeDeps = (over: Partial<VaultSyncDeps> = {}): { deps: VaultSyncDeps; logs: string[] } => {
   const logs: string[] = [];
   const deps: VaultSyncDeps = {
-    loadConfig: (): VaultsConfig => ({
-      version: 1,
-      vaults: { v: { path: '/tmp/v', origin: [{ remote: 'git@h:v.git', interval: 0 }] } },
-    }),
+    loadConfig: gitConfig,
     daemonPort: async () => null,
     runViaDaemon: async () => result(),
-    runInProcess: async () => result(),
+    runGitInProcess: async () => result(),
+    runCouchInProcess: async () => couchResult(),
     log: (m) => logs.push(m),
     ...over,
   };
@@ -31,64 +50,87 @@ const makeDeps = (over: Partial<VaultSyncDeps> = {}): { deps: VaultSyncDeps; log
 };
 
 describe('runVaultSync', () => {
-  it('reports "no git origin" for an unknown vault name', async () => {
+  it('reports "no syncable origin" for an unknown vault name', async () => {
     const { deps, logs } = makeDeps();
     await runVaultSync('missing', deps);
-    expect(logs.join()).toContain("No git origin configured for vault 'missing'");
+    expect(logs.join()).toContain("No syncable origin configured for vault 'missing'");
   });
 
-  it('hints when no git-synced vaults exist', async () => {
+  it('hints when no syncable vaults exist', async () => {
     const { deps, logs } = makeDeps({ loadConfig: () => ({ version: 1, vaults: {} }) });
     await runVaultSync(undefined, deps);
-    expect(logs.join()).toContain('No git-synced vaults');
+    expect(logs.join()).toContain('No syncable vaults');
   });
 
-  it('reports an account vault clearly and never attempts a git sync', async () => {
-    const runViaDaemon = vi.fn(async () => result());
-    const runInProcess = vi.fn(async () => result());
+  it('runs an account vault in-process over the couch channel', async () => {
+    const runCouchInProcess = vi.fn(async () => couchResult({ committed: true, pulled: true }));
+    const runGitInProcess = vi.fn(async (_t: SyncTarget) => result());
     const { deps, logs } = makeDeps({
-      loadConfig: () => ({
-        version: 1,
-        vaults: { acct: { path: '/tmp/acct', origin: [{ remote: 'agentage' }] } },
-      }),
-      daemonPort: async () => 4243,
-      runViaDaemon,
-      runInProcess,
+      loadConfig: acctConfig,
+      daemonPort: async () => null,
+      runCouchInProcess,
+      runGitInProcess,
     });
     await runVaultSync('acct', deps);
-    expect(logs.join()).toContain("Vault 'acct' is an account vault");
-    expect(runViaDaemon).not.toHaveBeenCalled();
-    expect(runInProcess).not.toHaveBeenCalled();
+    expect(runCouchInProcess).toHaveBeenCalledWith('acct');
+    expect(runGitInProcess).not.toHaveBeenCalled();
+    expect(logs.join()).toContain('acct (account): ');
+    expect(logs.join()).toContain('committed');
+    expect(logs.join()).toContain('pulled');
   });
 
-  it('runs in-process when the daemon is down', async () => {
-    const runInProcess = vi.fn(async (_t: SyncTarget) => result({ committed: true }));
-    const { deps, logs } = makeDeps({ daemonPort: async () => null, runInProcess });
+  it('renders a paused account vault clearly', async () => {
+    const { deps, logs } = makeDeps({
+      loadConfig: acctConfig,
+      daemonPort: async () => null,
+      runCouchInProcess: async () => couchResult({ paused: 'signed out' }),
+    });
+    await runVaultSync('acct', deps);
+    expect(logs.join()).toContain('paused (signed out)');
+  });
+
+  it('delegates an account vault to the daemon when one is reachable', async () => {
+    const runViaDaemon = vi.fn(async () => couchResult());
+    const runCouchInProcess = vi.fn(async () => couchResult());
+    const { deps } = makeDeps({
+      loadConfig: acctConfig,
+      daemonPort: async () => 4243,
+      runViaDaemon,
+      runCouchInProcess,
+    });
+    await runVaultSync('acct', deps);
+    expect(runViaDaemon).toHaveBeenCalledWith(4243, 'acct');
+    expect(runCouchInProcess).not.toHaveBeenCalled();
+  });
+
+  it('runs a git vault in-process when the daemon is down', async () => {
+    const runGitInProcess = vi.fn(async (_t: SyncTarget) => result({ committed: true }));
+    const { deps, logs } = makeDeps({ daemonPort: async () => null, runGitInProcess });
     await runVaultSync('v', deps);
-    expect(runInProcess).toHaveBeenCalledTimes(1);
+    expect(runGitInProcess).toHaveBeenCalledTimes(1);
     expect(logs.join()).toContain('committed');
     expect(logs.join()).toContain('pushed');
   });
 
-  it('delegates to the daemon when one is reachable', async () => {
+  it('delegates a git vault to the daemon when one is reachable', async () => {
     const runViaDaemon = vi.fn(async () => result());
-    const runInProcess = vi.fn(async (t: SyncTarget) => result({ vault: t.vault }));
-    const { deps } = makeDeps({ daemonPort: async () => 4243, runViaDaemon, runInProcess });
+    const runGitInProcess = vi.fn(async (t: SyncTarget) => result({ vault: t.vault }));
+    const { deps } = makeDeps({ daemonPort: async () => 4243, runViaDaemon, runGitInProcess });
     await runVaultSync('v', deps);
     expect(runViaDaemon).toHaveBeenCalledWith(4243, 'v');
-    expect(runInProcess).not.toHaveBeenCalled();
+    expect(runGitInProcess).not.toHaveBeenCalled();
   });
 
-  it('surfaces a failure line and lists preserved conflict copies', async () => {
+  it('surfaces a git failure line and lists preserved conflict copies', async () => {
     const { deps, logs } = makeDeps({
-      runInProcess: async () =>
+      runGitInProcess: async () =>
         result({ ok: false, pushed: false, reason: 'unreachable', error: 'nope' }),
     });
     await runVaultSync('v', deps);
     expect(logs.join()).toContain('failed (unreachable)');
 
     const { deps: d2, logs: l2 } = makeDeps({
-      runInProcess: async () => result({ conflicts: ['note.conflict.md'] }),
+      runGitInProcess: async () => result({ conflicts: ['note.conflict.md'] }),
     });
     await runVaultSync('v', d2);
     expect(l2.join()).toContain('kept remote copy: note.conflict.md');

--- a/src/commands/vault-sync.ts
+++ b/src/commands/vault-sync.ts
@@ -1,22 +1,27 @@
 import chalk from 'chalk';
-import { isAccountVault, type VaultsConfig } from '@agentage/memory-core';
-import { health, syncRun } from '../lib/daemon-client.js';
+import { type VaultsConfig } from '@agentage/memory-core';
+import { health, syncRun, type SyncRunResult } from '../lib/daemon-client.js';
 import { daemonDisabled } from '../lib/daemon-pref.js';
 import { loadVaultsConfig } from '../lib/vaults.js';
 import { resolvePort } from '../daemon/lifecycle.js';
 import { runSyncCycle, type SyncResult } from '../sync/cycle.js';
+import { createCouchSyncManager, type CouchSyncResult } from '../sync/couch/manager.js';
+import { couchTargets } from '../sync/couch/targets.js';
 import { syncTargets, type SyncTarget } from '../sync/planner.js';
 
 export interface VaultSyncDeps {
   loadConfig: () => VaultsConfig;
   // The port of a reachable daemon, or null to run in-process (daemon down or --no-daemon).
   daemonPort: () => Promise<number | null>;
-  runViaDaemon: (port: number, vault: string) => Promise<SyncResult>;
-  runInProcess: (target: SyncTarget) => Promise<SyncResult>;
+  runViaDaemon: (port: number, vault: string) => Promise<SyncRunResult>;
+  runGitInProcess: (target: SyncTarget) => Promise<SyncResult>;
+  runCouchInProcess: (vault: string) => Promise<CouchSyncResult>;
   log: (msg: string) => void;
 }
 
-const describe = (r: SyncResult): string => {
+const isCouch = (r: SyncRunResult): r is CouchSyncResult => 'channel' in r && r.channel === 'couch';
+
+const describeGit = (r: SyncResult): string => {
   if (!r.ok) return chalk.red(`failed (${r.reason ?? 'error'})${r.error ? `: ${r.error}` : ''}`);
   if (r.skipped) return chalk.yellow(`skipped (${r.skipped})`);
   const bits: string[] = [];
@@ -26,43 +31,54 @@ const describe = (r: SyncResult): string => {
   return chalk.green(bits.length ? bits.join(', ') : 'up to date');
 };
 
-const report = (log: (msg: string) => void, r: SyncResult): void => {
-  log(`${r.vault} -> ${r.remote}: ${describe(r)}`);
+const describeCouch = (r: CouchSyncResult): string => {
+  if (r.paused) return chalk.yellow(`paused (${r.paused})`);
+  if (!r.ok) return chalk.red(`failed${r.error ? `: ${r.error}` : ''}`);
+  const bits: string[] = [];
+  if (r.committed) bits.push('committed');
+  if (r.pulled) bits.push('pulled');
+  if (r.pendingCount) bits.push(`${r.pendingCount} pending`);
+  return chalk.green(bits.length ? bits.join(', ') : 'up to date');
+};
+
+const report = (log: (msg: string) => void, r: SyncRunResult): void => {
+  if (isCouch(r)) {
+    log(`${r.vault} (account): ${describeCouch(r)}`);
+    return;
+  }
+  log(`${r.vault} -> ${r.remote}: ${describeGit(r)}`);
   for (const c of r.conflicts) log(`  kept remote copy: ${c}`);
 };
 
-// `agentage vault sync [name]`: sync one vault (or every origin-carrying vault). Prefers a running
-// daemon (single writer), else runs the cycle in-process. Works for interval-0 (manual-only)
-// vaults and with the daemon down. Sync failures are surfaced, not thrown (V6: never a crash).
+// `agentage vault sync [name]`: sync one vault (or every syncable vault). Git-origin vaults
+// commit + push + pull-rebase; account (agentage) vaults sync the couch channel. Prefers a running
+// daemon (single writer), else runs the cycle in-process. Works for interval-0 (manual-only) vaults
+// and with the daemon down. Failures are surfaced, not thrown (V6: never a crash).
 export const runVaultSync = async (
   name: string | undefined,
   deps: VaultSyncDeps
 ): Promise<void> => {
   const config = deps.loadConfig();
-  const targets = syncTargets(config).filter((t) => !name || t.vault === name);
-  if (targets.length === 0) {
-    const entry = name ? config.vaults?.[name] : undefined;
-    if (entry && isAccountVault(entry))
-      // The account channel is not a git remote, so `vault sync` never touches it.
-      deps.log(
-        `Vault '${name}' is an account vault - not a git remote, so \`vault sync\` skips it.`
-      );
-    else
-      deps.log(
-        name
-          ? `No git origin configured for vault '${name}'.`
-          : 'No git-synced vaults. Add one with `agentage vault add <name> --git <remote>`.'
-      );
+  const gitTargets = syncTargets(config).filter((t) => !name || t.vault === name);
+  const couchVaults = couchTargets(config)
+    .filter((t) => !name || t.vault === name)
+    .map((t) => t.vault);
+  if (gitTargets.length === 0 && couchVaults.length === 0) {
+    deps.log(
+      name
+        ? `No syncable origin configured for vault '${name}'.`
+        : 'No syncable vaults. Add one with `agentage vault add <name>`.'
+    );
     return;
   }
   const port = await deps.daemonPort();
   if (port !== null) {
-    for (const vault of [...new Set(targets.map((t) => t.vault))]) {
-      report(deps.log, await deps.runViaDaemon(port, vault));
-    }
+    const vaults = [...new Set([...gitTargets.map((t) => t.vault), ...couchVaults])];
+    for (const vault of vaults) report(deps.log, await deps.runViaDaemon(port, vault));
     return;
   }
-  for (const target of targets) report(deps.log, await deps.runInProcess(target));
+  for (const target of gitTargets) report(deps.log, await deps.runGitInProcess(target));
+  for (const vault of couchVaults) report(deps.log, await deps.runCouchInProcess(vault));
 };
 
 const resolveDaemonPort = async (): Promise<number | null> => {
@@ -75,6 +91,7 @@ export const defaultVaultSyncDeps = (): VaultSyncDeps => ({
   loadConfig: () => loadVaultsConfig().config,
   daemonPort: resolveDaemonPort,
   runViaDaemon: syncRun,
-  runInProcess: runSyncCycle,
+  runGitInProcess: runSyncCycle,
+  runCouchInProcess: (vault) => createCouchSyncManager().runNow(vault),
   log: (msg) => console.log(msg),
 });

--- a/src/commands/vault.ts
+++ b/src/commands/vault.ts
@@ -143,7 +143,7 @@ export const registerVault = (program: Command): void => {
 
   vault
     .command('sync [name]')
-    .description('Sync git-synced vaults now (commit + push, pull-rebase)')
+    .description('Sync vaults now (git commit/push/pull, or the account channel)')
     .action((name: string | undefined) =>
       runVaultSync(name, defaultVaultSyncDeps()).catch((err: unknown) => {
         console.error(chalk.red(err instanceof Error ? err.message : String(err)));

--- a/src/daemon-entry.ts
+++ b/src/daemon-entry.ts
@@ -1,4 +1,5 @@
 import { unwatchFile, watchFile } from 'node:fs';
+import { isAccountVault } from '@agentage/memory-core';
 import { createClientProvider } from './daemon/client-provider.js';
 import {
   removePidFile,
@@ -9,33 +10,53 @@ import {
 } from './daemon/lifecycle.js';
 import { createDaemonServer } from './daemon/server.js';
 import { loadLocalMemoryServer } from './mcp/local-server.js';
-import { vaultsJsonPath } from './lib/vaults.js';
+import { loadVaultsConfig, vaultsJsonPath } from './lib/vaults.js';
+import { createCouchSyncManager } from './sync/couch/manager.js';
 import { createSyncManager } from './sync/manager.js';
 import { VERSION } from './utils/version.js';
 
 // The detached, long-lived engine host: one loopback HTTP server that owns a single in-process
 // engine and serialises every vault mutation, avoiding concurrent git index.lock collisions. It
-// also runs the git-sync loop (per-vault origin push/pull) and reschedules on config change.
+// runs both sync loops (git origins + the account/couch channel) and reschedules on config change.
 const main = async (): Promise<void> => {
   const port = resolvePort();
-  const manager = createSyncManager();
+  const git = createSyncManager();
+  const couch = createCouchSyncManager();
+
+  // A vault is on exactly one channel: an account (agentage) vault syncs over couch, else git.
+  const runNow = (
+    vault: string
+  ): ReturnType<typeof couch.runNow> | ReturnType<typeof git.runNow> => {
+    const entry = loadVaultsConfig().config.vaults?.[vault];
+    return entry && isAccountVault(entry) ? couch.runNow(vault) : git.runNow(vault);
+  };
+
   const server = createDaemonServer({
     getClient: createClientProvider(),
     buildMcpServer: loadLocalMemoryServer,
-    sync: { status: () => manager.status(), runNow: (vault) => manager.runNow(vault) },
+    sync: {
+      status: () => ({ ...git.status(), couch: couch.status() }),
+      runNow,
+    },
+    onMutation: (verb, body) => couch.onWrite(verb, body),
     version: VERSION,
   });
   await server.start(port);
   writePidFile(process.pid);
   writePortFile(port);
-  manager.reschedule();
+  git.reschedule();
+  couch.reschedule();
 
   const configPath = vaultsJsonPath();
-  watchFile(configPath, { interval: 2000 }, () => manager.reschedule());
+  watchFile(configPath, { interval: 2000 }, () => {
+    git.reschedule();
+    couch.reschedule();
+  });
 
   const shutdown = (): void => {
     unwatchFile(configPath);
-    manager.stop();
+    git.stop();
+    couch.stop();
     server.stop().finally(() => {
       removePidFile();
       removePortFile();

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -2,15 +2,17 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { type MemoryClient } from '../lib/memory-client.js';
 import { type SyncResult } from '../sync/cycle.js';
+import { type CouchSyncResult } from '../sync/couch/manager.js';
 import { type SyncStatus } from '../sync/manager.js';
-import { dispatchMemory, isMemoryVerb } from './actions.js';
+import { dispatchMemory, isMemoryVerb, type MemoryVerb } from './actions.js';
 import { handleMcp } from './mcp-http.js';
 
 const LOOPBACK = '127.0.0.1';
 
 export interface DaemonSyncApi {
   status: () => SyncStatus;
-  runNow: (vault: string) => Promise<SyncResult>;
+  // A git vault yields a SyncResult, an account vault a CouchSyncResult - the caller branches.
+  runNow: (vault: string) => Promise<SyncResult | CouchSyncResult>;
 }
 
 export interface DaemonServerOptions {
@@ -19,6 +21,9 @@ export interface DaemonServerOptions {
   buildMcpServer?: () => Promise<McpServer>;
   // The git-sync surface: GET /api/sync/status + POST /api/sync/run; omit to leave both unmounted.
   sync?: DaemonSyncApi;
+  // Fired after a successful write/edit/delete so the account channel can push-on-save. Never
+  // awaited: a couch failure must not affect the memory API response.
+  onMutation?: (verb: MemoryVerb, body: unknown) => void;
   version: string;
   startedAt?: number;
 }
@@ -91,8 +96,10 @@ export const createDaemonServer = (opts: DaemonServerOptions): DaemonServer => {
       const verb = match[1];
       if (!isMemoryVerb(verb)) return send(res, 404, { error: `unknown verb: ${verb}` });
       try {
-        const result = await dispatchMemory(await opts.getClient(), verb, await readBody(req));
+        const body = await readBody(req);
+        const result = await dispatchMemory(await opts.getClient(), verb, body);
         served += 1;
+        opts.onMutation?.(verb, body); // fire-and-forget account push-on-save
         return send(res, 200, result);
       } catch (err) {
         return send(res, 400, { error: err instanceof Error ? err.message : String(err) });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -25,6 +25,20 @@ const tryRefresh = async (auth: AuthState, links: Links): Promise<boolean> => {
   }
 };
 
+// The current OAuth bearer for background (couch) sync. Reads auth.json fresh on every call - the
+// user may sign in or out between ticks - and refreshes once when the stored token is past its
+// stated expiry. Returns null when signed out so a caller pauses with zero network, never throws.
+export const currentBearer = async (
+  readAuth: () => AuthState | null,
+  links: Links
+): Promise<string | null> => {
+  const auth = readAuth();
+  if (!auth?.tokens.accessToken) return null;
+  const expired = auth.tokens.expiresAt !== undefined && auth.tokens.expiresAt <= Date.now();
+  if (expired && !(await tryRefresh(auth, links))) return null;
+  return auth.tokens.accessToken;
+};
+
 export const authedGet = async <T>(auth: AuthState, links: Links, url: string): Promise<T> => {
   const call = (): Promise<Response> =>
     fetch(url, { headers: { authorization: `Bearer ${auth.tokens.accessToken}` } });

--- a/src/lib/daemon-client.ts
+++ b/src/lib/daemon-client.ts
@@ -10,8 +10,12 @@ import {
 } from '@agentage/memory-core';
 import { resolvePort } from '../daemon/lifecycle.js';
 import { type SyncResult } from '../sync/cycle.js';
+import { type CouchSyncResult } from '../sync/couch/manager.js';
 import { type SyncStatus } from '../sync/manager.js';
 import { VERSION } from '../utils/version.js';
+
+// One vault syncs on exactly one channel; /api/sync/run yields whichever result fits the vault.
+export type SyncRunResult = SyncResult | CouchSyncResult;
 import {
   type DeleteResult,
   type ListOptions,
@@ -67,8 +71,9 @@ export const syncStatus = async (port: number, timeoutMs = 1000): Promise<SyncSt
   }
 };
 
-// Ask the daemon to sync one vault now; the daemon runs the cycle in its own process.
-export const syncRun = async (port: number, vault: string): Promise<SyncResult> => {
+// Ask the daemon to sync one vault now; the daemon runs the cycle in its own process. The result
+// shape depends on the vault's channel (git SyncResult vs account CouchSyncResult).
+export const syncRun = async (port: number, vault: string): Promise<SyncRunResult> => {
   const res = await fetch(`${base(port)}/api/sync/run`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -78,7 +83,7 @@ export const syncRun = async (port: number, vault: string): Promise<SyncResult> 
     const data = (await res.json().catch(() => ({}))) as { error?: string };
     throw new Error(data.error || `sync request failed: ${res.status}`);
   }
-  return res.json() as Promise<SyncResult>;
+  return res.json() as Promise<SyncRunResult>;
 };
 
 export const waitForHealth = async (

--- a/src/lib/origins.test.ts
+++ b/src/lib/origins.test.ts
@@ -34,8 +34,10 @@ describe('links', () => {
       api: 'https://api.agentage.io/api',
       auth: 'https://auth.agentage.io',
       mcp: 'https://memory.agentage.io/mcp',
+      sync: 'https://sync.agentage.io',
     });
     expect(links('dev.agentage.io').auth).toBe('https://auth.dev.agentage.io');
+    expect(links('dev.agentage.io').sync).toBe('https://sync.dev.agentage.io');
   });
 
   it('maps localhost to the local port set', () => {
@@ -44,6 +46,17 @@ describe('links', () => {
       api: 'http://localhost:3001/api',
       auth: 'http://localhost:3010',
       mcp: 'http://localhost:3003/mcp',
+      sync: 'http://localhost:3011',
+    });
+  });
+
+  it('collapses a 127.0.0.1:<port> fqdn onto one stub origin', () => {
+    expect(links('127.0.0.1:8080')).toEqual({
+      site: 'http://127.0.0.1:8080',
+      api: 'http://127.0.0.1:8080/api',
+      auth: 'http://127.0.0.1:8080',
+      mcp: 'http://127.0.0.1:8080/mcp',
+      sync: 'http://127.0.0.1:8080',
     });
   });
 });

--- a/src/lib/origins.ts
+++ b/src/lib/origins.ts
@@ -7,6 +7,8 @@ export interface Links {
   api: string;
   auth: string;
   mcp: string;
+  // Sync bootstrap host for GET /.well-known/agentage-sync (git + couch endpoints).
+  sync: string;
 }
 
 const DEFAULT_FQDN = 'agentage.io';
@@ -25,20 +27,33 @@ export const siteFqdn = (): string => normalizeFqdn(process.env['AGENTAGE_SITE_F
 const isLocal = (fqdn: string): boolean =>
   fqdn === 'localhost' || fqdn.startsWith('localhost:') || fqdn.startsWith('127.0.0.1');
 
+// A loopback-IP-with-port fqdn (`127.0.0.1:<port>`) collapses every service onto that one
+// origin, path-prefixed - the single-server stub convention the hermetic e2e drives. The bare
+// `localhost` / `localhost:<port>` dev fqdns keep the multi-port dev mapping below untouched.
+const stubOrigin = (fqdn: string): string | null => {
+  const m = fqdn.match(/^127\.0\.0\.1:(\d+)$/);
+  return m ? `http://127.0.0.1:${m[1]}` : null;
+};
+
 export const environment = (fqdn: string): Env =>
   isLocal(fqdn) || fqdn.startsWith('dev.') ? 'development' : 'production';
 
-export const links = (fqdn: string): Links =>
-  isLocal(fqdn)
+export const links = (fqdn: string): Links => {
+  const stub = stubOrigin(fqdn);
+  if (stub) return { site: stub, api: `${stub}/api`, auth: stub, mcp: `${stub}/mcp`, sync: stub };
+  return isLocal(fqdn)
     ? {
         site: 'http://localhost:3000',
         api: 'http://localhost:3001/api',
         auth: 'http://localhost:3010',
         mcp: 'http://localhost:3003/mcp',
+        sync: 'http://localhost:3011',
       }
     : {
         site: `https://${fqdn}`,
         api: `https://api.${fqdn}/api`,
         auth: `https://auth.${fqdn}`,
         mcp: `https://memory.${fqdn}/mcp`,
+        sync: `https://sync.${fqdn}`,
       };
+};

--- a/src/sync/couch/discovery.test.ts
+++ b/src/sync/couch/discovery.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import { type FetchJson } from '@agentage/memory-core';
+import { type ProvisionResult, type ProvisionStatus } from '../../lib/provision.js';
+import { createDiscovery } from './discovery.js';
+
+// A well-known payload advertising the couch channel for the given vault names.
+const payload = (vaults: string[]): { status: number; json: unknown } => ({
+  status: 200,
+  json: {
+    git_endpoint: 'https://sync.test',
+    ttl: 3600,
+    couch_endpoint: 'https://couch.test',
+    couch_token_url: 'https://auth.test/couch-token',
+    couch_vaults: vaults.map((v) => ({ vault: v, db: `mem_${v}` })),
+  },
+});
+
+const prov = (status: ProvisionStatus): ProvisionResult => ({ status, message: '' });
+
+const make = (
+  fetchJson: FetchJson,
+  provision: () => Promise<ProvisionResult> = async () => prov('provisioned')
+) =>
+  createDiscovery({
+    bootstrapHost: 'https://sync.test',
+    fetchJson,
+    provision: vi.fn(provision),
+    now: () => 0,
+  });
+
+describe('createDiscovery', () => {
+  it('resolves the couch channel and caches within the payload ttl', async () => {
+    const fetchJson = vi.fn(async () => payload(['acct']));
+    const d = make(fetchJson);
+    expect(await d.channelFor('acct', 'tok')).toEqual({
+      kind: 'couch',
+      endpoint: 'https://couch.test',
+      db: 'mem_acct',
+      tokenUrl: 'https://auth.test/couch-token',
+    });
+    await d.channelFor('acct', 'tok');
+    expect(fetchJson).toHaveBeenCalledTimes(1); // second call served from the ttl cache
+  });
+
+  it('provisions once and refreshes discovery once when the vault is missing', async () => {
+    let present = false;
+    const fetchJson = vi.fn(async () => payload(present ? ['acct'] : []));
+    const provision = vi.fn(async () => {
+      present = true;
+      return prov('provisioned');
+    });
+    const d = createDiscovery({
+      bootstrapHost: 'https://sync.test',
+      fetchJson,
+      provision,
+      now: () => 0,
+    });
+    expect(await d.channelFor('acct', 'tok')).toMatchObject({ kind: 'couch', db: 'mem_acct' });
+    expect(provision).toHaveBeenCalledTimes(1);
+    expect(fetchJson).toHaveBeenCalledTimes(2); // initial + one refresh after provisioning
+  });
+
+  it('pauses with a CHANNEL_DISABLED reason when provisioning cannot enable the channel', async () => {
+    const fetchJson = vi.fn(async () => payload([])); // never advertises acct
+    const d = make(fetchJson, async () => prov('disabled'));
+    expect(await d.channelFor('acct', 'tok')).toEqual({
+      kind: 'paused',
+      reason: 'account sync is not enabled on this server',
+    });
+  });
+
+  it('maps a conflict and an unauthenticated provision to distinct paused reasons', async () => {
+    const conflict = make(
+      vi.fn(async () => payload([])),
+      async () => prov('conflict')
+    );
+    expect(await conflict.channelFor('acct', 'tok')).toEqual({
+      kind: 'paused',
+      reason: 'name conflicts with a memory on another channel',
+    });
+    const signedOut = make(
+      vi.fn(async () => payload([])),
+      async () => prov('unauthenticated')
+    );
+    expect(await signedOut.channelFor('acct', 'tok')).toEqual({
+      kind: 'paused',
+      reason: 'signed out',
+    });
+  });
+});

--- a/src/sync/couch/discovery.ts
+++ b/src/sync/couch/discovery.ts
@@ -1,0 +1,58 @@
+import { channelForVault, HostResolver, type FetchJson } from '@agentage/memory-core';
+import { type ProvisionResult } from '../../lib/provision.js';
+
+// Resolves which channel each account vault syncs on, from GET /.well-known/agentage-sync
+// (cached for the payload ttl in memory only). A vault absent from couch_vaults is provisioned
+// once (idempotent) then discovery is refreshed once; if it is still absent the target pauses with
+// a reason and retries next tick. A signed-out caller never reaches here (zero network).
+
+export type ChannelDecision =
+  | { kind: 'couch'; endpoint: string; db: string; tokenUrl: string }
+  | { kind: 'paused'; reason: string };
+
+export interface DiscoveryDeps {
+  bootstrapHost: string; // the sync origin, e.g. https://sync.<fqdn>
+  fetchJson: FetchJson;
+  provision: (vault: string) => Promise<ProvisionResult>;
+  now?: () => number;
+}
+
+export interface Discovery {
+  channelFor(vault: string, token: string): Promise<ChannelDecision>;
+  reset(): void;
+}
+
+const pausedReason = (prov: ProvisionResult): string => {
+  switch (prov.status) {
+    case 'disabled':
+      return 'account sync is not enabled on this server';
+    case 'conflict':
+      return 'name conflicts with a memory on another channel';
+    case 'unauthenticated':
+      return 'signed out';
+    default:
+      return 'provisioning - will retry';
+  }
+};
+
+export const createDiscovery = (deps: DiscoveryDeps): Discovery => {
+  const resolver = new HostResolver(deps.bootstrapHost, deps.fetchJson, deps.now ?? Date.now);
+  const toCouch = (ch: ReturnType<typeof channelForVault>): ChannelDecision | null =>
+    ch.channel === 'couch'
+      ? { kind: 'couch', endpoint: ch.endpoint, db: ch.db, tokenUrl: ch.tokenUrl }
+      : null;
+  return {
+    async channelFor(vault, token) {
+      const first = toCouch(channelForVault(await resolver.resolve(token), vault));
+      if (first) return first;
+      // Missing from couch_vaults: provision once, refresh discovery once, re-check.
+      const prov = await deps.provision(vault);
+      resolver.invalidate();
+      const second = toCouch(channelForVault(await resolver.resolve(token), vault));
+      return second ?? { kind: 'paused', reason: pausedReason(prov) };
+    },
+    reset() {
+      resolver.invalidate();
+    },
+  };
+};

--- a/src/sync/couch/file-store.test.ts
+++ b/src/sync/couch/file-store.test.ts
@@ -1,0 +1,48 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createFileStore } from './file-store.js';
+
+describe('createFileStore', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'fstore-'));
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('lists nested *.md as sorted POSIX relative paths, excluding dotfiles and non-md', async () => {
+    await mkdir(join(root, 'notes', 'sub'), { recursive: true });
+    await mkdir(join(root, '.git', 'objects'), { recursive: true });
+    await mkdir(join(root, '.obsidian'), { recursive: true });
+    await writeFile(join(root, 'top.md'), 'x');
+    await writeFile(join(root, 'notes', 'sub', 'deep.md'), 'x');
+    await writeFile(join(root, 'notes', 'not-markdown.txt'), 'x');
+    await writeFile(join(root, '.git', 'objects', 'ignored.md'), 'x');
+    await writeFile(join(root, '.obsidian', 'workspace.md'), 'x');
+
+    const store = createFileStore(root);
+    expect(await store.listMarkdown()).toEqual(['notes/sub/deep.md', 'top.md']);
+  });
+
+  it('returns [] for a missing root', async () => {
+    expect(await createFileStore(join(root, 'nope')).listMarkdown()).toEqual([]);
+  });
+
+  it('write creates parent dirs; read returns content, null when absent', async () => {
+    const store = createFileStore(root);
+    expect(await store.read('a/b/c.md')).toBeNull();
+    await store.write('a/b/c.md', 'hello');
+    expect(await store.read('a/b/c.md')).toBe('hello');
+    expect(await readFile(join(root, 'a', 'b', 'c.md'), 'utf8')).toBe('hello');
+  });
+
+  it('remove deletes the file and is a no-op when absent', async () => {
+    const store = createFileStore(root);
+    await store.write('gone.md', 'bye');
+    await store.remove('gone.md');
+    expect(await store.read('gone.md')).toBeNull();
+    await expect(store.remove('never.md')).resolves.toBeUndefined();
+  });
+});

--- a/src/sync/couch/file-store.ts
+++ b/src/sync/couch/file-store.ts
@@ -1,0 +1,46 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, relative, sep } from 'node:path';
+import { type FileStore } from '@agentage/memory-core';
+
+// The couch channel speaks vault-relative POSIX paths; on Windows the fs layer still uses `\`.
+const toPosix = (p: string): string => (sep === '/' ? p : p.split(sep).join('/'));
+const fromPosix = (p: string): string => (sep === '/' ? p : p.split('/').join(sep));
+
+// Recursively collect *.md under root as vault-relative POSIX paths. Dot-directories are skipped -
+// `.git` (the engine's own repo) must never enter the content-addressed model, and editor state
+// like `.obsidian/` holds no synced notes; this mirrors memory-core's own local listing.
+const walk = async (root: string, dir: string, acc: string[]): Promise<void> => {
+  const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+  for (const e of entries) {
+    if (e.name.startsWith('.')) continue;
+    const abs = join(dir, e.name);
+    if (e.isDirectory()) await walk(root, abs, acc);
+    else if (e.isFile() && e.name.endsWith('.md')) acc.push(toPosix(relative(root, abs)));
+  }
+};
+
+// A FileStore rooted at one account vault's mirror dir: the seam CouchSync reads/writes through.
+export const createFileStore = (root: string): FileStore => ({
+  async listMarkdown() {
+    if (!existsSync(root)) return [];
+    const acc: string[] = [];
+    await walk(root, root, acc);
+    return acc.sort();
+  },
+  async read(path) {
+    try {
+      return await readFile(join(root, fromPosix(path)), 'utf8');
+    } catch {
+      return null; // gone from the file set
+    }
+  },
+  async write(path, body) {
+    const abs = join(root, fromPosix(path));
+    await mkdir(dirname(abs), { recursive: true });
+    await writeFile(abs, body, 'utf8');
+  },
+  async remove(path) {
+    await rm(join(root, fromPosix(path)), { force: true });
+  },
+});

--- a/src/sync/couch/manager.test.ts
+++ b/src/sync/couch/manager.test.ts
@@ -35,7 +35,8 @@ const makeManager = (over: Partial<CouchSyncManagerDeps> = {}) => {
   const couch = {
     pushFileLive: vi.fn(async () => {}),
     removeFile: vi.fn(async () => {}),
-    syncNow: vi.fn(async () => {}),
+    flushPending: vi.fn(async () => {}),
+    syncNow: vi.fn(async () => ({ pushed: true, pulled: true })),
   };
   const discovery: Discovery = {
     channelFor: vi.fn(async () => couchDecision),
@@ -142,6 +143,44 @@ describe('createCouchSyncManager.onWrite', () => {
     expect(discovery.channelFor).not.toHaveBeenCalled();
     expect(couch.pushFileLive).not.toHaveBeenCalled();
   });
+
+  it('a signed-out delete enqueues a durable deletion, zero network', async () => {
+    const deletions: string[] = [];
+    const { mgr, couch, discovery } = makeManager({
+      getBearer: async () => null,
+      makeStatePersistence: () => ({
+        load: async () => null,
+        save: async (s) => {
+          deletions.push(...(s.deletions ?? []));
+        },
+      }),
+    });
+    mgr.onWrite('delete', { ref: 'notes/x.md' });
+    await vi.waitFor(() => expect(deletions).toContain('notes/x.md'));
+    expect(discovery.channelFor).not.toHaveBeenCalled();
+    expect(couch.removeFile).not.toHaveBeenCalled();
+  });
+
+  it('a delete surviving a discovery failure is enqueued, never dropped', async () => {
+    const deletions: string[] = [];
+    const { mgr, couch } = makeManager({
+      discovery: {
+        channelFor: vi.fn(async () => {
+          throw new Error('well-known unreachable');
+        }),
+        reset: vi.fn(),
+      },
+      makeStatePersistence: () => ({
+        load: async () => null,
+        save: async (s) => {
+          deletions.push(...(s.deletions ?? []));
+        },
+      }),
+    });
+    mgr.onWrite('delete', { ref: 'notes/x.md' });
+    await vi.waitFor(() => expect(deletions).toContain('notes/x.md'));
+    expect(couch.removeFile).not.toHaveBeenCalled();
+  });
 });
 
 describe('createCouchSyncManager.status and runNow', () => {
@@ -187,5 +226,42 @@ describe('createCouchSyncManager.status and runNow', () => {
     expect(result).toMatchObject({ vault: 'acct', ok: true });
     expect(result.paused).toBeUndefined();
     expect(mgr.status()[0]!.lastSync).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('commits dirty local changes BEFORE syncNow, even when couch is unreachable', async () => {
+    const order: string[] = [];
+    const couch = {
+      pushFileLive: vi.fn(async () => {}),
+      removeFile: vi.fn(async () => {}),
+      flushPending: vi.fn(async () => {
+        order.push('flush');
+      }),
+      syncNow: vi.fn(async () => {
+        order.push('sync');
+        return { pushed: false, pulled: false, error: 'couch unreachable' };
+      }),
+    };
+    const { mgr } = makeManager({
+      makeCouchSync: () => couch,
+      commitDirty: vi.fn(async (_path: string, message: string) => {
+        order.push(message.startsWith('sync: couch') ? 'commit-post' : 'commit-pre');
+        return { committed: message.startsWith('sync: couch') === false, skipped: false };
+      }),
+    });
+    const result = await mgr.runNow('acct');
+    // The dirty working tree is committed first, so a couch outage never loses the local truth.
+    expect(order).toEqual(['commit-pre', 'flush', 'sync', 'commit-post']);
+    expect(result).toMatchObject({ ok: false, committed: true, error: 'couch unreachable' });
+    expect(mgr.status()[0]!.lastError).toBe('couch unreachable');
+    expect(mgr.status()[0]!.lastSync).toBeUndefined();
+  });
+
+  it('flushes queued deletions on a manual run before the push/pull round', async () => {
+    const { mgr, couch } = makeManager();
+    await mgr.runNow('acct');
+    expect(couch.flushPending).toHaveBeenCalledTimes(1);
+    expect(couch.flushPending.mock.invocationCallOrder[0]!).toBeLessThan(
+      couch.syncNow.mock.invocationCallOrder[0]!
+    );
   });
 });

--- a/src/sync/couch/manager.test.ts
+++ b/src/sync/couch/manager.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from 'vitest';
+import { type FileStore, type VaultsConfig } from '@agentage/memory-core';
+import { type ChannelDecision, type Discovery } from './discovery.js';
+import {
+  createCouchSyncManager,
+  resolveMutationTarget,
+  type CouchSyncManagerDeps,
+} from './manager.js';
+
+const config: VaultsConfig = {
+  version: 1,
+  default: 'acct',
+  vaults: {
+    acct: { path: '/tmp/acct', origin: [{ remote: 'agentage', interval: 0 }] },
+    git: { path: '/tmp/git', origin: [{ remote: 'git@h:g.git' }] },
+    local: { path: '/tmp/local' },
+  },
+};
+
+const noopStore = (): FileStore => ({
+  listMarkdown: async () => [],
+  read: async () => null,
+  write: async () => {},
+  remove: async () => {},
+});
+
+const couchDecision: ChannelDecision = {
+  kind: 'couch',
+  endpoint: 'https://couch.test',
+  db: 'mem_acct',
+  tokenUrl: 'https://auth.test/couch-token',
+};
+
+const makeManager = (over: Partial<CouchSyncManagerDeps> = {}) => {
+  const couch = {
+    pushFileLive: vi.fn(async () => {}),
+    removeFile: vi.fn(async () => {}),
+    syncNow: vi.fn(async () => {}),
+  };
+  const discovery: Discovery = {
+    channelFor: vi.fn(async () => couchDecision),
+    reset: vi.fn(),
+  };
+  const mgr = createCouchSyncManager({
+    getConfig: () => config,
+    configDir: () => '/tmp/cfg',
+    getBearer: async () => 'tok',
+    discovery,
+    makeCouchSync: () => couch,
+    makeFileStore: noopStore,
+    makeStatePersistence: () => ({ load: async () => null, save: async () => {} }),
+    commitDirty: async () => ({ committed: false, skipped: false }),
+    now: () => '2026-01-01T00:00:00Z',
+    ...over,
+  });
+  return { mgr, couch, discovery };
+};
+
+describe('resolveMutationTarget', () => {
+  it('maps a bare ref to the default vault when it is an account vault', () => {
+    expect(resolveMutationTarget(config, { ref: 'notes/x.md' })).toEqual({
+      vault: 'acct',
+      path: 'notes/x.md',
+    });
+  });
+
+  it('honours an explicit @vault/ prefix', () => {
+    expect(resolveMutationTarget(config, { ref: '@acct/a/b.md' })).toEqual({
+      vault: 'acct',
+      path: 'a/b.md',
+    });
+  });
+
+  it('honours opts.vault over the default', () => {
+    expect(resolveMutationTarget(config, { ref: 'z.md', opts: { vault: 'acct' } })).toEqual({
+      vault: 'acct',
+      path: 'z.md',
+    });
+  });
+
+  it('returns null for git/local vaults and for non-file refs', () => {
+    expect(resolveMutationTarget(config, { ref: '@git/z.md' })).toBeNull();
+    expect(resolveMutationTarget(config, { ref: 'z.md', opts: { vault: 'local' } })).toBeNull();
+    expect(resolveMutationTarget(config, { ref: '@acct' })).toBeNull();
+    expect(resolveMutationTarget(config, {})).toBeNull();
+  });
+
+  it('resolves a single-vault config with no default', () => {
+    const single: VaultsConfig = {
+      version: 1,
+      vaults: { only: { path: '/tmp/only', origin: [{ remote: 'agentage' }] } },
+    };
+    expect(resolveMutationTarget(single, { ref: 'n.md' })).toEqual({ vault: 'only', path: 'n.md' });
+  });
+});
+
+describe('createCouchSyncManager.onWrite', () => {
+  it('pushes a write on an account vault via the couch channel', async () => {
+    const { mgr, couch } = makeManager();
+    mgr.onWrite('write', { ref: 'notes/x.md' });
+    await vi.waitFor(() => expect(couch.pushFileLive).toHaveBeenCalledWith('notes/x.md'));
+    expect(couch.removeFile).not.toHaveBeenCalled();
+  });
+
+  it('tombstones a delete on an account vault', async () => {
+    const { mgr, couch } = makeManager();
+    mgr.onWrite('delete', { ref: 'notes/x.md' });
+    await vi.waitFor(() => expect(couch.removeFile).toHaveBeenCalledWith('notes/x.md'));
+    expect(couch.pushFileLive).not.toHaveBeenCalled();
+  });
+
+  it('never touches couch for a git or local vault mutation', async () => {
+    const { mgr, couch, discovery } = makeManager();
+    mgr.onWrite('write', { ref: '@git/z.md' });
+    mgr.onWrite('edit', { ref: 'z.md', opts: { vault: 'local' } });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(couch.pushFileLive).not.toHaveBeenCalled();
+    expect(discovery.channelFor).not.toHaveBeenCalled();
+  });
+
+  it('does not fire for read/search/list verbs', async () => {
+    const { mgr, couch } = makeManager();
+    mgr.onWrite('read', { ref: 'notes/x.md' });
+    mgr.onWrite('list', {});
+    await new Promise((r) => setTimeout(r, 20));
+    expect(couch.pushFileLive).not.toHaveBeenCalled();
+  });
+
+  it('enqueues (no network) when signed out', async () => {
+    const enqueued: string[] = [];
+    const { mgr, couch, discovery } = makeManager({
+      getBearer: async () => null,
+      makeStatePersistence: () => ({
+        load: async () => null,
+        save: async (s) => {
+          enqueued.push(...s.pending);
+        },
+      }),
+    });
+    mgr.onWrite('write', { ref: 'notes/x.md' });
+    await vi.waitFor(() => expect(enqueued).toContain('notes/x.md'));
+    expect(discovery.channelFor).not.toHaveBeenCalled();
+    expect(couch.pushFileLive).not.toHaveBeenCalled();
+  });
+});
+
+describe('createCouchSyncManager.status and runNow', () => {
+  it('reports one couch target with its cadence and zero pending', () => {
+    const { mgr } = makeManager();
+    expect(mgr.status()).toEqual([
+      {
+        vault: 'acct',
+        channel: 'couch',
+        intervalSeconds: 0,
+        lastSync: undefined,
+        lastError: undefined,
+        pendingCount: 0,
+        paused: undefined,
+        running: false,
+      },
+    ]);
+  });
+
+  it('runNow pauses a signed-out target with zero network', async () => {
+    const { mgr, couch, discovery } = makeManager({ getBearer: async () => null });
+    const result = await mgr.runNow('acct');
+    expect(result).toMatchObject({
+      vault: 'acct',
+      channel: 'couch',
+      ok: true,
+      paused: 'signed out',
+    });
+    expect(discovery.channelFor).not.toHaveBeenCalled();
+    expect(couch.syncNow).not.toHaveBeenCalled();
+    expect(mgr.status()[0]!.paused).toBe('signed out');
+  });
+
+  it('runNow throws for a vault that is not an account vault', async () => {
+    const { mgr } = makeManager();
+    await expect(mgr.runNow('git')).rejects.toThrow('not an account vault');
+  });
+
+  it('runNow completes a full cycle and records lastSync', async () => {
+    const { mgr, couch } = makeManager();
+    const result = await mgr.runNow('acct');
+    expect(couch.syncNow).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ vault: 'acct', ok: true });
+    expect(result.paused).toBeUndefined();
+    expect(mgr.status()[0]!.lastSync).toBe('2026-01-01T00:00:00Z');
+  });
+});

--- a/src/sync/couch/manager.ts
+++ b/src/sync/couch/manager.ts
@@ -1,0 +1,343 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  CouchSync,
+  CouchTokenClient,
+  createCouchState,
+  isAccountVault,
+  type CouchState,
+  type CouchStatePersistence,
+  type FetchLike,
+  type FetchJson,
+  type FileStore,
+  type VaultsConfig,
+} from '@agentage/memory-core';
+import { currentBearer } from '../../lib/api.js';
+import { getConfigDir, readAuth } from '../../lib/config.js';
+import { links, siteFqdn } from '../../lib/origins.js';
+import { defaultProvisionDeps, provisionAccountVault } from '../../lib/provision.js';
+import { loadVaultsConfig } from '../../lib/vaults.js';
+import { type MemoryVerb } from '../../daemon/actions.js';
+import { createSyncGit, GitError } from '../git-exec.js';
+import { intervalMs } from '../planner.js';
+import { createDiscovery, type ChannelDecision, type Discovery } from './discovery.js';
+import { createFileStore } from './file-store.js';
+import { createStatePersistence } from './state-store.js';
+import { autoCouchTargets, couchTargets, type CouchTarget } from './targets.js';
+
+export interface CouchSyncResult {
+  vault: string;
+  channel: 'couch';
+  ok: boolean;
+  committed: boolean; // committed local dirty changes before the push
+  pulled: boolean; // a pull applied changes and they were committed
+  pendingCount: number;
+  paused?: string; // set when the target is paused (signed out / not provisioned)
+  error?: string;
+}
+
+export interface CouchTargetStatus {
+  vault: string;
+  channel: 'couch';
+  intervalSeconds: number;
+  lastSync?: string;
+  lastError?: string;
+  pendingCount: number;
+  paused?: string;
+  running: boolean;
+}
+
+// What the manager uses from a CouchSync - the real class satisfies it; tests inject a mock.
+interface CouchLike {
+  pushFileLive(path: string): Promise<void>;
+  removeFile(path: string): Promise<void>;
+  syncNow(): Promise<void>;
+}
+
+type MakeCouchSync = (
+  files: FileStore,
+  cfg: { endpoint: string; db: string },
+  fetch: FetchLike,
+  authorize: () => Promise<string>,
+  onUnauthorized: () => void,
+  state: CouchState,
+  log?: (msg: string) => void
+) => CouchLike;
+
+interface CommitOutcome {
+  committed: boolean;
+  skipped: boolean; // an index.lock collision - retried next cycle
+}
+
+export interface CouchSyncManagerDeps {
+  getConfig?: () => VaultsConfig;
+  configDir?: () => string;
+  getBearer?: () => Promise<string | null>;
+  discovery?: Discovery;
+  fetch?: FetchLike;
+  makeFileStore?: (path: string) => FileStore;
+  makeStatePersistence?: (configDir: string, vault: string) => CouchStatePersistence;
+  makeCouchSync?: MakeCouchSync;
+  commitDirty?: (path: string, message: string) => Promise<CommitOutcome>;
+  now?: () => string; // ISO timestamp
+  log?: (msg: string) => void;
+}
+
+export interface CouchSyncManager {
+  reschedule(): void;
+  runNow(vault: string): Promise<CouchSyncResult>;
+  onWrite(verb: MemoryVerb, body: unknown): void;
+  status(): CouchTargetStatus[];
+  stop(): void;
+}
+
+interface TargetState {
+  target: CouchTarget;
+  files: FileStore;
+  state?: CouchState;
+  statePromise?: Promise<CouchState>;
+  couch?: CouchLike;
+  wireKey?: string;
+  running: boolean;
+  lastSync?: string;
+  lastError?: string;
+  paused?: string;
+}
+
+// Map one memory-verb wire payload to the account vault + vault-relative POSIX path it mutated, or
+// null when the target is not an account vault (git/local mutations never touch the couch channel).
+export const resolveMutationTarget = (
+  config: VaultsConfig,
+  body: unknown
+): { vault: string; path: string } | null => {
+  const p = (body ?? {}) as { ref?: unknown; opts?: { vault?: unknown } };
+  const ref = typeof p.ref === 'string' ? p.ref : '';
+  if (!ref) return null;
+  let vault: string | undefined;
+  let path: string;
+  if (ref.startsWith('@')) {
+    const m = ref.match(/^@([^/]+)\/(.+)$/);
+    if (!m) return null; // a bare '@vault' is not a file mutation
+    vault = m[1];
+    path = m[2] as string;
+  } else {
+    vault = (typeof p.opts?.vault === 'string' ? p.opts.vault : undefined) ?? config.default;
+    if (!vault) {
+      const names = Object.keys(config.vaults ?? {});
+      if (names.length === 1) vault = names[0];
+    }
+    path = ref;
+  }
+  if (!vault) return null;
+  const entry = config.vaults?.[vault];
+  if (!entry || !isAccountVault(entry)) return null;
+  return { vault, path: path.replace(/^\.?\//, '') };
+};
+
+// The default local-git commit: stage everything and make one commit when the tree is dirty. An
+// index.lock collision (the engine mid-mutation) is a clean skip - the change stays for next cycle.
+const gitCommitDirty = async (path: string, message: string): Promise<CommitOutcome> => {
+  if (!existsSync(path)) return { committed: false, skipped: false };
+  const git = createSyncGit(path);
+  try {
+    if (!existsSync(join(path, '.git'))) await git.run(['init', '-b', 'main']);
+    await git.run(['add', '-A']);
+    if ((await git.exec(['diff', '--cached', '--quiet'])).code === 0)
+      return { committed: false, skipped: false };
+    await git.run(['commit', '-m', message]);
+    return { committed: true, skipped: false };
+  } catch (err) {
+    if (err instanceof GitError && err.kind === 'lock') return { committed: false, skipped: true };
+    throw err;
+  }
+};
+
+const defaultFetch: FetchLike = (url, init) => globalThis.fetch(url, init as RequestInit);
+
+const defaultFetchJson: FetchJson = async (url, token) => {
+  const res = await globalThis.fetch(url, { headers: { authorization: `Bearer ${token}` } });
+  const json = await res.json().catch(() => null);
+  return { status: res.status, json };
+};
+
+// The daemon-side couch scheduler: per-account-vault timers + a persistent CouchSync per target for
+// sync-on-save. Every couch failure is caught and recorded (lastError / paused); it never crashes
+// the daemon and never blocks a memory API response.
+export const createCouchSyncManager = (deps: CouchSyncManagerDeps = {}): CouchSyncManager => {
+  const getConfig = deps.getConfig ?? (() => loadVaultsConfig().config);
+  const configDir = deps.configDir ?? getConfigDir;
+  const getBearer = deps.getBearer ?? (() => currentBearer(readAuth, links(siteFqdn())));
+  const fetch = deps.fetch ?? defaultFetch;
+  const makeFileStore = deps.makeFileStore ?? createFileStore;
+  const makeStatePersistence = deps.makeStatePersistence ?? createStatePersistence;
+  const makeCouchSync: MakeCouchSync =
+    deps.makeCouchSync ??
+    ((files, cfg, f, authorize, onUnauthorized, state, log) =>
+      new CouchSync(files, cfg, f, authorize, onUnauthorized, state, log));
+  const commitDirty = deps.commitDirty ?? gitCommitDirty;
+  const nowIso = deps.now ?? (() => new Date().toISOString());
+  const log = deps.log ?? (() => {});
+  const discovery =
+    deps.discovery ??
+    createDiscovery({
+      bootstrapHost: links(siteFqdn()).sync,
+      fetchJson: defaultFetchJson,
+      provision: (vault) => provisionAccountVault(vault, defaultProvisionDeps()),
+    });
+
+  const states = new Map<string, TargetState>();
+  const timers = new Map<string, NodeJS.Timeout>();
+
+  const ensureTargetState = (target: CouchTarget): TargetState => {
+    const existing = states.get(target.vault);
+    if (existing) {
+      existing.target = target;
+      return existing;
+    }
+    const fresh: TargetState = { target, files: makeFileStore(target.path), running: false };
+    states.set(target.vault, fresh);
+    return fresh;
+  };
+
+  const getState = (st: TargetState): Promise<CouchState> =>
+    (st.statePromise ??= createCouchState(makeStatePersistence(configDir(), st.target.vault)).then(
+      (s) => (st.state = s)
+    ));
+
+  const ensureWire = async (st: TargetState, d: ChannelDecision): Promise<CouchLike> => {
+    if (d.kind !== 'couch') throw new Error('ensureWire: not a couch channel');
+    const key = `${d.endpoint}|${d.db}|${d.tokenUrl}`;
+    if (st.couch && st.wireKey === key) return st.couch;
+    const state = await getState(st);
+    const tokens = new CouchTokenClient(d.tokenUrl, st.target.vault, fetch, getBearer, Date.now);
+    st.couch = makeCouchSync(
+      st.files,
+      { endpoint: d.endpoint, db: d.db },
+      fetch,
+      () => tokens.token(),
+      () => tokens.invalidate(),
+      state,
+      log
+    );
+    st.wireKey = key;
+    return st.couch;
+  };
+
+  const cycle = async (st: TargetState): Promise<CouchSyncResult> => {
+    const vault = st.target.vault;
+    const build = (extra: Partial<CouchSyncResult>): CouchSyncResult => ({
+      vault,
+      channel: 'couch',
+      ok: true,
+      committed: false,
+      pulled: false,
+      pendingCount: st.state?.pendingPaths().length ?? 0,
+      ...extra,
+    });
+    if (st.running) return build({});
+    st.running = true;
+    try {
+      const bearer = await getBearer();
+      if (!bearer) {
+        st.paused = 'signed out';
+        st.lastError = undefined;
+        return build({ paused: 'signed out' });
+      }
+      const decision = await discovery.channelFor(vault, bearer);
+      if (decision.kind === 'paused') {
+        st.paused = decision.reason;
+        st.lastError = undefined;
+        return build({ paused: decision.reason });
+      }
+      st.paused = undefined;
+      const couch = await ensureWire(st, decision);
+      const pre = await commitDirty(st.target.path, `sync: ${nowIso()}`);
+      await couch.syncNow(); // pushAll (rev-cache skips no-ops) then pullOnce
+      const post = await commitDirty(st.target.path, `sync: couch ${nowIso()}`);
+      st.lastSync = nowIso();
+      st.lastError = undefined;
+      return build({ committed: pre.committed, pulled: post.committed });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      st.lastError = msg;
+      return build({ ok: false, error: msg });
+    } finally {
+      st.running = false;
+    }
+  };
+
+  // Sync-on-save: push (or tombstone) one path right after the engine committed it. Failures queue
+  // the path in the module's pending set (retried by the next cycle) and never surface to the API.
+  const pushOnWrite = async (st: TargetState, verb: MemoryVerb, path: string): Promise<void> => {
+    try {
+      const bearer = await getBearer();
+      if (bearer) {
+        const decision = await discovery.channelFor(st.target.vault, bearer);
+        if (decision.kind === 'couch') {
+          const couch = await ensureWire(st, decision);
+          if (verb === 'delete') await couch.removeFile(path);
+          else await couch.pushFileLive(path);
+          return;
+        }
+      }
+      if (verb !== 'delete') await (await getState(st)).enqueue(path); // deferred until a wire exists
+    } catch (err) {
+      log(`couch push-on-write ${path}: ${err instanceof Error ? err.message : String(err)}`);
+      if (verb !== 'delete')
+        await getState(st)
+          .then((s) => s.enqueue(path))
+          .catch(() => {});
+    }
+  };
+
+  return {
+    reschedule() {
+      for (const timer of timers.values()) clearInterval(timer);
+      timers.clear();
+      const targets = couchTargets(getConfig());
+      const live = new Set(targets.map((t) => t.vault));
+      for (const vault of [...states.keys()]) if (!live.has(vault)) states.delete(vault);
+      for (const t of targets) void getState(ensureTargetState(t)).catch(() => {});
+      for (const t of autoCouchTargets(getConfig())) {
+        const timer = setInterval(
+          () => void cycle(ensureTargetState(t)),
+          intervalMs(t.intervalSeconds)
+        );
+        timer.unref?.();
+        timers.set(t.vault, timer);
+      }
+    },
+    async runNow(vault) {
+      const t = couchTargets(getConfig()).find((x) => x.vault === vault);
+      if (!t) throw new Error(`'${vault}' is not an account vault`);
+      return cycle(ensureTargetState(t));
+    },
+    onWrite(verb, body) {
+      if (verb !== 'write' && verb !== 'edit' && verb !== 'delete') return;
+      const target = resolveMutationTarget(getConfig(), body);
+      if (!target) return;
+      const t = couchTargets(getConfig()).find((x) => x.vault === target.vault);
+      if (!t) return;
+      void pushOnWrite(ensureTargetState(t), verb, target.path);
+    },
+    status() {
+      return couchTargets(getConfig()).map((t): CouchTargetStatus => {
+        const st = states.get(t.vault);
+        return {
+          vault: t.vault,
+          channel: 'couch',
+          intervalSeconds: t.intervalSeconds,
+          lastSync: st?.lastSync,
+          lastError: st?.lastError,
+          pendingCount: st?.state?.pendingPaths().length ?? 0,
+          paused: st?.paused,
+          running: st?.running ?? false,
+        };
+      });
+    },
+    stop() {
+      for (const timer of timers.values()) clearInterval(timer);
+      timers.clear();
+    },
+  };
+};

--- a/src/sync/couch/manager.ts
+++ b/src/sync/couch/manager.ts
@@ -10,6 +10,7 @@ import {
   type FetchLike,
   type FetchJson,
   type FileStore,
+  type SyncResult as CouchChannelResult,
   type VaultsConfig,
 } from '@agentage/memory-core';
 import { currentBearer } from '../../lib/api.js';
@@ -51,7 +52,8 @@ export interface CouchTargetStatus {
 interface CouchLike {
   pushFileLive(path: string): Promise<void>;
   removeFile(path: string): Promise<void>;
-  syncNow(): Promise<void>;
+  flushPending(): Promise<void>;
+  syncNow(): Promise<CouchChannelResult>;
 }
 
 type MakeCouchSync = (
@@ -188,6 +190,10 @@ export const createCouchSyncManager = (deps: CouchSyncManagerDeps = {}): CouchSy
   const states = new Map<string, TargetState>();
   const timers = new Map<string, NodeJS.Timeout>();
 
+  // Everything queued for retry: failed/deferred pushes plus not-yet-tombstoned deletions.
+  const pendingCount = (st: TargetState | undefined): number =>
+    st?.state ? st.state.pendingPaths().length + st.state.deletionPaths().length : 0;
+
   const ensureTargetState = (target: CouchTarget): TargetState => {
     const existing = states.get(target.vault);
     if (existing) {
@@ -231,7 +237,7 @@ export const createCouchSyncManager = (deps: CouchSyncManagerDeps = {}): CouchSy
       ok: true,
       committed: false,
       pulled: false,
-      pendingCount: st.state?.pendingPaths().length ?? 0,
+      pendingCount: pendingCount(st),
       ...extra,
     });
     if (st.running) return build({});
@@ -252,8 +258,18 @@ export const createCouchSyncManager = (deps: CouchSyncManagerDeps = {}): CouchSy
       st.paused = undefined;
       const couch = await ensureWire(st, decision);
       const pre = await commitDirty(st.target.path, `sync: ${nowIso()}`);
-      await couch.syncNow(); // pushAll (rev-cache skips no-ops) then pullOnce
+      await couch.flushPending(); // drain queued pushes AND queued deletions first
+      const res = await couch.syncNow(); // pushAll + reconcile deletions, then pullOnce
       const post = await commitDirty(st.target.path, `sync: couch ${nowIso()}`);
+      if (res.error) {
+        st.lastError = res.error;
+        return build({
+          ok: false,
+          committed: pre.committed,
+          pulled: post.committed,
+          error: res.error,
+        });
+      }
       st.lastSync = nowIso();
       st.lastError = undefined;
       return build({ committed: pre.committed, pulled: post.committed });
@@ -267,8 +283,15 @@ export const createCouchSyncManager = (deps: CouchSyncManagerDeps = {}): CouchSy
   };
 
   // Sync-on-save: push (or tombstone) one path right after the engine committed it. Failures queue
-  // the path in the module's pending set (retried by the next cycle) and never surface to the API.
+  // the path in the module's persisted pending/deletion sets (retried by the next cycle) and never
+  // surface to the API. A delete is durable regardless of auth/network state at delete time: with
+  // no wire it enqueues the deletion, and removeFile itself self-enqueues on transport failure.
   const pushOnWrite = async (st: TargetState, verb: MemoryVerb, path: string): Promise<void> => {
+    const defer = async (): Promise<void> => {
+      const state = await getState(st);
+      if (verb === 'delete') await state.enqueueDeletion(path);
+      else await state.enqueue(path);
+    };
     try {
       const bearer = await getBearer();
       if (bearer) {
@@ -280,13 +303,10 @@ export const createCouchSyncManager = (deps: CouchSyncManagerDeps = {}): CouchSy
           return;
         }
       }
-      if (verb !== 'delete') await (await getState(st)).enqueue(path); // deferred until a wire exists
+      await defer(); // no wire yet (signed out / paused) - queued until one exists
     } catch (err) {
       log(`couch push-on-write ${path}: ${err instanceof Error ? err.message : String(err)}`);
-      if (verb !== 'delete')
-        await getState(st)
-          .then((s) => s.enqueue(path))
-          .catch(() => {});
+      await defer().catch(() => {});
     }
   };
 
@@ -329,7 +349,7 @@ export const createCouchSyncManager = (deps: CouchSyncManagerDeps = {}): CouchSy
           intervalSeconds: t.intervalSeconds,
           lastSync: st?.lastSync,
           lastError: st?.lastError,
-          pendingCount: st?.state?.pendingPaths().length ?? 0,
+          pendingCount: pendingCount(st),
           paused: st?.paused,
           running: st?.running ?? false,
         };

--- a/src/sync/couch/state-store.test.ts
+++ b/src/sync/couch/state-store.test.ts
@@ -1,0 +1,39 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type CouchSyncState } from '@agentage/memory-core';
+import { couchStateDir, createStatePersistence } from './state-store.js';
+
+const sample: CouchSyncState = { cursor: '42', revs: { 'a.md': 'h:1,h:2' }, pending: ['b.md'] };
+
+describe('createStatePersistence', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'cstate-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('round-trips a saved state and writes under couch-state/<vault>.json', async () => {
+    const p = createStatePersistence(dir, 'acct');
+    expect(await p.load()).toBeNull();
+    await p.save(sample);
+    expect(await p.load()).toEqual(sample);
+    const raw = await readFile(join(couchStateDir(dir), 'acct.json'), 'utf8');
+    expect(JSON.parse(raw)).toEqual(sample);
+  });
+
+  it('degrades a corrupt state file to a fresh (null) state instead of throwing', async () => {
+    const p = createStatePersistence(dir, 'acct');
+    await p.save(sample);
+    writeFileSync(join(couchStateDir(dir), 'acct.json'), '{ not json');
+    expect(await p.load()).toBeNull();
+  });
+
+  it('leaves no .tmp behind after an atomic save', async () => {
+    const p = createStatePersistence(dir, 'acct');
+    await p.save(sample);
+    await expect(readFile(join(couchStateDir(dir), 'acct.json.tmp'), 'utf8')).rejects.toThrow();
+  });
+});

--- a/src/sync/couch/state-store.ts
+++ b/src/sync/couch/state-store.ts
@@ -1,0 +1,30 @@
+import { mkdirSync } from 'node:fs';
+import { readFile, rename, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { type CouchStatePersistence, type CouchSyncState } from '@agentage/memory-core';
+
+// The couch sync cursor + rev-cache + pending queue for one vault, at
+// <configDir>/couch-state/<vault>.json. Load returns null on a missing OR unparseable file so a
+// corrupt state degrades to a fresh from-scratch sync rather than crashing the daemon; save is
+// atomic (temp + rename) so a crash mid-write never truncates it.
+export const couchStateDir = (configDir: string): string => join(configDir, 'couch-state');
+
+export const createStatePersistence = (configDir: string, vault: string): CouchStatePersistence => {
+  const dir = couchStateDir(configDir);
+  const path = join(dir, `${encodeURIComponent(vault)}.json`);
+  return {
+    async load(): Promise<CouchSyncState | null> {
+      try {
+        return JSON.parse(await readFile(path, 'utf8')) as CouchSyncState;
+      } catch {
+        return null;
+      }
+    },
+    async save(state: CouchSyncState): Promise<void> {
+      mkdirSync(dir, { recursive: true });
+      const tmp = `${path}.tmp`;
+      await writeFile(tmp, JSON.stringify(state), 'utf8');
+      await rename(tmp, path);
+    },
+  };
+};

--- a/src/sync/couch/targets.test.ts
+++ b/src/sync/couch/targets.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { type VaultsConfig } from '@agentage/memory-core';
+import { autoCouchTargets, couchTargets } from './targets.js';
+
+const config = (vaults: VaultsConfig['vaults']): VaultsConfig => ({ version: 1, vaults });
+
+describe('couchTargets', () => {
+  it('selects only account (agentage) vaults with a path', () => {
+    const targets = couchTargets(
+      config({
+        acct: { path: '/tmp/acct', origin: [{ remote: 'agentage' }] },
+        gitv: { path: '/tmp/gitv', origin: [{ remote: 'git@h:g.git' }] },
+        local: { path: '/tmp/local' },
+      })
+    );
+    expect(targets.map((t) => t.vault)).toEqual(['acct']);
+    expect(targets[0]!.path).toBe('/tmp/acct');
+  });
+
+  it('defaults the interval to 300s and honours an explicit one', () => {
+    const targets = couchTargets(
+      config({
+        a: { path: '/tmp/a', origin: [{ remote: 'agentage' }] },
+        b: { path: '/tmp/b', origin: [{ remote: 'agentage', interval: 60 }] },
+        c: { path: '/tmp/c', origin: [{ remote: 'agentage', interval: 0 }] },
+      })
+    );
+    expect(Object.fromEntries(targets.map((t) => [t.vault, t.intervalSeconds]))).toEqual({
+      a: 300,
+      b: 60,
+      c: 0,
+    });
+  });
+
+  it('autoCouchTargets excludes interval-0 (manual-only) vaults', () => {
+    const auto = autoCouchTargets(
+      config({
+        a: { path: '/tmp/a', origin: [{ remote: 'agentage', interval: 60 }] },
+        c: { path: '/tmp/c', origin: [{ remote: 'agentage', interval: 0 }] },
+      })
+    );
+    expect(auto.map((t) => t.vault)).toEqual(['a']);
+  });
+
+  it('is empty for a config with no account vaults', () => {
+    expect(
+      couchTargets(config({ g: { path: '/tmp/g', origin: [{ remote: 'x:y.git' }] } }))
+    ).toEqual([]);
+    expect(couchTargets({ version: 1 })).toEqual([]);
+  });
+});

--- a/src/sync/couch/targets.ts
+++ b/src/sync/couch/targets.ts
@@ -1,0 +1,32 @@
+import { expandPath, isAccountVault, type VaultsConfig } from '@agentage/memory-core';
+import { DEFAULT_INTERVAL_SECONDS } from '../planner.js';
+
+// The account (agentage) channel a couch target syncs to. Unlike a git target it has no external
+// remote URL: the daemon resolves the per-memory CouchDB + JWT endpoints from discovery at runtime.
+export const ACCOUNT_REMOTE = 'agentage';
+
+export interface CouchTarget {
+  vault: string;
+  path: string; // absolute local working-copy path (the account mirror)
+  intervalSeconds: number;
+}
+
+// Every account vault (agentage origin) with a local mirror path is a couch target. Interval rides
+// on the agentage origin and matches git semantics: absent = 300s, 0 = manual-only.
+export const couchTargets = (config: VaultsConfig): CouchTarget[] => {
+  const out: CouchTarget[] = [];
+  for (const [vault, entry] of Object.entries(config.vaults ?? {})) {
+    if (!isAccountVault(entry) || !entry.path) continue;
+    const origin = entry.origin?.find((o) => o.remote === ACCOUNT_REMOTE);
+    out.push({
+      vault,
+      path: expandPath(entry.path),
+      intervalSeconds: origin?.interval ?? DEFAULT_INTERVAL_SECONDS,
+    });
+  }
+  return out;
+};
+
+// The couch targets the daemon auto-loop schedules: interval 0 is manual-only and excluded.
+export const autoCouchTargets = (config: VaultsConfig): CouchTarget[] =>
+  couchTargets(config).filter((t) => t.intervalSeconds > 0);

--- a/src/sync/manager.ts
+++ b/src/sync/manager.ts
@@ -1,5 +1,6 @@
 import { type VaultsConfig } from '@agentage/memory-core';
 import { loadVaultsConfig } from '../lib/vaults.js';
+import { type CouchTargetStatus } from './couch/manager.js';
 import { runSyncCycle, type SyncResult } from './cycle.js';
 import { autoSyncTargets, intervalMs, syncTargets, type SyncTarget } from './planner.js';
 
@@ -15,6 +16,8 @@ export interface VaultSyncState {
 
 export interface SyncStatus {
   vaults: VaultSyncState[];
+  // The account (couch) targets, composed in by the daemon; absent on an older daemon.
+  couch?: CouchTargetStatus[];
 }
 
 export interface SyncManagerDeps {


### PR DESCRIPTION
## M5 - couch account sync in the daemon

Adds the account (couch) sync channel to the local daemon, over `@agentage/memory-core@0.3.0`'s couch module. An account vault (agentage origin) is now a live two-way mirror: sync-on-save pushes every write to the per-memory CouchDB, a periodic/manual cycle pulls remote changes back onto disk and commits them, and everything stays offline-safe and crash-proof.

### What ships
- **`src/sync/couch/`** - the new channel:
  - `targets.ts` - account-only target planner; interval semantics identical to git (absent = 300s, 0 = manual-only).
  - `file-store.ts` - `FileStore` over the vault mirror: recursive `.md` listing (excludes `.git/` and dotfiles), parent-dir creation, POSIX-relative paths.
  - `state-store.ts` - `CouchStatePersistence` at `<configDir>/couch-state/<vault>.json` (atomic temp+rename; corrupt file -> fresh state).
  - `discovery.ts` - wraps memory-core's `HostResolver`: `GET /.well-known/agentage-sync` with a TTL cache, provision-once-and-refresh-once when a vault is missing from `couch_vaults`, else paused with a reason.
  - `manager.ts` - the scheduler: per-account-vault timers + a persistent `CouchSync` per target for sync-on-save. Tick cycle = commit-if-dirty (`sync: <ISO>`, lock-tolerant) -> `couch.syncNow()` -> commit-if-pull-applied (`sync: couch <ISO>`). Every failure is caught -> `lastError`/`paused`, never crashes the daemon.
- **Discovery host** - `src/lib/origins.ts` gains `sync` (`sync.<fqdn>`; local `:3011`); a `127.0.0.1:<port>` fqdn collapses every origin onto one stub (the hermetic-e2e convention).
- **Push-on-write** - `daemon/server.ts` gains an `onMutation` hook fired after a successful write/edit/delete; `daemon-entry.ts` wires it to `couch.onWrite`, which maps the wire ref to the account vault + relative path and fires `pushFileLive`/`removeFile` fire-and-forget (never touches the API response; git/local vaults are ignored).
- **Status + manual run** - `/api/sync/status` now carries `couch[]` targets (`vault, channel, lastSync?, lastError?, pendingCount, paused?`); `/api/sync/run` + `agentage vault sync [name]` trigger the couch cycle for account vaults (daemon-if-up, in-process fallback). Replaces M1c's "vault sync skips account vaults" message with the real behavior. `daemon status` prints a `couch sync` section.
- **Auth** - `api.ts` `currentBearer()` re-reads `auth.json` each call with refresh-once; signed out -> paused with zero network.

### Tests
- **Unit (+32, 295 total):** targets planner, FileStore, state persistence, discovery cache/provision-retry/paused-reasons, push-on-write routing (account-only), status shapes, `resolveMutationTarget`, origins stub mapping.
- **Hermetic e2e tier** (`e2e/couch-sync.test.ts`, `@couch`): a REAL `couchdb:3.4` container (JWT handler in `local.ini` at startup) + a node:http stub for discovery/token/provision, driving the built CLI + daemon. The stub mints a REAL HS256 JWT that CouchDB must accept (proves the production member-scoped auth mode). Covers: sync-on-save push (asserts the content-addressed `f:`/`h:` docs via `encodeFile`), reverse pull + commit + read, delete both directions, signed-out pause with zero couch requests, and `daemon status`. Docker-gated (`docker info`) -> skips with a reason when unavailable. Whole file runs in ~9s.

### Follow-up: durable deletes (memory-core 0.3.1)
Adversarial verification found signed-out/offline deletes could be dropped before the module saw them. Fixed on top of `@agentage/memory-core@0.3.1` (deletion queue + `reconcileDeletions` + never-throw `removeFile` + non-rejecting `syncNow`):
- `pushOnWrite` now defers a delete durably: no bearer / paused / discovery failure -> `enqueueDeletion` (writes still `enqueue`); `removeFile` self-enqueues on transport failure. Invariant: a CLI delete always eventually yields a tombstone (or a legitimate edit-wins 409 resolution), regardless of auth/network state at delete time.
- The cycle drains BOTH retry queues (`flushPending`) before `syncNow`, and consumes `syncNow`'s `{pushed, pulled, error?}` into `lastError`/`ok`.
- `pendingCount` now counts queued deletions too.
- New unit tests: signed-out delete enqueues durably (zero network), discovery-failure delete never dropped, commit-if-dirty runs BEFORE syncNow (local truth survives a couch outage), flushPending ordering.
- New e2e regressions: signed-out delete -> sign-in -> tombstone + a fresh replica replaying from cursor 0 never resurrects the file; delete during a token-endpoint 401 outage converges once tokens recover.

### Hygiene
Zero new deps (memory-core bumped `^0.2.0` -> `^0.3.1` via targeted installs; lock diff limited to it). Strict TS ESM, R6 package-guard intact.

