### PR TITLE
fix(config): advisory lock kills cross-process lost updates (#231)

### DIFF
--- a/e2e/integrity.test.ts
+++ b/e2e/integrity.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawn } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import {
@@ -268,6 +268,30 @@ test.describe('store data integrity @p0', () => {
       expect(existsSync(join(vaultDir, 'notes', 'keep.md'))).toBe(true);
       expect(existsSync(join(vaultDir, '.git'))).toBe(true);
       expect(commitCount(vaultDir)).toBe(commits);
+    } finally {
+      m.cleanup();
+    }
+  });
+
+  // Issue #231: two batches of real `vault add` processes racing one shared vaults.json - the exact
+  // lockless read-modify-write that silently dropped a reported add (2/40 in the prior probe). With
+  // the advisory config lock every entry must survive: valid JSON, all names present, no stale lock.
+  test('30 concurrent vault-add processes on one config all land, none lost', async () => {
+    const m = createCliMachine(OFFLINE);
+    try {
+      const names = [
+        ...Array.from({ length: 20 }, (_, i) => `cli${i}`),
+        ...Array.from({ length: 10 }, (_, i) => `other${i}`), // the competing writer batch
+      ];
+      const results = await Promise.all(
+        names.map((n) => m.exec(['vault', 'add', n, '--local', join(m.configDir, n)]))
+      );
+      results.forEach((r, i) => expect(r.code, `add ${names[i]} failed:\n${r.stderr}`).toBe(0));
+
+      const raw = readFileSync(join(m.configDir, 'vaults.json'), 'utf-8');
+      const parsed = JSON.parse(raw) as { vaults: Record<string, unknown> }; // valid JSON, not torn
+      expect(Object.keys(parsed.vaults).sort()).toEqual([...names].sort());
+      expect(readdirSync(m.configDir).filter((f) => f.endsWith('.lock'))).toEqual([]);
     } finally {
       m.cleanup();
     }

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,7 +1,13 @@
 import chalk from 'chalk';
 import { type Command } from 'commander';
 import { startCallbackServer } from '../lib/callback-server.js';
-import { deleteAuth, ensureConfigDir, readAuth, saveAuth, type AuthState } from '../lib/config.js';
+import {
+  deleteAuth,
+  ensureConfigDir,
+  mutateAuth,
+  readAuth,
+  type AuthState,
+} from '../lib/config.js';
 import {
   buildAuthorizeUrl,
   exchangeCode,
@@ -107,7 +113,7 @@ export const runSetup = async (
       redirectUri: server.redirectUri,
       verifier,
     });
-    saveAuth(toAuthState(fqdn, clientId, tokens));
+    await mutateAuth(() => toAuthState(fqdn, clientId, tokens));
     console.log(chalk.green('\nSigned in.\n'));
     await deps.printStatus();
   } finally {

--- a/src/commands/vault.test.ts
+++ b/src/commands/vault.test.ts
@@ -13,9 +13,11 @@ const makeDeps = (
   const provisioned: string[] = [];
   const deps: VaultDeps = {
     load: () => ({ config, source: null }),
-    save: (c) => {
-      config = c;
-      return '/tmp/vaults.json';
+    // Mirror mutateVaultsConfig: apply fn to the current config, honoring the null no-op skip.
+    mutate: async (fn) => {
+      const next = fn(config);
+      if (next !== null) config = next ?? config;
+      return config;
     },
     ensureDir: (p) => ensured.push(p),
     provision: async (name) => {
@@ -126,7 +128,7 @@ describe('vault remove', () => {
     await runVaultAdd('a', { local: '/tmp/a' }, h.deps);
     await runVaultAdd('b', { local: '/tmp/b' }, h.deps);
     h.logs.length = 0;
-    runVaultRemove('a', h.deps);
+    await runVaultRemove('a', h.deps);
     expect(Object.keys(h.get().vaults ?? {})).toEqual(['b']);
     expect(h.get().default).toBe('b');
     expect(h.logs.join()).toContain("Default vault is now 'b'");
@@ -137,37 +139,37 @@ describe('vault remove', () => {
     await runVaultAdd('acct', {}, h.deps);
     h.logs.length = 0;
     h.provisioned.length = 0;
-    runVaultRemove('acct', h.deps);
+    await runVaultRemove('acct', h.deps);
     expect(h.get().vaults).toEqual({});
     // Remove is purely local: it never re-enters the provisioning path.
     expect(h.provisioned).toEqual([]);
     expect(h.logs.join()).toContain('files left on disk');
   });
 
-  it('throws when the vault is absent', () => {
+  it('throws when the vault is absent', async () => {
     const h = makeDeps();
-    expect(() => runVaultRemove('nope', h.deps)).toThrow(/not found/);
+    await expect(runVaultRemove('nope', h.deps)).rejects.toThrow(/not found/);
   });
 
-  it('appends the name to the discover-root ignore when the path sits under it', () => {
+  it('appends the name to the discover-root ignore when the path sits under it', async () => {
     const h = makeDeps({
       version: 1,
       discover: [{ path: '/data/roots' }],
       vaults: { teamnotes: { path: '/data/roots/teamnotes', origin: [{ remote: 'agentage' }] } },
     });
-    runVaultRemove('teamnotes', h.deps);
+    await runVaultRemove('teamnotes', h.deps);
     expect(h.get().vaults).toEqual({});
     expect(h.get().discover?.[0]?.ignore).toEqual(['teamnotes']);
     expect(h.logs.join()).toContain('/data/roots ignore');
   });
 
-  it('leaves the discover config untouched for a vault outside every root', () => {
+  it('leaves the discover config untouched for a vault outside every root', async () => {
     const h = makeDeps({
       version: 1,
       discover: [{ path: '/data/roots' }],
       vaults: { work: { path: '/elsewhere/work', mcp: ['local'] } },
     });
-    runVaultRemove('work', h.deps);
+    await runVaultRemove('work', h.deps);
     expect(h.get().discover?.[0]?.ignore).toBeUndefined();
     expect(h.logs.join()).not.toContain('ignore');
   });

--- a/src/commands/vault.ts
+++ b/src/commands/vault.ts
@@ -14,12 +14,13 @@ import {
   provisionAccountVault,
   type ProvisionResult,
 } from '../lib/provision.js';
-import { loadVaultsConfig, saveVaultsConfig, type LoadedVaults } from '../lib/vaults.js';
+import { loadVaultsConfig, mutateVaultsConfig, type LoadedVaults } from '../lib/vaults.js';
 import { defaultVaultSyncDeps, runVaultSync } from './vault-sync.js';
 
 export interface VaultDeps {
   load: () => LoadedVaults;
-  save: (config: VaultsConfig) => string;
+  // A cross-process-locked read-modify-write; add/remove run their whole change through this.
+  mutate: (fn: (config: VaultsConfig) => VaultsConfig | null | void) => Promise<VaultsConfig>;
   ensureDir: (path: string) => void;
   provision: (name: string) => Promise<ProvisionResult>;
   log: (msg: string) => void;
@@ -27,7 +28,7 @@ export interface VaultDeps {
 
 const defaultDeps: VaultDeps = {
   load: loadVaultsConfig,
-  save: saveVaultsConfig,
+  mutate: mutateVaultsConfig,
   ensureDir: ensureVaultDir,
   provision: (name) => provisionAccountVault(name, defaultProvisionDeps()),
   log: (msg) => console.log(msg),
@@ -63,9 +64,9 @@ export const runVaultAdd = async (
   deps: VaultDeps = defaultDeps
 ): Promise<void> => {
   const entry = buildEntry(name, opts);
-  const config = addVault(deps.load().config, name, entry);
+  // The dup check + save run together under the lock, against the FRESH on-disk config.
+  await deps.mutate((config) => addVault(config, name, entry));
   if (entry.path) deps.ensureDir(entry.path);
-  deps.save(config);
   const kind = vaultType(entry);
   const where = entry.path ?? entry.origin?.[0]?.remote ?? '';
   const via = kind === 'git' && entry.origin?.length ? ` <- ${entry.origin[0]!.remote}` : '';
@@ -74,17 +75,27 @@ export const runVaultAdd = async (
   if (isAccountVault(entry)) deps.log((await deps.provision(name)).message);
 };
 
-export const runVaultRemove = (name: string, deps: VaultDeps = defaultDeps): void => {
-  const { config } = deps.load();
-  const wasDefault = config.default === name;
-  const path = config.vaults?.[name]?.path;
-  let next = removeVault(config, name);
-  // V8: keep the removal and the ignore in one atomic save, else the next scan re-adds the folder.
-  const ignored = path ? appendDiscoverIgnore(next, name, path) : null;
-  if (ignored) next = ignored.config;
-  deps.save(next);
+export const runVaultRemove = async (
+  name: string,
+  deps: VaultDeps = defaultDeps
+): Promise<void> => {
+  let wasDefault = false;
+  let ignoredRoot: string | null = null;
+  // The removal and the discover-ignore append run as one locked read-modify-write, against the
+  // FRESH on-disk config, else a concurrent writer's update is lost or the next scan re-adds the folder.
+  const next = await deps.mutate((config) => {
+    wasDefault = config.default === name;
+    const path = config.vaults?.[name]?.path;
+    let updated = removeVault(config, name);
+    const ignored = path ? appendDiscoverIgnore(updated, name, path) : null;
+    if (ignored) {
+      updated = ignored.config;
+      ignoredRoot = ignored.root;
+    }
+    return updated;
+  });
   deps.log(`Removed vault '${name}' (files left on disk).`);
-  if (ignored) deps.log(`Added '${name}' to ${ignored.root} ignore so it is not re-discovered.`);
+  if (ignoredRoot) deps.log(`Added '${name}' to ${ignoredRoot} ignore so it is not re-discovered.`);
   if (wasDefault && next.default) deps.log(`Default vault is now '${next.default}'.`);
 };
 
@@ -145,7 +156,7 @@ export const registerVault = (program: Command): void => {
   vault
     .command('remove <name>')
     .description('Unregister a vault (files stay on disk)')
-    .action((name: string) => guard(() => runVaultRemove(name)));
+    .action((name: string) => guardAsync(() => runVaultRemove(name)));
 
   vault
     .command('sync [name]')

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { saveAuth, type AuthState } from './config.js';
+import { mutateAuth, type AuthState, type StoredTokens } from './config.js';
 import { refreshTokens } from './oauth.js';
 import { type Links } from './origins.js';
 
@@ -13,12 +13,19 @@ const tryRefresh = async (auth: AuthState, links: Links): Promise<boolean> => {
   if (!auth.tokens.refreshToken) return false;
   try {
     const fresh = await refreshTokens(links.auth, auth.clientId, auth.tokens.refreshToken);
-    auth.tokens = {
+    const tokens: StoredTokens = {
       accessToken: fresh.access_token,
       refreshToken: fresh.refresh_token ?? auth.tokens.refreshToken,
       expiresAt: fresh.expires_in ? Date.now() + fresh.expires_in * 1000 : undefined,
     };
-    saveAuth(auth);
+    auth.tokens = tokens; // the caller retries its request with this in-memory copy
+    // Persist under the lock, folding the new tokens onto the freshly-read state so a concurrent
+    // writer's other fields (clientId, siteFqdn) are not clobbered by a stale in-memory copy.
+    await mutateAuth((current) => {
+      const base = current ?? auth;
+      base.tokens = tokens;
+      return base;
+    });
     return true;
   } catch {
     return false;

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -6,6 +6,7 @@ import {
   deleteAuth,
   ensureConfigDir,
   getConfigDir,
+  mutateAuth,
   readAuth,
   saveAuth,
   type AuthState,
@@ -66,5 +67,57 @@ describe('config store', () => {
   it('writes auth.json without an existing config dir', () => {
     saveAuth(sample);
     expect(JSON.parse(readFileSync(join(getConfigDir(), 'auth.json'), 'utf-8'))).toEqual(sample);
+  });
+
+  describe('mutateAuth (cross-process locked read-modify-write)', () => {
+    it('writes a brand-new state and returns it', async () => {
+      const next = await mutateAuth(() => sample);
+      expect(next).toEqual(sample);
+      expect(readAuth()).toEqual(sample);
+    });
+
+    it('folds a change onto the freshly-read on-disk state', async () => {
+      saveAuth(sample);
+      await mutateAuth((current) => {
+        current!.tokens.accessToken = 'rotated';
+        return current;
+      });
+      expect(readAuth()?.tokens.accessToken).toBe('rotated');
+      expect(readAuth()?.clientId).toBe('client-1'); // untouched fields preserved
+    });
+
+    it('does not resurrect a signed-out file when fn returns void on a null read', async () => {
+      const result = await mutateAuth((current) => {
+        if (!current) return;
+        current.clientId = 'x';
+        return current;
+      });
+      expect(result).toBeNull();
+      expect(readAuth()).toBeNull();
+    });
+
+    it('folds 20 concurrent token rotations without losing the write', async () => {
+      saveAuth(sample);
+      await Promise.all(
+        Array.from({ length: 20 }, (_, i) =>
+          mutateAuth((current) => {
+            current!.tokens.accessToken = `at-${i}`;
+            return current;
+          })
+        )
+      );
+      expect(readAuth()?.tokens.accessToken).toMatch(/^at-\d+$/); // one clean winner, valid state
+      expect(readdirSync(getConfigDir()).filter((f) => f.endsWith('.lock'))).toEqual([]);
+    });
+
+    it('releases the lock and leaves no lockfile when fn throws', async () => {
+      ensureConfigDir();
+      await expect(
+        mutateAuth(() => {
+          throw new Error('nope');
+        })
+      ).rejects.toThrow('nope');
+      expect(readdirSync(getConfigDir()).filter((f) => f.endsWith('.lock'))).toEqual([]);
+    });
   });
 });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -10,6 +10,7 @@ import {
 } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { withFileLock } from './file-lock.js';
 
 export interface StoredTokens {
   accessToken: string;
@@ -60,4 +61,21 @@ export const saveAuth = (state: AuthState): void => {
 export const deleteAuth = (): void => {
   const path = authPath();
   if (existsSync(path)) unlinkSync(path);
+};
+
+// Cross-process-safe read-modify-write on auth.json (issue #231). Under the advisory lock, re-read
+// FRESH from disk, apply `fn`, then atomic-save - so a foreground sign-in and a background token
+// refresh can never clobber each other. `fn` may return a new state, mutate the fresh one and return
+// void, or leave a null re-read null (a concurrent sign-out is never resurrected). Any network
+// refresh must run BEFORE this call, never under the lock. Returns the state on disk after the call.
+export const mutateAuth = async (
+  fn: (current: AuthState | null) => AuthState | null | void
+): Promise<AuthState | null> => {
+  ensureConfigDir();
+  return withFileLock(authPath(), () => {
+    const current = readAuth();
+    const next = fn(current) ?? current;
+    if (next) saveAuth(next);
+    return next;
+  });
 };

--- a/src/lib/file-lock.test.ts
+++ b/src/lib/file-lock.test.ts
@@ -1,0 +1,143 @@
+import { execFile } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import ts from 'typescript';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { acquireFileLock, releaseFileLock, withFileLock } from './file-lock.js';
+
+describe('file lock', () => {
+  let dir: string;
+  let target: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'agentage-filelock-'));
+    target = join(dir, 'data.json');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const lockFile = (): string => `${target}.lock`;
+
+  it('acquires when no lock is held', () => {
+    expect(acquireFileLock(target)).toBe(true);
+    expect(existsSync(lockFile())).toBe(true);
+    releaseFileLock(target);
+  });
+
+  it('refuses when a fresh lock is already held', () => {
+    const now = 1_000_000;
+    expect(acquireFileLock(target, now)).toBe(true);
+    expect(acquireFileLock(target, now + 5_000)).toBe(false); // 5s later, within the 10s TTL
+    releaseFileLock(target);
+  });
+
+  it('takes over a stale lock (older than the 10s TTL)', () => {
+    const now = 1_000_000;
+    expect(acquireFileLock(target, now)).toBe(true);
+    expect(acquireFileLock(target, now + 11_000)).toBe(true); // 11s later, stale
+    releaseFileLock(target);
+  });
+
+  it('releases idempotently', () => {
+    acquireFileLock(target);
+    releaseFileLock(target);
+    releaseFileLock(target);
+    expect(existsSync(lockFile())).toBe(false);
+  });
+
+  it('runs fn while holding the lock and releases it after', async () => {
+    const result = await withFileLock(target, () => {
+      expect(existsSync(lockFile())).toBe(true);
+      return 42;
+    });
+    expect(result).toBe(42);
+    expect(existsSync(lockFile())).toBe(false);
+  });
+
+  it('releases the lock even when fn throws (finally path)', async () => {
+    await expect(
+      withFileLock(target, () => {
+        throw new Error('boom');
+      })
+    ).rejects.toThrow('boom');
+    expect(existsSync(lockFile())).toBe(false);
+  });
+
+  it('takes over a stale lock left by a crashed holder, never wedging', async () => {
+    writeFileSync(lockFile(), `999 ${Date.now() - 11_000}`); // 11s old = crashed holder
+    const result = await withFileLock(target, () => 'recovered');
+    expect(result).toBe('recovered');
+    expect(existsSync(lockFile())).toBe(false);
+  });
+
+  it('serializes many concurrent in-process read-modify-writes, losing none', async () => {
+    writeFileSync(target, JSON.stringify([]));
+    await Promise.all(
+      Array.from({ length: 30 }, (_, i) =>
+        withFileLock(target, () => {
+          const arr = JSON.parse(readFileSync(target, 'utf-8')) as number[];
+          arr.push(i);
+          writeFileSync(target, JSON.stringify(arr));
+        })
+      )
+    );
+    const arr = JSON.parse(readFileSync(target, 'utf-8')) as number[];
+    expect(arr.sort((a, b) => a - b)).toEqual(Array.from({ length: 30 }, (_, i) => i));
+  });
+
+  // Real OS processes racing the exact read-modify-write shape from issue #231. Each child appends
+  // its id to one shared JSON array through withFileLock; a lockless RMW drops appends whose read
+  // raced another writer's write. The transpiled module has no non-builtin imports.
+  const raceAppends = async (count: number): Promise<string[]> => {
+    const libDir = join(dir, 'lib');
+    mkdirSync(libDir, { recursive: true });
+    const out = ts.transpileModule(
+      readFileSync(join(import.meta.dirname, 'file-lock.ts'), 'utf-8'),
+      {
+        compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+      }
+    ).outputText;
+    writeFileSync(join(libDir, 'file-lock.js'), out, 'utf-8');
+    const mod = pathToFileURL(join(libDir, 'file-lock.js')).href;
+    const script = join(dir, 'race.mjs');
+    writeFileSync(
+      script,
+      `import { existsSync, readFileSync, writeFileSync } from 'node:fs';\n` +
+        `import { withFileLock } from '${mod}';\n` +
+        `const [, , target, id] = process.argv;\n` +
+        `await withFileLock(target, () => {\n` +
+        `  const arr = existsSync(target) ? JSON.parse(readFileSync(target, 'utf-8')) : [];\n` +
+        `  const until = Date.now() + 3;\n` + // widen the read->write gap a lockless RMW would lose
+        `  while (Date.now() < until) {}\n` +
+        `  arr.push(Number(id));\n` +
+        `  writeFileSync(target, JSON.stringify(arr));\n` +
+        `});\n` +
+        `process.stdout.write('ok');\n`,
+      'utf-8'
+    );
+    return Promise.all(
+      Array.from(
+        { length: count },
+        (_, i) =>
+          new Promise<string>((resolve) => {
+            execFile(process.execPath, [script, target, String(i)], {}, (_e, stdout) =>
+              resolve(stdout)
+            );
+          })
+      )
+    );
+  };
+
+  it('20 concurrent processes each land their append, zero lost, no leftover lock', async () => {
+    writeFileSync(target, JSON.stringify([]));
+    const runs = await raceAppends(20);
+    expect(runs.filter((r) => r === 'ok')).toHaveLength(20);
+    const arr = JSON.parse(readFileSync(target, 'utf-8')) as number[];
+    expect(arr.sort((a, b) => a - b)).toEqual(Array.from({ length: 20 }, (_, i) => i));
+    expect(existsSync(lockFile())).toBe(false);
+  }, 30_000);
+});

--- a/src/lib/file-lock.ts
+++ b/src/lib/file-lock.ts
@@ -1,0 +1,100 @@
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+// A cross-process advisory lock keyed to a target file (`<target>.lock`). Config read-modify-writes
+// are sub-millisecond, so a lock older than this is a crashed holder to be taken over.
+const LOCK_TTL_MS = 10_000;
+// A caller blocks up to this long for a contended lock. Past the TTL so a crashed holder is taken
+// over rather than wedging the caller; a throw only happens if the lock is genuinely stuck.
+const MAX_WAIT_MS = 15_000;
+const STEP_MS = 25;
+
+const lockPath = (target: string): string => `${target}.lock`;
+
+// The lock file holds "<pid> <timestamp>"; the trailing token is the acquisition time used for
+// staleness. pid is there for debuggability only.
+const heldAt = (path: string): number | null => {
+  try {
+    const parts = readFileSync(path, 'utf-8').trim().split(/\s+/);
+    const n = Number.parseInt(parts[parts.length - 1] ?? '', 10);
+    return Number.isNaN(n) ? null : n;
+  } catch {
+    return null;
+  }
+};
+
+const unlinkQuiet = (path: string): void => {
+  try {
+    unlinkSync(path);
+  } catch {
+    // already gone
+  }
+};
+
+// Serialize stale-lock takeover behind its own exclusive create so no taker can delete a lock that
+// turned FRESH mid-takeover (the ABA race: a reader sees the stale timestamp, a winner re-creates
+// the lock, the reader deletes the winner's file). Same O_EXCL-guard design proven in
+// update-lock.ts. Returns whether to re-race the create.
+const takeOverStale = (target: string, now: number): boolean => {
+  const path = lockPath(target);
+  const guard = `${path}.takeover`;
+  const guardHeld = heldAt(guard);
+  if (guardHeld !== null && now - guardHeld >= LOCK_TTL_MS) unlinkQuiet(guard);
+  try {
+    writeFileSync(guard, `${process.pid} ${now}`, { flag: 'wx' });
+  } catch {
+    return false; // another taker is mid-takeover; let it win
+  }
+  try {
+    const held = heldAt(path);
+    if (held !== null && now - held < LOCK_TTL_MS) return false; // became fresh meanwhile
+    unlinkQuiet(path);
+    return true;
+  } finally {
+    unlinkQuiet(guard);
+  }
+};
+
+// One-shot acquire: the O_EXCL ('wx') create IS the mutex - concurrent callers cannot both win it,
+// unlike a check-then-write. A fresh holder refuses; a stale one (crashed holder) is cleared under
+// the takeover guard and re-raced once. `now` is injectable for tests.
+export const acquireFileLock = (target: string, now: number = Date.now()): boolean => {
+  mkdirSync(dirname(target), { recursive: true });
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      writeFileSync(lockPath(target), `${process.pid} ${now}`, { flag: 'wx' });
+      return true;
+    } catch {
+      const held = heldAt(lockPath(target));
+      if (held !== null && now - held < LOCK_TTL_MS) return false;
+      if (!takeOverStale(target, now)) return false;
+    }
+  }
+  return false;
+};
+
+export const releaseFileLock = (target: string): void => unlinkQuiet(lockPath(target));
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+// Run `fn` while holding the advisory lock for `target`, blocking with bounded backoff until the
+// lock is free (or a crashed holder is taken over past the TTL). `fn` MUST be synchronous: the lock
+// is held only across one synchronous critical section, so in-process callers can never both be
+// inside it. The whole read-modify-write belongs in `fn` - locking only the write still loses
+// updates across the read->write gap. Released in a finally, so a throw never wedges the lock.
+export const withFileLock = async <T>(target: string, fn: () => T): Promise<T> => {
+  const deadline = Date.now() + MAX_WAIT_MS;
+  for (;;) {
+    if (acquireFileLock(target)) {
+      try {
+        return fn();
+      } finally {
+        releaseFileLock(target);
+      }
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`could not acquire lock for ${target} within ${MAX_WAIT_MS}ms`);
+    }
+    await sleep(STEP_MS + Math.floor(Math.random() * STEP_MS));
+  }
+};

--- a/src/lib/update-lock.test.ts
+++ b/src/lib/update-lock.test.ts
@@ -52,7 +52,7 @@ describe('update lock', () => {
   const raceProcesses = async (count: number, now: number): Promise<string[]> => {
     const libDir = join(dir, 'lib');
     mkdirSync(libDir, { recursive: true });
-    for (const src of ['config.ts', 'update-lock.ts']) {
+    for (const src of ['config.ts', 'file-lock.ts', 'update-lock.ts']) {
       const out = ts.transpileModule(readFileSync(join(import.meta.dirname, src), 'utf-8'), {
         compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
       }).outputText;

--- a/src/lib/vaults.test.ts
+++ b/src/lib/vaults.test.ts
@@ -3,10 +3,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { VaultsConfig } from '@agentage/memory-core';
+import { addVault } from './vault-registry.js';
 import { ensureConfigDir, getConfigDir } from './config.js';
 import {
   ensureVaultsConfig,
   loadVaultsConfig,
+  mutateVaultsConfig,
   saveVaultsConfig,
   vaultsJsonPath,
 } from './vaults.js';
@@ -110,5 +112,64 @@ describe('vaults config store', () => {
     write(vaultsJsonPath(), original);
     ensureVaultsConfig();
     expect(readFileSync(vaultsJsonPath(), 'utf-8')).toBe(original);
+  });
+});
+
+describe('mutateVaultsConfig (cross-process locked read-modify-write)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'agentage-mutate-'));
+    process.env['AGENTAGE_CONFIG_DIR'] = join(dir, 'cfg');
+  });
+
+  afterEach(() => {
+    delete process.env['AGENTAGE_CONFIG_DIR'];
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('applies the mutation and returns the saved config', async () => {
+    const next = await mutateVaultsConfig((cfg) => addVault(cfg, 'work', { path: '~/w' }));
+    expect(next.vaults?.work).toMatchObject({ path: '~/w' });
+    expect(loadVaultsConfig().config.vaults?.work).toMatchObject({ path: '~/w' });
+  });
+
+  it('leaves the file untouched when fn returns null (no-op skip)', async () => {
+    saveVaultsConfig({ version: 1, vaults: { a: { path: '/a' } } });
+    const before = readFileSync(vaultsJsonPath(), 'utf-8');
+    const result = await mutateVaultsConfig(() => null);
+    expect(result.vaults?.a).toMatchObject({ path: '/a' });
+    expect(readFileSync(vaultsJsonPath(), 'utf-8')).toBe(before);
+  });
+
+  it('releases the lock and leaves no lockfile when fn throws', async () => {
+    await expect(
+      mutateVaultsConfig(() => {
+        throw new Error('nope');
+      })
+    ).rejects.toThrow('nope');
+    expect(readdirSync(getConfigDir()).filter((f) => f.endsWith('.lock'))).toEqual([]);
+  });
+
+  it('folds 20 concurrent in-process mutations together, losing none', async () => {
+    await Promise.all(
+      Array.from({ length: 20 }, (_, i) =>
+        mutateVaultsConfig((cfg) => addVault(cfg, `v${i}`, { path: `/tmp/v${i}` }))
+      )
+    );
+    const names = Object.keys(loadVaultsConfig().config.vaults ?? {}).sort();
+    expect(names).toEqual(Array.from({ length: 20 }, (_, i) => `v${i}`).sort());
+    expect(readdirSync(getConfigDir()).filter((f) => f.endsWith('.lock'))).toEqual([]);
+  });
+
+  it('re-reads FRESH under the lock: a mutation sees a write that landed after its own load', async () => {
+    // Both mutators start from the same empty outer view; the second to run must still see the
+    // first's write (fresh re-read), else its save would clobber it and one vault would be lost.
+    await Promise.all([
+      mutateVaultsConfig((cfg) => addVault(cfg, 'first', { path: '/first' })),
+      mutateVaultsConfig((cfg) => addVault(cfg, 'second', { path: '/second' })),
+    ]);
+    const names = Object.keys(loadVaultsConfig().config.vaults ?? {}).sort();
+    expect(names).toEqual(['first', 'second']);
   });
 });

--- a/src/lib/vaults.ts
+++ b/src/lib/vaults.ts
@@ -3,6 +3,7 @@ import { chmodSync, existsSync, readFileSync, renameSync, writeFileSync } from '
 import { join } from 'node:path';
 import { validateConfig, type VaultsConfig } from '@agentage/memory-core';
 import { ensureConfigDir, getConfigDir } from './config.js';
+import { withFileLock } from './file-lock.js';
 import { VAULTS_SCHEMA_URL } from './vaults.schema.js';
 
 export const vaultsJsonPath = (): string => join(getConfigDir(), 'vaults.json');
@@ -48,4 +49,24 @@ export const saveVaultsConfig = (config: VaultsConfig): string => {
   renameSync(tmp, path);
   chmodSync(path, 0o600);
   return path;
+};
+
+// Cross-process-safe read-modify-write on vaults.json (issue #231). Under the advisory lock, re-read
+// FRESH from disk, apply `fn`, then atomic-save - so a concurrent `vault add` or the daemon's
+// discovery write-back can never clobber each other's update. `fn` may return a new config, mutate
+// the fresh one in place and return void, or return null to skip the write entirely (a no-op scan
+// must not re-touch the file, else the daemon's config watcher would loop). Returns the config on
+// disk after the call. A plain read stays lock-free via loadVaultsConfig.
+export const mutateVaultsConfig = async (
+  fn: (config: VaultsConfig) => VaultsConfig | null | void
+): Promise<VaultsConfig> => {
+  ensureConfigDir();
+  return withFileLock(vaultsJsonPath(), () => {
+    const fresh = loadVaultsConfig().config;
+    const next = fn(fresh);
+    if (next === null) return fresh; // explicit no-op: leave the file untouched
+    const result = next ?? fresh;
+    saveVaultsConfig(result);
+    return result;
+  });
 };

--- a/src/sync/discover/watcher.test.ts
+++ b/src/sync/discover/watcher.test.ts
@@ -12,6 +12,18 @@ const candidate = (name: string): DiscoverCandidate => ({
   entry: { path: `/root/${name}`, origin: [{ remote: 'agentage' }], mcp: ['local'] },
 });
 
+// Mirror mutateVaultsConfig: re-read fresh, apply fn, honor the null no-op skip, save otherwise.
+const fakeMutate =
+  (read: () => VaultsConfig, onSave: (c: VaultsConfig) => void) =>
+  async (fn: (c: VaultsConfig) => VaultsConfig | null | void): Promise<VaultsConfig> => {
+    const fresh = read();
+    const next = fn(fresh);
+    if (next === null) return fresh;
+    const result = next ?? fresh;
+    onSave(result);
+    return result;
+  };
+
 describe('discover watcher', () => {
   it('coalesces rapid change events into a single debounced rescan', async () => {
     vi.useFakeTimers();
@@ -80,8 +92,10 @@ describe('discover watcher', () => {
     const provisioned: string[] = [];
     const w = createDiscoverWatcher({
       getConfig: () => snapshot,
-      loadConfig: () => disk,
-      saveConfig: (c) => void (saved = c),
+      mutate: fakeMutate(
+        () => disk,
+        (c) => void (saved = c)
+      ),
       scan: () => [candidate('teamnotes')],
       isDirectory: () => true,
       provision: async (n) => void provisioned.push(n),
@@ -100,12 +114,14 @@ describe('discover watcher', () => {
     let saved: VaultsConfig | undefined;
     const w = createDiscoverWatcher({
       getConfig: () => ({ version: 1, discover: [{ path: '/root' }], vaults: {} }),
-      loadConfig: () => ({
-        version: 1,
-        discover: [{ path: '/root' }],
-        vaults: { teamnotes: { path: '/root/teamnotes', mcp: ['local'] } },
-      }),
-      saveConfig: (c) => void (saved = c),
+      mutate: fakeMutate(
+        () => ({
+          version: 1,
+          discover: [{ path: '/root' }],
+          vaults: { teamnotes: { path: '/root/teamnotes', mcp: ['local'] } },
+        }),
+        (c) => void (saved = c)
+      ),
       scan: () => [candidate('teamnotes')],
       isDirectory: () => true,
       watch: () => ({ close: () => {} }),
@@ -121,8 +137,10 @@ describe('discover watcher', () => {
     const cfg: VaultsConfig = { version: 1, discover: [{ path: '/root' }], vaults: {} };
     const w = createDiscoverWatcher({
       getConfig: () => cfg,
-      loadConfig: () => cfg,
-      saveConfig: (c) => void (saved = c),
+      mutate: fakeMutate(
+        () => cfg,
+        (c) => void (saved = c)
+      ),
       scan: () => [candidate('gone')],
       isDirectory: (p) => p !== '/root/gone', // the candidate dir is no longer a directory
       watch: () => ({ close: () => {} }),
@@ -146,8 +164,10 @@ describe('discover watcher', () => {
       // Real scanDiscoverRoots + real isDirectory here: this exercises the autosync=false path.
       const w = createDiscoverWatcher({
         getConfig: () => cfg,
-        loadConfig: () => cfg,
-        saveConfig: (c) => void (saved = c),
+        mutate: fakeMutate(
+          () => cfg,
+          (c) => void (saved = c)
+        ),
         provision: async () => {},
         watch: () => ({ close: () => {} }),
         pollMs: HUGE,

--- a/src/sync/discover/watcher.ts
+++ b/src/sync/discover/watcher.ts
@@ -7,7 +7,7 @@ import {
 } from '@agentage/memory-core';
 import { defaultProvisionDeps, provisionAccountVault } from '../../lib/provision.js';
 import { addVault } from '../../lib/vault-registry.js';
-import { loadVaultsConfig, saveVaultsConfig } from '../../lib/vaults.js';
+import { loadVaultsConfig, mutateVaultsConfig } from '../../lib/vaults.js';
 
 // The daemon-side live-autodiscovery loop (M5): fs.watch each `discover` root plus a slow polling
 // fallback for watch-unreliable filesystems, register any new subfolder as an account vault, and
@@ -24,8 +24,8 @@ interface Watcher {
 
 export interface DiscoverWatcherDeps {
   getConfig?: () => VaultsConfig;
-  loadConfig?: () => VaultsConfig; // re-read at save time (re-load-check-save)
-  saveConfig?: (config: VaultsConfig) => void;
+  // The cross-process-locked read-modify-write: re-reads fresh, folds new candidates in, saves.
+  mutate?: (fn: (config: VaultsConfig) => VaultsConfig | null | void) => Promise<VaultsConfig>;
   scan?: (config: VaultsConfig) => DiscoverCandidate[];
   provision?: (name: string) => Promise<unknown>;
   isDirectory?: (path: string) => boolean;
@@ -64,8 +64,7 @@ const defaultWatch = (dir: string, onChange: () => void): Watcher => {
 
 export const createDiscoverWatcher = (deps: DiscoverWatcherDeps = {}): DiscoverWatcher => {
   const getConfig = deps.getConfig ?? (() => loadVaultsConfig().config);
-  const loadConfig = deps.loadConfig ?? (() => loadVaultsConfig().config);
-  const saveConfig = deps.saveConfig ?? saveVaultsConfig;
+  const mutate = deps.mutate ?? mutateVaultsConfig;
   const scan = deps.scan ?? scanDiscoverRoots;
   const provision =
     deps.provision ?? ((name: string) => provisionAccountVault(name, defaultProvisionDeps()));
@@ -93,35 +92,32 @@ export const createDiscoverWatcher = (deps: DiscoverWatcherDeps = {}): DiscoverW
       return [];
     }
     if (candidates.length === 0) return [];
-    // Re-load-check-save: re-read the on-disk config right before the save so a recent edit by
-    // another writer is folded in. In-process safe + atomic rename; a lockless cross-process RMW
-    // can still lose an update (follow-up: cross-process config locking).
-    let fresh: VaultsConfig;
+    // Fold the candidates onto the FRESH on-disk config inside the cross-process lock (issue #231):
+    // re-read, register any still-absent-and-present folder, save - so a concurrent `vault add` (or
+    // a second daemon) is never clobbered. Return null when nothing changed so the file is left
+    // untouched (a redundant write would loop the daemon's own config watcher).
+    let added: DiscoverCandidate[] = [];
     try {
-      fresh = loadConfig();
-    } catch (err) {
-      log(`reload failed: ${msgOf(err)}`);
-      return [];
-    }
-    let next = fresh;
-    const added: DiscoverCandidate[] = [];
-    for (const c of candidates) {
-      if (fresh.vaults?.[c.name]) continue; // registered by a concurrent writer
-      if (!c.entry.path || !isDirectory(c.entry.path)) continue; // vanished before we wrote it
-      try {
-        next = addVault(next, c.name, c.entry);
-        added.push(c);
-      } catch (err) {
-        log(`register '${c.name}' failed: ${msgOf(err)}`);
-      }
-    }
-    if (added.length === 0) return [];
-    try {
-      saveConfig(next);
+      await mutate((fresh) => {
+        added = [];
+        let next = fresh;
+        for (const c of candidates) {
+          if (next.vaults?.[c.name]) continue; // registered by a concurrent writer
+          if (!c.entry.path || !isDirectory(c.entry.path)) continue; // vanished before we wrote it
+          try {
+            next = addVault(next, c.name, c.entry);
+            added.push(c);
+          } catch (err) {
+            log(`register '${c.name}' failed: ${msgOf(err)}`);
+          }
+        }
+        return added.length > 0 ? next : null;
+      });
     } catch (err) {
       log(`save failed: ${msgOf(err)}`);
       return [];
     }
+    if (added.length === 0) return [];
     for (const c of added) {
       log(`discovered account vault '${c.name}' -> ${c.entry.path}`);
       void provision(c.name).catch(() => {}); // never fatal: the couch loop re-provisions


### PR DESCRIPTION
Fixes #231.

## The bug
Both the daemon (discover watcher write-back) and CLI processes (and the Obsidian plugin) do lockless read-modify-write on `vaults.json` (and `auth.json`). The unique-tmp fix (#229) made each individual save atomic and corruption-free, but last-writer-wins RMW still LOSES updates: a reported `agentage vault add X` was silently absent from the final config after the daemon's concurrent discover-save clobbered it (2/40 in the prior probe).

## The fix - advisory lock around the whole read-modify-write
Chosen over daemon-single-writer because it is self-contained in the config layer, covers every writer, and works with the daemon up OR down.

**`src/lib/file-lock.ts`** - a small advisory-lock primitive:
- `acquireFileLock(target, now?)` creates `<target>.lock` with `writeFileSync({flag:'wx'})` (O_EXCL = the mutex); the exclusive create is what admits exactly one winner, unlike a check-then-write.
- Stale takeover reuses the exact O_EXCL-guard design proven in `update-lock.ts` (adversarially shown to admit exactly one winner under 320 concurrent processes): a lock older than a 10s TTL (config writes are sub-millisecond) is cleared under a serialized `.takeover` guard so the ABA race cannot delete a lock that turned fresh mid-takeover. Deliberately a parallel primitive, not a refactor of the proven `update.lock` (different TTL + wait-vs-skip semantics); pattern-reuse, not code-reuse.
- `withFileLock(target, fn)` blocks with bounded backoff (~25-50ms steps, up to 15s, past the TTL so a crashed holder is taken over rather than wedging the caller), runs a synchronous `fn`, and releases in a `finally`. Lock content is `<pid> <ts>` for staleness + debuggability.

**Mutator helpers** run the ENTIRE read-modify-write under the lock (locking only the write is useless - the lost update happens across the read->save gap):
- `mutateVaultsConfig(fn)` in `lib/vaults.ts` - acquire, re-read FRESH from disk, apply `fn`, atomic-save. `fn` may return a new config, mutate in place (void), or return `null` to skip the write entirely (a no-op scan must not re-touch the file, else the daemon's config watcher would loop).
- `mutateAuth(fn)` in `lib/config.ts` - same, for `auth.json`. Any network token refresh runs BEFORE the lock, never under it.

## Migrated callers (every load-modify-save)
- `vault add` (`runVaultAdd`) and `vault remove` (incl. the discover-ignore append) -> `mutate` dep, defaulting to `mutateVaultsConfig`.
- The daemon autodiscovery write-back (`sync/discover/watcher.ts`) - its re-load-check-save now routes through `mutateVaultsConfig`, sharing the lock with foreground adds.
- `auth.json` writers: `setup` sign-in and the `api.ts` token refresh (the couch/background bearer path flows through the same refresh) -> `mutateAuth`.
- Plain read-only `loadVaultsConfig` / `readAuth` stay lock-free (no perf regression on the common single-process path - acquire is one O_EXCL create).

## Proof the lost update is gone
Measured before/after, 30 real OS processes each appending to one shared JSON file (read->write window widened 3ms to expose the race):

| | lost of 30 (3 trials) |
|---|---|
| lockless RMW (old) | 15, 18, 16 |
| `withFileLock` (fix) | 0, 0, 0 |

Tests:
- **Unit** (`file-lock.test.ts`): acquire/refuse-fresh/stale-takeover/idempotent-release, release-on-throw, stale lock left by a crashed holder is taken over (never wedges), 30 concurrent in-process RMW lose none, and 20 real spawned processes each land their append with no leftover lock.
- **Unit** (`vaults.test.ts` / `config.test.ts`): 20 concurrent `mutateVaultsConfig` / `mutateAuth` calls lose none; the fresh-re-read proof (a mutation sees a write that landed after its own outer load); null no-op skip leaves the file byte-identical; lock released + no `.lock` left on a mutator throw.
- **E2E** (`integrity.test.ts @p0`, the real proof): 30 concurrent `agentage vault add` processes (a 20-name batch + a 10-name competing batch) against one shared config dir - all 30 present, valid JSON, zero leftover `.lock`. This is the exact scenario that dropped 2/40. Passed 3x clean locally.

`npm run verify` green: 337 tests (up from ~318). No new deps (node built-ins only); the `package-guard` runtime-deps check stays green.

## Downstream follow-up (not in this PR)
The Obsidian plugin co-writes `vaults.json` / `auth.json` and is NOT covered until it adopts the same `<target>.lock` O_EXCL convention. That lives in a separate repo and is left as a follow-up; it must adopt this same lock file naming + O_EXCL protocol to fully close the cross-writer race.
