### PR TITLE
test(e2e): scope the cloud search assertion with @vault folder

### DIFF
--- a/e2e/couch-cloud.test.ts
+++ b/e2e/couch-cloud.test.ts
@@ -256,8 +256,12 @@ test.describe('couch <-> cloud MCP roundtrip vs live dev @full', () => {
         'cloud read text channel'
       ).toBe(true);
       expect(JSON.stringify(fwd!.structuredContent)).toContain(FWD_PATH);
+      // Bare cloud search scopes to the default vault by design - use the @-scoped convention.
       const search = asResult(
-        await mcp.callTool({ name: 'memory__search', arguments: { query: fwdMark } })
+        await mcp.callTool({
+          name: 'memory__search',
+          arguments: { query: fwdMark, folder: `@${VAULT}` },
+        })
       );
       expect(
         JSON.stringify(search.structuredContent ?? {}),


### PR DESCRIPTION
web#414 shipped @vault routing to the cloud MCP and the @full tier self-armed - the forward read now surfaces the couch write. The remaining failure was this tier's bare search call: bare cloud search scopes to the default vault by documented design (local fans out - accepted divergence), so the assertion must use the shared convention folder:"@<vault>". With this fix the FULL roundtrip asserts green vs live dev in ~13s (forward + reverse + delete legs). Local run: 1 passed (14.2s).