### PR TITLE
feat(discover): live autodiscovery of discover roots (M5)

### DIFF
--- a/e2e/couch-sync.test.ts
+++ b/e2e/couch-sync.test.ts
@@ -9,7 +9,7 @@
  */
 import { execFile, execFileSync } from 'node:child_process';
 import { createHash, createHmac, randomUUID } from 'node:crypto';
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { createServer as netServer, type AddressInfo } from 'node:net';
@@ -195,14 +195,36 @@ interface Stub {
   requests(): number;
   setDb(db: string): void;
   setTokenFail(fail: boolean): void;
+  // Map an extra vault name onto the current db (the discover tier registers 'teamnotes' at runtime).
+  addVault(name: string): void;
+  // The vault names the daemon POSTed to /api/memories (proves the discover watcher provisioned).
+  provisioned(): string[];
   stop(): Promise<void>;
 }
+
+const readJson = (req: IncomingMessage): Promise<Record<string, unknown>> =>
+  new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      try {
+        resolve(
+          JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}') as Record<string, unknown>
+        );
+      } catch {
+        resolve({});
+      }
+    });
+    req.on('error', () => resolve({}));
+  });
 
 const startStub = async (couch: Couch): Promise<Stub> => {
   const port = await freeTcpPort();
   let db = '';
   let count = 0;
   let tokenFail = false;
+  const vaultNames = new Set<string>([VAULT]);
+  const provisioned: string[] = [];
   const handle = (req: IncomingMessage, res: ServerResponse): void => {
     count += 1;
     const url = (req.url ?? '').split('?')[0] ?? '';
@@ -216,7 +238,7 @@ const startStub = async (couch: Couch): Promise<Stub> => {
         vaults: [],
         couch_endpoint: couch.url,
         couch_token_url: `http://127.0.0.1:${port}/account/couch-token`,
-        couch_vaults: [{ vault: VAULT, db }],
+        couch_vaults: [...vaultNames].map((vault) => ({ vault, db })),
         ttl: 60,
       });
     if (req.method === 'POST' && url === '/account/couch-token') {
@@ -228,7 +250,13 @@ const startStub = async (couch: Couch): Promise<Stub> => {
         data: { jwt: mintJwt(couch.jwtSecret), db, sub: SUB, expSec: 61 },
       });
     }
-    if (req.method === 'POST' && url === '/api/memories') return send(200, { success: true });
+    if (req.method === 'POST' && url === '/api/memories') {
+      void readJson(req).then((body) => {
+        if (typeof body['name'] === 'string') provisioned.push(body['name']);
+        send(200, { success: true });
+      });
+      return;
+    }
     send(404, { error: 'not found' });
   };
   const server = createServer(handle);
@@ -242,6 +270,8 @@ const startStub = async (couch: Couch): Promise<Stub> => {
     setTokenFail: (f) => {
       tokenFail = f;
     },
+    addVault: (name) => void vaultNames.add(name),
+    provisioned: () => [...provisioned],
     stop: () => new Promise((resolve) => server.close(() => resolve())),
   };
 };
@@ -496,6 +526,92 @@ test.describe('couch account sync (hermetic) @couch', () => {
       await waitFor(async () => (await getDoc(couch, db, 'f:notes/q.md')).status === 404);
     } finally {
       await cleanup();
+    }
+  });
+
+  test('live-discovers a folder dropped into a discover root, then honors remove+ignore', async () => {
+    const db = await createDb(couch);
+    stub.setDb(db);
+    stub.addVault('teamnotes'); // the discovered account vault resolves to this test's db
+    const daemonPort = await freePort();
+    const m = createCliMachine({
+      AGENTAGE_SITE_FQDN: `127.0.0.1:${stub.port}`,
+      AGENTAGE_NO_DAEMON: '',
+      AGENTAGE_DAEMON_PORT: String(daemonPort),
+      // Short knobs keep the tier deterministic even where fs.watch is unreliable (the poll covers it).
+      AGENTAGE_DISCOVER_POLL_MS: '800',
+      AGENTAGE_DISCOVER_DEBOUNCE_MS: '150',
+    });
+    fakeAuth(m, stub.port);
+    const rootDir = join(m.configDir, 'discover-root');
+    mkdirSync(rootDir, { recursive: true });
+    const vaultsPath = join(m.configDir, 'vaults.json');
+    // autosync:false -> discovered entries are interval 0 (manual-only): no background timer race.
+    writeFileSync(
+      vaultsPath,
+      JSON.stringify(
+        { version: 1, discover: [{ path: rootDir, autosync: false }], vaults: {} },
+        null,
+        2
+      )
+    );
+    interface Cfg {
+      vaults?: Record<string, { origin?: { remote: string; interval?: number }[]; mcp?: string[] }>;
+      discover?: { path: string; ignore?: string[] }[];
+    }
+    const readCfg = (): Cfg => JSON.parse(readFileSync(vaultsPath, 'utf8')) as Cfg;
+
+    const start = await m.exec(['daemon', 'start']);
+    expect(start.code, start.stderr).toBe(0);
+    try {
+      // Drop a new folder (with a note) plus an invalid-named folder into the watched root.
+      mkdirSync(join(rootDir, 'teamnotes'));
+      writeFileSync(
+        join(rootDir, 'teamnotes', 'note.md'),
+        '# team note\nfrom a discovered folder\n'
+      );
+      mkdirSync(join(rootDir, 'bad name!'));
+
+      // WITHOUT a daemon restart the watcher registers teamnotes as an account vault.
+      await waitFor(async () => Boolean(readCfg().vaults?.teamnotes));
+      const entry = readCfg().vaults!.teamnotes!;
+      expect(entry.origin?.[0]).toEqual({ remote: 'agentage', interval: 0 }); // account shape
+      expect(entry.mcp).toEqual(['local']);
+      expect(readCfg().vaults?.['bad name!'], 'invalid names never register').toBeUndefined();
+
+      // The watcher provisioned the discovered vault's cloud channel.
+      await waitFor(async () => stub.provisioned().includes('teamnotes'));
+
+      // /api/sync/status lists both the discover root and the new couch target.
+      await waitFor(async () => {
+        const s = (await (
+          await fetch(`http://127.0.0.1:${daemonPort}/api/sync/status`)
+        ).json()) as { couch?: { vault: string }[]; discover?: { roots: string[] } };
+        return (
+          (s.discover?.roots ?? []).includes(rootDir) &&
+          (s.couch ?? []).some((c) => c.vault === 'teamnotes')
+        );
+      });
+
+      // A manual sync pushes the dropped note to couch as f:note.md.
+      const sync = await m.exec(['vault', 'sync', 'teamnotes']);
+      expect(sync.code, sync.stderr).toBe(0);
+      await waitFor(async () => (await getDoc(couch, db, 'f:note.md')).status === 200);
+
+      // Remove appends the name to the root's ignore in the same save (V8).
+      const removed = await m.exec(['vault', 'remove', 'teamnotes']);
+      expect(removed.code, removed.stderr).toBe(0);
+      expect(removed.stdout).toContain('ignore');
+      expect(readCfg().discover?.[0]?.ignore).toContain('teamnotes');
+      expect(readCfg().vaults?.teamnotes).toBeUndefined();
+
+      // Touch the folder again: an ignored name is never re-discovered.
+      writeFileSync(join(rootDir, 'teamnotes', 'note2.md'), 'second note\n');
+      await sleep(2500); // > debounce + several poll cycles
+      expect(readCfg().vaults?.teamnotes, 'ignored folder must not be re-added').toBeUndefined();
+    } finally {
+      await m.exec(['daemon', 'stop']).catch(() => {});
+      m.cleanup();
     }
   });
 });

