### PR TITLE
test(e2e): retry the couch admin cold-start 401 in the harness

### DIFF
--- a/e2e/couch-sync.test.ts
+++ b/e2e/couch-sync.test.ts
@@ -112,10 +112,15 @@ const startCouch = async (): Promise<Couch> => {
     const adminAuth = 'Basic ' + Buffer.from(`${ADMIN_USER}:${ADMIN_PASS}`).toString('base64');
     await waitUp(url);
     for (const db of ['_users', '_replicator']) {
-      const res = await fetch(`${url}/${db}`, {
+      // /_up can 200 before the env-provided admin is active - retry the cold-start 401 window
+      let res = await fetch(`${url}/${db}`, {
         method: 'PUT',
         headers: { Authorization: adminAuth },
       });
+      for (let attempt = 0; res.status === 401 && attempt < 40; attempt++) {
+        await new Promise((r) => setTimeout(r, 250));
+        res = await fetch(`${url}/${db}`, { method: 'PUT', headers: { Authorization: adminAuth } });
+      }
       if (!res.ok && res.status !== 412) throw new Error(`system db ${db} failed (${res.status})`);
     }
     const jwtSecret = `m5-secret-${randomUUID()}`;


### PR DESCRIPTION
## What
The @couch harness treated any `/_up` 200 as ready, but couchdb:3.4 activates the env-provided admin slightly later - a cold-start window where the `_users`/`_replicator` PUT gets 401. Measured at ~20% under 5 consecutive cold runs (stability audit); one CI-poisoning flake class.

Fix: bounded retry (40 x 250ms) of the system-db PUT only while it returns 401.

## Verify
- @couch tier 3x locally post-fix: 7/7 each (~19s)
- npm run verify green (318 unit tests)

Side note: this CI run doubles as the first post-web#408/#409 run of the @full cloud tier - the dev bridge race is fixed and deployed, so the roundtrip legs should now assert instead of skipping.