--- a/e2e/couch-sync.test.ts
+++ b/e2e/couch-sync.test.ts
@@ -538,8 +538,8 @@ test.describe('couch account sync (hermetic) @couch', () => {
       AGENTAGE_SITE_FQDN: `127.0.0.1:${stub.port}`,
       AGENTAGE_NO_DAEMON: '',
       AGENTAGE_DAEMON_PORT: String(daemonPort),
-      // Short knobs keep the tier deterministic even where fs.watch is unreliable (the poll covers it).
-      AGENTAGE_DISCOVER_POLL_MS: '800',
+      // Short knobs (floored at 1000/50ms) keep the tier deterministic even where fs.watch is flaky.
+      AGENTAGE_DISCOVER_POLL_MS: '1000',
       AGENTAGE_DISCOVER_DEBOUNCE_MS: '150',
     });
     fakeAuth(m, stub.port);

--- a/src/commands/daemon-cmd.ts
+++ b/src/commands/daemon-cmd.ts
@@ -79,6 +79,10 @@ const statusAction = async (): Promise<void> => {
       console.log(`  ${v.vault.padEnd(16)} ${cadence.padEnd(12)} ${state}${pending}`);
     }
   }
+  if (sync?.discover && sync.discover.roots.length > 0) {
+    console.log(`discover roots (${sync.discover.roots.length})`);
+    for (const root of sync.discover.roots) console.log(`  ${root}`);
+  }
 };
 
 export const registerDaemon = (program: Command): void => {

--- a/src/commands/vault.test.ts
+++ b/src/commands/vault.test.ts
@@ -148,6 +148,29 @@ describe('vault remove', () => {
     const h = makeDeps();
     expect(() => runVaultRemove('nope', h.deps)).toThrow(/not found/);
   });
+
+  it('appends the name to the discover-root ignore when the path sits under it', () => {
+    const h = makeDeps({
+      version: 1,
+      discover: [{ path: '/data/roots' }],
+      vaults: { teamnotes: { path: '/data/roots/teamnotes', origin: [{ remote: 'agentage' }] } },
+    });
+    runVaultRemove('teamnotes', h.deps);
+    expect(h.get().vaults).toEqual({});
+    expect(h.get().discover?.[0]?.ignore).toEqual(['teamnotes']);
+    expect(h.logs.join()).toContain('/data/roots ignore');
+  });
+
+  it('leaves the discover config untouched for a vault outside every root', () => {
+    const h = makeDeps({
+      version: 1,
+      discover: [{ path: '/data/roots' }],
+      vaults: { work: { path: '/elsewhere/work', mcp: ['local'] } },
+    });
+    runVaultRemove('work', h.deps);
+    expect(h.get().discover?.[0]?.ignore).toBeUndefined();
+    expect(h.logs.join()).not.toContain('ignore');
+  });
 });
 
 describe('vault list', () => {

--- a/src/commands/vault.ts
+++ b/src/commands/vault.ts
@@ -3,6 +3,7 @@ import { type Command } from 'commander';
 import { isAccountVault, type VaultEntry, type VaultsConfig } from '@agentage/memory-core';
 import {
   addVault,
+  appendDiscoverIgnore,
   ensureVaultDir,
   formatVaultLine,
   removeVault,
@@ -76,9 +77,14 @@ export const runVaultAdd = async (
 export const runVaultRemove = (name: string, deps: VaultDeps = defaultDeps): void => {
   const { config } = deps.load();
   const wasDefault = config.default === name;
-  const next = removeVault(config, name);
+  const path = config.vaults?.[name]?.path;
+  let next = removeVault(config, name);
+  // V8: keep the removal and the ignore in one atomic save, else the next scan re-adds the folder.
+  const ignored = path ? appendDiscoverIgnore(next, name, path) : null;
+  if (ignored) next = ignored.config;
   deps.save(next);
   deps.log(`Removed vault '${name}' (files left on disk).`);
+  if (ignored) deps.log(`Added '${name}' to ${ignored.root} ignore so it is not re-discovered.`);
   if (wasDefault && next.default) deps.log(`Default vault is now '${next.default}'.`);
 };
 

--- a/src/daemon-entry.ts
+++ b/src/daemon-entry.ts
@@ -12,8 +12,14 @@ import { createDaemonServer } from './daemon/server.js';
 import { loadLocalMemoryServer } from './mcp/local-server.js';
 import { loadVaultsConfig, vaultsJsonPath } from './lib/vaults.js';
 import { createCouchSyncManager } from './sync/couch/manager.js';
+import { createDiscoverWatcher } from './sync/discover/watcher.js';
 import { createSyncManager } from './sync/manager.js';
 import { VERSION } from './utils/version.js';
+
+const envInt = (name: string): number | undefined => {
+  const v = Number(process.env[name]);
+  return Number.isFinite(v) && v >= 0 ? v : undefined;
+};
 
 // The detached, long-lived engine host: one loopback HTTP server that owns a single in-process
 // engine and serialises every vault mutation, avoiding concurrent git index.lock collisions. It
@@ -22,6 +28,11 @@ const main = async (): Promise<void> => {
   const port = resolvePort();
   const git = createSyncManager();
   const couch = createCouchSyncManager();
+  const discover = createDiscoverWatcher({
+    log: (msg) => console.log(`[discover] ${msg}`),
+    debounceMs: envInt('AGENTAGE_DISCOVER_DEBOUNCE_MS'),
+    pollMs: envInt('AGENTAGE_DISCOVER_POLL_MS'),
+  });
 
   // A vault is on exactly one channel: an account (agentage) vault syncs over couch, else git.
   const runNow = (
@@ -35,7 +46,7 @@ const main = async (): Promise<void> => {
     getClient: createClientProvider(),
     buildMcpServer: loadLocalMemoryServer,
     sync: {
-      status: () => ({ ...git.status(), couch: couch.status() }),
+      status: () => ({ ...git.status(), couch: couch.status(), discover: discover.status() }),
       runNow,
     },
     onMutation: (verb, body) => couch.onWrite(verb, body),
@@ -46,17 +57,20 @@ const main = async (): Promise<void> => {
   writePortFile(port);
   git.reschedule();
   couch.reschedule();
+  discover.reschedule();
 
   const configPath = vaultsJsonPath();
   watchFile(configPath, { interval: 2000 }, () => {
     git.reschedule();
     couch.reschedule();
+    discover.reschedule();
   });
 
   const shutdown = (): void => {
     unwatchFile(configPath);
     git.stop();
     couch.stop();
+    discover.stop();
     server.stop().finally(() => {
       removePidFile();
       removePortFile();

--- a/src/daemon-entry.ts
+++ b/src/daemon-entry.ts
@@ -16,8 +16,11 @@ import { createDiscoverWatcher } from './sync/discover/watcher.js';
 import { createSyncManager } from './sync/manager.js';
 import { VERSION } from './utils/version.js';
 
+// Unset/empty/invalid -> undefined (the watcher's defaults apply); the watcher floors low values.
 const envInt = (name: string): number | undefined => {
-  const v = Number(process.env[name]);
+  const raw = process.env[name];
+  if (!raw) return undefined;
+  const v = Number(raw);
   return Number.isFinite(v) && v >= 0 ? v : undefined;
 };
 

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -42,11 +42,11 @@ describe('config store', () => {
     expect(mode).toBe(0o600);
   });
 
+  // Per-save unique tmp names make cross-process tmp clobbering structurally impossible.
   it('writes atomically, leaving no temp file behind', () => {
-    saveAuth(sample);
-    saveAuth({ ...sample, clientId: 'client-2' });
-    expect(existsSync(join(getConfigDir(), 'auth.json.tmp'))).toBe(false);
-    expect(readAuth()?.clientId).toBe('client-2');
+    for (let i = 0; i < 25; i++) saveAuth({ ...sample, clientId: `client-${i}` });
+    expect(readdirSync(getConfigDir()).filter((f) => f.endsWith('.tmp'))).toEqual([]);
+    expect(readAuth()?.clientId).toBe('client-24');
     expect(statSync(join(getConfigDir(), 'auth.json')).mode & 0o777).toBe(0o600);
   });
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import {
   chmodSync,
   existsSync,
@@ -45,11 +46,12 @@ export const readAuth = (): AuthState | null => {
 };
 
 // Atomic 0600 write: a token file is never left half-written or briefly world-readable. Write a
-// sibling temp, chmod it 0600 BEFORE the rename, then rename over the target in one step.
+// per-save sibling temp (unique name: concurrent savers can never clobber each other's tmp),
+// chmod it 0600 BEFORE the rename, then rename over the target in one step.
 export const saveAuth = (state: AuthState): void => {
   ensureConfigDir();
   const path = authPath();
-  const tmp = `${path}.tmp`;
+  const tmp = `${path}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
   writeFileSync(tmp, JSON.stringify(state, null, 2) + '\n', { encoding: 'utf-8', mode: 0o600 });
   chmodSync(tmp, 0o600);
   renameSync(tmp, path);

--- a/src/lib/vault-registry.test.ts
+++ b/src/lib/vault-registry.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { VaultsConfig } from '@agentage/memory-core';
 import {
   addVault,
+  appendDiscoverIgnore,
   ensureVaultDir,
   formatVaultLine,
   removeVault,
@@ -65,6 +66,43 @@ describe('removeVault', () => {
 
   it('throws when the vault is absent', () => {
     expect(() => removeVault(base(), 'nope')).toThrow(/not found/);
+  });
+});
+
+describe('appendDiscoverIgnore', () => {
+  const withRoot = (ignore?: string[]): VaultsConfig => ({
+    version: 1,
+    discover: [{ path: '/data/roots', ...(ignore ? { ignore } : {}) }],
+    vaults: {},
+  });
+
+  it('appends the name to the root the vault path sits directly under', () => {
+    const res = appendDiscoverIgnore(withRoot(), 'teamnotes', '/data/roots/teamnotes');
+    expect(res).not.toBeNull();
+    expect(res!.root).toBe('/data/roots');
+    expect(res!.config.discover?.[0]?.ignore).toEqual(['teamnotes']);
+  });
+
+  it('preserves an existing ignore list', () => {
+    const res = appendDiscoverIgnore(withRoot(['old']), 'teamnotes', '/data/roots/teamnotes');
+    expect(res!.config.discover?.[0]?.ignore).toEqual(['old', 'teamnotes']);
+  });
+
+  it('is idempotent when the name is already ignored', () => {
+    const res = appendDiscoverIgnore(withRoot(['teamnotes']), 'teamnotes', '/data/roots/teamnotes');
+    expect(res!.config.discover?.[0]?.ignore).toEqual(['teamnotes']);
+  });
+
+  it('returns null for a vault nested deeper than a direct child of the root', () => {
+    expect(appendDiscoverIgnore(withRoot(), 'x', '/data/roots/sub/x')).toBeNull();
+  });
+
+  it('returns null when the path is not under any discover root', () => {
+    expect(appendDiscoverIgnore(withRoot(), 'elsewhere', '/other/place/elsewhere')).toBeNull();
+  });
+
+  it('returns null when there are no discover roots', () => {
+    expect(appendDiscoverIgnore({ version: 1, vaults: {} }, 'x', '/data/roots/x')).toBeNull();
   });
 });
 

--- a/src/lib/vault-registry.ts
+++ b/src/lib/vault-registry.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
 import {
   expandPath,
   isAccountVault,
@@ -61,4 +62,23 @@ export const removeVault = (config: VaultsConfig, name: string): VaultsConfig =>
     else delete next.default;
   }
   return validateConfig(next);
+};
+
+// V8: when a removed vault sat directly under a discover root, append its name to that root's
+// `ignore` so the next scan does not re-add it. Returns the updated config plus the matched root
+// path (for the message), or null when the path is not directly under any discover root.
+export const appendDiscoverIgnore = (
+  config: VaultsConfig,
+  name: string,
+  vaultPath: string
+): { config: VaultsConfig; root: string } | null => {
+  const parent = resolve(expandPath(vaultPath), '..');
+  const roots = config.discover ?? [];
+  const idx = roots.findIndex((r) => resolve(expandPath(r.path)) === parent);
+  if (idx === -1) return null;
+  const root = roots[idx]!;
+  if (root.ignore?.includes(name)) return { config, root: root.path };
+  const next = [...roots];
+  next[idx] = { ...root, ignore: [...(root.ignore ?? []), name] };
+  return { config: validateConfig({ ...config, discover: next }), root: root.path };
 };

--- a/src/lib/vaults.test.ts
+++ b/src/lib/vaults.test.ts
@@ -1,9 +1,9 @@
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { VaultsConfig } from '@agentage/memory-core';
-import { ensureConfigDir } from './config.js';
+import { ensureConfigDir, getConfigDir } from './config.js';
 import {
   ensureVaultsConfig,
   loadVaultsConfig,
@@ -82,6 +82,18 @@ describe('vaults config store', () => {
   it('always rewrites the canonical $schema url on save', () => {
     const path = saveVaultsConfig({ $schema: 'https://evil/x.json', version: 1, vaults: {} });
     expect(JSON.parse(readFileSync(path, 'utf-8'))['$schema']).toBe(SCHEMA);
+  });
+
+  // Per-save unique tmp names make cross-process tmp clobbering structurally impossible.
+  it('rapid successive saves never throw and the survivor is valid JSON', () => {
+    let path = '';
+    for (let i = 0; i < 25; i++) {
+      path = saveVaultsConfig({ version: 1, vaults: { [`v${i}`]: { path: `/tmp/v${i}` } } });
+    }
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as { vaults: Record<string, unknown> };
+    expect(Object.keys(parsed.vaults)).toEqual(['v24']);
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+    expect(readdirSync(getConfigDir()).filter((f) => f.endsWith('.tmp'))).toEqual([]);
   });
 
   it('scaffolds an empty, $schema-linked vaults.json when none exists', () => {

--- a/src/lib/vaults.test.ts
+++ b/src/lib/vaults.test.ts
@@ -69,6 +69,16 @@ describe('vaults config store', () => {
     expect(loadVaultsConfig().config.vaults).toEqual(config.vaults);
   });
 
+  it('preserves the discover roots through a save round-trip', () => {
+    const config: VaultsConfig = {
+      version: 1,
+      discover: [{ path: '~/roots', autosync: false, ignore: ['skip'] }],
+      vaults: { work: { path: '~/w', mcp: ['local'] } },
+    };
+    saveVaultsConfig(config);
+    expect(loadVaultsConfig().config.discover).toEqual(config.discover);
+  });
+
   it('always rewrites the canonical $schema url on save', () => {
     const path = saveVaultsConfig({ $schema: 'https://evil/x.json', version: 1, vaults: {} });
     expect(JSON.parse(readFileSync(path, 'utf-8'))['$schema']).toBe(SCHEMA);

--- a/src/lib/vaults.ts
+++ b/src/lib/vaults.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import { chmodSync, existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { validateConfig, type VaultsConfig } from '@agentage/memory-core';
@@ -41,7 +42,8 @@ export const saveVaultsConfig = (config: VaultsConfig): string => {
   if (config.default !== undefined) out.default = config.default;
   if (config.discover !== undefined) out.discover = config.discover;
   out.vaults = config.vaults ?? {};
-  const tmp = `${path}.tmp`;
+  // A per-save tmp name: two concurrent savers can never clobber each other's tmp file.
+  const tmp = `${path}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
   writeFileSync(tmp, JSON.stringify(out, null, 2) + '\n', { encoding: 'utf-8', mode: 0o600 });
   renameSync(tmp, path);
   chmodSync(path, 0o600);

--- a/src/lib/vaults.ts
+++ b/src/lib/vaults.ts
@@ -39,6 +39,7 @@ export const saveVaultsConfig = (config: VaultsConfig): string => {
   if (config.autodiscover !== undefined) out.autodiscover = config.autodiscover;
   if (config.autoInit !== undefined) out.autoInit = config.autoInit;
   if (config.default !== undefined) out.default = config.default;
+  if (config.discover !== undefined) out.discover = config.discover;
   out.vaults = config.vaults ?? {};
   const tmp = `${path}.tmp`;
   writeFileSync(tmp, JSON.stringify(out, null, 2) + '\n', { encoding: 'utf-8', mode: 0o600 });

--- a/src/sync/discover/watcher.test.ts
+++ b/src/sync/discover/watcher.test.ts
@@ -1,0 +1,193 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import type { DiscoverCandidate, VaultsConfig } from '@agentage/memory-core';
+import { createDiscoverWatcher } from './watcher.js';
+
+const HUGE = 10 ** 9; // an effectively-disabled poll interval for the non-poll tests
+
+const candidate = (name: string): DiscoverCandidate => ({
+  name,
+  entry: { path: `/root/${name}`, origin: [{ remote: 'agentage' }], mcp: ['local'] },
+});
+
+describe('discover watcher', () => {
+  it('coalesces rapid change events into a single debounced rescan', async () => {
+    vi.useFakeTimers();
+    const scan = vi.fn((): DiscoverCandidate[] => []);
+    let fire = (): void => {};
+    const w = createDiscoverWatcher({
+      getConfig: () => ({ version: 1, discover: [{ path: '/root' }], vaults: {} }),
+      scan,
+      isDirectory: () => true,
+      watch: (_dir, onChange) => {
+        fire = onChange;
+        return { close: () => {} };
+      },
+      debounceMs: 500,
+      pollMs: HUGE,
+    });
+    w.reschedule(); // one initial scan + captures the change callback
+    expect(scan).toHaveBeenCalledTimes(1);
+    fire();
+    fire();
+    fire();
+    expect(scan).toHaveBeenCalledTimes(1); // still inside the debounce window
+    await vi.advanceTimersByTimeAsync(500);
+    expect(scan).toHaveBeenCalledTimes(2); // three events collapse to one rescan
+    w.stop();
+    vi.useRealTimers();
+  });
+
+  it('re-watches and rescans when the config gains a root', async () => {
+    const configs: VaultsConfig[] = [
+      { version: 1, vaults: {} },
+      { version: 1, discover: [{ path: '/root' }], vaults: {} },
+    ];
+    let idx = 0;
+    const scan = vi.fn((): DiscoverCandidate[] => []);
+    const watched: string[] = [];
+    const w = createDiscoverWatcher({
+      getConfig: () => configs[idx]!,
+      scan,
+      isDirectory: () => true,
+      watch: (dir) => {
+        watched.push(dir);
+        return { close: () => {} };
+      },
+      pollMs: HUGE,
+    });
+    w.reschedule();
+    expect(watched).toEqual([]); // no roots configured yet
+    idx = 1;
+    w.reschedule();
+    await Promise.resolve();
+    expect(watched).toEqual(['/root']);
+    expect(scan).toHaveBeenCalledTimes(2); // one scan per reschedule
+    w.stop();
+  });
+
+  it('writes discovered candidates onto the freshly re-read config (concurrent-write safe)', async () => {
+    const snapshot: VaultsConfig = { version: 1, discover: [{ path: '/root' }], vaults: {} };
+    // Disk gained an unrelated vault between the scan and the save (an external writer).
+    const disk: VaultsConfig = {
+      version: 1,
+      discover: [{ path: '/root' }],
+      vaults: { personal: { path: '/p', mcp: ['local'] } },
+    };
+    let saved: VaultsConfig | undefined;
+    const provisioned: string[] = [];
+    const w = createDiscoverWatcher({
+      getConfig: () => snapshot,
+      loadConfig: () => disk,
+      saveConfig: (c) => void (saved = c),
+      scan: () => [candidate('teamnotes')],
+      isDirectory: () => true,
+      provision: async (n) => void provisioned.push(n),
+      watch: () => ({ close: () => {} }),
+      pollMs: HUGE,
+    });
+    const added = await w.scanNow();
+    expect(added.map((c) => c.name)).toEqual(['teamnotes']);
+    expect(saved?.vaults?.personal).toEqual({ path: '/p', mcp: ['local'] }); // unrelated preserved
+    expect(saved?.vaults?.teamnotes).toEqual(candidate('teamnotes').entry);
+    expect(provisioned).toEqual(['teamnotes']);
+    w.stop();
+  });
+
+  it('skips a candidate a concurrent writer already registered, writing nothing', async () => {
+    let saved: VaultsConfig | undefined;
+    const w = createDiscoverWatcher({
+      getConfig: () => ({ version: 1, discover: [{ path: '/root' }], vaults: {} }),
+      loadConfig: () => ({
+        version: 1,
+        discover: [{ path: '/root' }],
+        vaults: { teamnotes: { path: '/root/teamnotes', mcp: ['local'] } },
+      }),
+      saveConfig: (c) => void (saved = c),
+      scan: () => [candidate('teamnotes')],
+      isDirectory: () => true,
+      watch: () => ({ close: () => {} }),
+      pollMs: HUGE,
+    });
+    expect(await w.scanNow()).toEqual([]);
+    expect(saved).toBeUndefined();
+    w.stop();
+  });
+
+  it('does not register a candidate whose directory vanished before the write', async () => {
+    let saved: VaultsConfig | undefined;
+    const cfg: VaultsConfig = { version: 1, discover: [{ path: '/root' }], vaults: {} };
+    const w = createDiscoverWatcher({
+      getConfig: () => cfg,
+      loadConfig: () => cfg,
+      saveConfig: (c) => void (saved = c),
+      scan: () => [candidate('gone')],
+      isDirectory: (p) => p !== '/root/gone', // the candidate dir is no longer a directory
+      watch: () => ({ close: () => {} }),
+      pollMs: HUGE,
+    });
+    expect(await w.scanNow()).toEqual([]);
+    expect(saved).toBeUndefined();
+    w.stop();
+  });
+
+  it('propagates an autosync:false root as interval-0 discovered entries', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agentage-discover-'));
+    mkdirSync(join(root, 'teamnotes'));
+    const cfg: VaultsConfig = {
+      version: 1,
+      discover: [{ path: root, autosync: false }],
+      vaults: {},
+    };
+    let saved: VaultsConfig | undefined;
+    try {
+      // Real scanDiscoverRoots + real isDirectory here: this exercises the autosync=false path.
+      const w = createDiscoverWatcher({
+        getConfig: () => cfg,
+        loadConfig: () => cfg,
+        saveConfig: (c) => void (saved = c),
+        provision: async () => {},
+        watch: () => ({ close: () => {} }),
+        pollMs: HUGE,
+      });
+      const added = await w.scanNow();
+      expect(added).toHaveLength(1);
+      expect(saved?.vaults?.teamnotes?.origin?.[0]).toEqual({ remote: 'agentage', interval: 0 });
+      w.stop();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('runs the polling fallback on its interval when no directory is watchable', async () => {
+    vi.useFakeTimers();
+    const scan = vi.fn((): DiscoverCandidate[] => []);
+    const w = createDiscoverWatcher({
+      getConfig: () => ({ version: 1, discover: [{ path: '/root' }], vaults: {} }),
+      scan,
+      isDirectory: () => false, // nothing to fs.watch -> only the poll fallback drives scans
+      watch: () => ({ close: () => {} }),
+      pollMs: 1000,
+    });
+    w.reschedule();
+    expect(scan).toHaveBeenCalledTimes(1); // the initial scan
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(scan).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(scan).toHaveBeenCalledTimes(3);
+    w.stop();
+    vi.useRealTimers();
+  });
+
+  it('reports the configured discover roots in status', () => {
+    const w = createDiscoverWatcher({
+      getConfig: () => ({ version: 1, discover: [{ path: '/a' }, { path: '/b' }], vaults: {} }),
+      watch: () => ({ close: () => {} }),
+      pollMs: HUGE,
+    });
+    expect(w.status().roots).toEqual(['/a', '/b']);
+    w.stop();
+  });
+});

--- a/src/sync/discover/watcher.test.ts
+++ b/src/sync/discover/watcher.test.ts
@@ -68,7 +68,7 @@ describe('discover watcher', () => {
     w.stop();
   });
 
-  it('writes discovered candidates onto the freshly re-read config (concurrent-write safe)', async () => {
+  it('writes discovered candidates onto the freshly re-read config (re-load-check-save)', async () => {
     const snapshot: VaultsConfig = { version: 1, discover: [{ path: '/root' }], vaults: {} };
     // Disk gained an unrelated vault between the scan and the save (an external writer).
     const disk: VaultsConfig = {
@@ -176,6 +176,35 @@ describe('discover watcher', () => {
     await vi.advanceTimersByTimeAsync(1000);
     expect(scan).toHaveBeenCalledTimes(2);
     await vi.advanceTimersByTimeAsync(1000);
+    expect(scan).toHaveBeenCalledTimes(3);
+    w.stop();
+    vi.useRealTimers();
+  });
+
+  it('floors a 0 poll interval and a 0 debounce so neither can busy-loop', async () => {
+    vi.useFakeTimers();
+    const scan = vi.fn((): DiscoverCandidate[] => []);
+    let fire = (): void => {};
+    const w = createDiscoverWatcher({
+      getConfig: () => ({ version: 1, discover: [{ path: '/root' }], vaults: {} }),
+      scan,
+      isDirectory: () => true,
+      watch: (_dir, onChange) => {
+        fire = onChange;
+        return { close: () => {} };
+      },
+      debounceMs: 0,
+      pollMs: 0,
+    });
+    w.reschedule(); // the initial scan
+    fire();
+    await vi.advanceTimersByTimeAsync(49);
+    expect(scan).toHaveBeenCalledTimes(1); // debounce floored to 50ms, not 0
+    await vi.advanceTimersByTimeAsync(1);
+    expect(scan).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(949);
+    expect(scan).toHaveBeenCalledTimes(2); // poll floored to 1000ms, not a ~1ms busy-loop
+    await vi.advanceTimersByTimeAsync(1);
     expect(scan).toHaveBeenCalledTimes(3);
     w.stop();
     vi.useRealTimers();

--- a/src/sync/discover/watcher.ts
+++ b/src/sync/discover/watcher.ts
@@ -1,0 +1,199 @@
+import { statSync, watch as fsWatch } from 'node:fs';
+import {
+  expandPath,
+  scanDiscoverRoots,
+  type DiscoverCandidate,
+  type VaultsConfig,
+} from '@agentage/memory-core';
+import { defaultProvisionDeps, provisionAccountVault } from '../../lib/provision.js';
+import { addVault } from '../../lib/vault-registry.js';
+import { loadVaultsConfig, saveVaultsConfig } from '../../lib/vaults.js';
+
+// The daemon-side live-autodiscovery loop (M5): fs.watch each `discover` root plus a slow polling
+// fallback for watch-unreliable filesystems, register any new subfolder as an account vault, and
+// let the existing vaults.json-change reactions bring the engine + sync loops up without a restart.
+
+export interface DiscoverStatus {
+  // The configured discover roots, expanded to absolute paths, so the feature is observable.
+  roots: string[];
+}
+
+interface Watcher {
+  close(): void;
+}
+
+export interface DiscoverWatcherDeps {
+  getConfig?: () => VaultsConfig;
+  loadConfig?: () => VaultsConfig; // re-read at save time for concurrent-write safety
+  saveConfig?: (config: VaultsConfig) => void;
+  scan?: (config: VaultsConfig) => DiscoverCandidate[];
+  provision?: (name: string) => Promise<unknown>;
+  isDirectory?: (path: string) => boolean;
+  watch?: (dir: string, onChange: () => void) => Watcher;
+  debounceMs?: number;
+  pollMs?: number;
+  log?: (msg: string) => void;
+}
+
+export interface DiscoverWatcher {
+  reschedule(): void;
+  scanNow(): Promise<DiscoverCandidate[]>;
+  status(): DiscoverStatus;
+  stop(): void;
+}
+
+const msgOf = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+const isDir = (path: string): boolean => {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+};
+
+const defaultWatch = (dir: string, onChange: () => void): Watcher => {
+  const w = fsWatch(dir, { persistent: false }, () => onChange());
+  w.on('error', () => {}); // an unreliable fs: the poll fallback still covers the root
+  return w;
+};
+
+export const createDiscoverWatcher = (deps: DiscoverWatcherDeps = {}): DiscoverWatcher => {
+  const getConfig = deps.getConfig ?? (() => loadVaultsConfig().config);
+  const loadConfig = deps.loadConfig ?? (() => loadVaultsConfig().config);
+  const saveConfig = deps.saveConfig ?? saveVaultsConfig;
+  const scan = deps.scan ?? scanDiscoverRoots;
+  const provision =
+    deps.provision ?? ((name: string) => provisionAccountVault(name, defaultProvisionDeps()));
+  const isDirectory = deps.isDirectory ?? isDir;
+  const watch = deps.watch ?? defaultWatch;
+  const debounceMs = deps.debounceMs ?? 500;
+  const pollMs = deps.pollMs ?? 60_000;
+  const log = deps.log ?? (() => {});
+
+  const watchers: Watcher[] = [];
+  let debounceTimer: NodeJS.Timeout | undefined;
+  let pollTimer: NodeJS.Timeout | undefined;
+  let scanning = false;
+  let queued = false;
+
+  const roots = (config: VaultsConfig): string[] =>
+    (config.discover ?? []).map((r) => expandPath(r.path));
+
+  const runScan = async (): Promise<DiscoverCandidate[]> => {
+    let candidates: DiscoverCandidate[];
+    try {
+      candidates = scan(getConfig());
+    } catch (err) {
+      log(`scan failed: ${msgOf(err)}`);
+      return [];
+    }
+    if (candidates.length === 0) return [];
+    // Concurrent-write safety: re-read the on-disk config right before the save and re-check each
+    // candidate against it, so a registration by another writer (or the daemon) is never clobbered.
+    let fresh: VaultsConfig;
+    try {
+      fresh = loadConfig();
+    } catch (err) {
+      log(`reload failed: ${msgOf(err)}`);
+      return [];
+    }
+    let next = fresh;
+    const added: DiscoverCandidate[] = [];
+    for (const c of candidates) {
+      if (fresh.vaults?.[c.name]) continue; // registered by a concurrent writer
+      if (!c.entry.path || !isDirectory(c.entry.path)) continue; // vanished before we wrote it
+      try {
+        next = addVault(next, c.name, c.entry);
+        added.push(c);
+      } catch (err) {
+        log(`register '${c.name}' failed: ${msgOf(err)}`);
+      }
+    }
+    if (added.length === 0) return [];
+    try {
+      saveConfig(next);
+    } catch (err) {
+      log(`save failed: ${msgOf(err)}`);
+      return [];
+    }
+    for (const c of added) {
+      log(`discovered account vault '${c.name}' -> ${c.entry.path}`);
+      void provision(c.name).catch(() => {}); // never fatal: the couch loop re-provisions
+    }
+    return added;
+  };
+
+  // Serialise scans against themselves; a change during an in-flight scan queues one more pass.
+  const scanNow = async (): Promise<DiscoverCandidate[]> => {
+    if (scanning) {
+      queued = true;
+      return [];
+    }
+    scanning = true;
+    try {
+      return await runScan();
+    } finally {
+      scanning = false;
+      if (queued) {
+        queued = false;
+        void scanNow();
+      }
+    }
+  };
+
+  const debounced = (): void => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = undefined;
+      void scanNow();
+    }, debounceMs);
+    debounceTimer.unref?.();
+  };
+
+  const closeWatchers = (): void => {
+    for (const w of watchers.splice(0)) {
+      try {
+        w.close();
+      } catch {
+        // already closed
+      }
+    }
+  };
+
+  const reschedule = (): void => {
+    closeWatchers();
+    const config = getConfig();
+    for (const dir of roots(config).filter(isDirectory)) {
+      try {
+        watchers.push(watch(dir, debounced));
+      } catch (err) {
+        log(`watch ${dir} failed: ${msgOf(err)}`);
+      }
+    }
+    // The poll fallback runs while any root is configured (even one not yet a directory), so a root
+    // created after boot is still picked up where fs.watch is unreliable.
+    if (roots(config).length > 0 && !pollTimer) {
+      pollTimer = setInterval(() => void scanNow(), pollMs);
+      pollTimer.unref?.();
+    } else if (roots(config).length === 0 && pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = undefined;
+    }
+    void scanNow(); // initial scan on boot, and a re-scan whenever the config changes
+  };
+
+  const stop = (): void => {
+    closeWatchers();
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+      debounceTimer = undefined;
+    }
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = undefined;
+    }
+  };
+
+  return { reschedule, scanNow, status: () => ({ roots: roots(getConfig()) }), stop };
+};

--- a/src/sync/discover/watcher.ts
+++ b/src/sync/discover/watcher.ts
@@ -24,7 +24,7 @@ interface Watcher {
 
 export interface DiscoverWatcherDeps {
   getConfig?: () => VaultsConfig;
-  loadConfig?: () => VaultsConfig; // re-read at save time for concurrent-write safety
+  loadConfig?: () => VaultsConfig; // re-read at save time (re-load-check-save)
   saveConfig?: (config: VaultsConfig) => void;
   scan?: (config: VaultsConfig) => DiscoverCandidate[];
   provision?: (name: string) => Promise<unknown>;
@@ -43,6 +43,10 @@ export interface DiscoverWatcher {
 }
 
 const msgOf = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+// Floors: a 0/near-0 poll interval would busy-loop the daemon; a 0 debounce defeats coalescing.
+const POLL_FLOOR_MS = 1000;
+const DEBOUNCE_FLOOR_MS = 50;
 
 const isDir = (path: string): boolean => {
   try {
@@ -67,8 +71,8 @@ export const createDiscoverWatcher = (deps: DiscoverWatcherDeps = {}): DiscoverW
     deps.provision ?? ((name: string) => provisionAccountVault(name, defaultProvisionDeps()));
   const isDirectory = deps.isDirectory ?? isDir;
   const watch = deps.watch ?? defaultWatch;
-  const debounceMs = deps.debounceMs ?? 500;
-  const pollMs = deps.pollMs ?? 60_000;
+  const debounceMs = Math.max(DEBOUNCE_FLOOR_MS, deps.debounceMs ?? 500);
+  const pollMs = Math.max(POLL_FLOOR_MS, deps.pollMs ?? 60_000);
   const log = deps.log ?? (() => {});
 
   const watchers: Watcher[] = [];
@@ -89,8 +93,9 @@ export const createDiscoverWatcher = (deps: DiscoverWatcherDeps = {}): DiscoverW
       return [];
     }
     if (candidates.length === 0) return [];
-    // Concurrent-write safety: re-read the on-disk config right before the save and re-check each
-    // candidate against it, so a registration by another writer (or the daemon) is never clobbered.
+    // Re-load-check-save: re-read the on-disk config right before the save so a recent edit by
+    // another writer is folded in. In-process safe + atomic rename; a lockless cross-process RMW
+    // can still lose an update (follow-up: cross-process config locking).
     let fresh: VaultsConfig;
     try {
       fresh = loadConfig();

--- a/src/sync/manager.ts
+++ b/src/sync/manager.ts
@@ -1,6 +1,7 @@
 import { type VaultsConfig } from '@agentage/memory-core';
 import { loadVaultsConfig } from '../lib/vaults.js';
 import { type CouchTargetStatus } from './couch/manager.js';
+import { type DiscoverStatus } from './discover/watcher.js';
 import { runSyncCycle, type SyncResult } from './cycle.js';
 import { autoSyncTargets, intervalMs, syncTargets, type SyncTarget } from './planner.js';
 
@@ -18,6 +19,8 @@ export interface SyncStatus {
   vaults: VaultSyncState[];
   // The account (couch) targets, composed in by the daemon; absent on an older daemon.
   couch?: CouchTargetStatus[];
+  // The active discover roots, composed in by the daemon; absent on an older daemon.
+  discover?: DiscoverStatus;
 }
 
 export interface SyncManagerDeps {


### PR DESCRIPTION
## M5 final piece: live autodiscovery of `discover[]` roots

A folder dropped into a configured `discover` root is registered, provisioned, and syncing **without a daemon restart**.

### What lands
- **Discovery watcher** (`src/sync/discover/watcher.ts`): on daemon start and on every `vaults.json` change, scans each `discover` root (`scanDiscoverRoots` from memory-core), `fs.watch`es each root with a ~500ms debounce plus a 60s polling fallback for watch-unreliable filesystems (env knobs `AGENTAGE_DISCOVER_DEBOUNCE_MS` / `_POLL_MS`, floored at 50ms/1000ms so neither can busy-loop). New candidates are written into `vaults.json` via the normal atomic registry save and provisioned (`provision.ts`, never fatal). The existing `vaults.json`-change reactions (`client-provider` mtime rebuild + git/couch `reschedule`) bring the engine and sync loops up with no restart.
  - **Re-load-check-save:** the config is re-read from disk right before the save and every candidate re-checked against it, so a recent registration by another writer is folded in rather than clobbered. This is in-process safe + atomic rename; a lockless cross-process read-modify-write can still lose an update - tracked as a follow-up (cross-process config locking).
  - **Vanished-dir guard:** never registers a folder that appeared then disappeared before the write.
  - One log line per discovered vault. Scans serialise against themselves; a change mid-scan queues one more pass.
- **Remove-appends-ignore (V8)** (`vault remove <name>`): when the removed entry sits directly under a discover root, the name is appended to that root's `ignore` **in the same atomic save**, so the next scan does not re-add it. Prints `Added '<name>' to <root> ignore ...`.
- **Observability:** `/api/sync/status` now carries `discover.roots` (count + paths); `daemon status` prints a `discover roots (N)` section.
- **Config fixes:** `saveVaultsConfig` now preserves the `discover` field (previously dropped on every save), and both `saveVaultsConfig` and `saveAuth` write a **per-save unique tmp name** (`<file>.<pid>.<rand>.tmp`) before the atomic rename - a fixed `.tmp` let two concurrent savers clobber each other's tmp (rename-ENOENT throws + transient invalid-JSON reads under contention).

### Tests
- **Unit** (`watcher.test.ts`, `vault-registry.test.ts`, `vault.test.ts`, `vaults.test.ts`, `config.test.ts`): debounce coalescing, rescan-on-config-change, re-load-check-save preserving an external edit, concurrent-registration skip, vanished-dir guard, `autosync:false` -> interval-0 entries, poll fallback, poll/debounce floor clamps, status roots; remove-appends-ignore (root match + non-discover untouched); discover save round-trip; rapid successive saves never throw, leave no tmp files, survivor valid JSON (unique tmp names make cross-process tmp clobbering structurally impossible).
- **Hermetic E2E** (`@couch` tier, docker-gated): drops `<root>/teamnotes/note.md` into a watched root -> without restart the entry appears in `vaults.json` (account shape), the provision stub is hit for `teamnotes`, `/api/sync/status` lists it, and after `vault sync` the note lands in couch as `f:note.md`; then `vault remove teamnotes` appends the ignore and re-touching the folder does **not** re-add it; an invalid-name dir (`bad name!`) is never registered.

### Hygiene
Zero new deps, strict TS ESM, public-repo-safe. `npm run verify` green (318 unit tests); `@couch` tier + full offline e2e set green locally.
