### PR TITLE
chore(deps): memory-core 0.3.2 - commit lock-retry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
-        "@agentage/memory-core": "^0.3.1",
+        "@agentage/memory-core": "^0.3.2",
         "@agentage/server-memory": "^0.0.3",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chalk": "latest",
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@agentage/memory-core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@agentage/memory-core/-/memory-core-0.3.1.tgz",
-      "integrity": "sha512-GBP+DCBLf1E/WTr8lbj3j3lq1aW+gCFIJsaSgJxSH7y8b30wts76UEMHzYskJeeofFRvpwnUEN/9sIEnNWYz5Q==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@agentage/memory-core/-/memory-core-0.3.2.tgz",
+      "integrity": "sha512-r/Mpm/hekKs2d8UQv7k2UyZxE6JoKKct+1s0cY0B/tv+vP0c7Wb50R1Mn/GkXoi6oKxdh9P/pnkGAjPBQ55neA==",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prepublishOnly": "npm run verify"
   },
   "dependencies": {
-    "@agentage/memory-core": "^0.3.1",
+    "@agentage/memory-core": "^0.3.2",
     "@agentage/server-memory": "^0.0.3",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chalk": "latest",


### PR DESCRIPTION
## What

Bump `@agentage/memory-core` `^0.3.1` -> `^0.3.2` to pick up the LocalBackend
commit lock-retry (memory-core#19/#20): a transient `git commit failed` under a
concurrent write + sync storm is now retried inside the engine, so the daemon's
directly-spawned sync `git` no longer races the engine's commit into a spurious
failure.

## Scope

Targeted bump only. The lock diff touches **only** `@agentage/memory-core`:

- `package.json`: `^0.3.1` -> `^0.3.2`
- `package-lock.json` root dep + `node_modules/@agentage/memory-core`: `0.3.1` -> `0.3.2`
- nested `@agentage/memory-core@0.1.3` under `@agentage/server-memory` (pinned `^0.1.3`) is unchanged

No other packages moved; the runtime dep set is identical (package-guard green).

## Verify

- `npm run verify` green - 337 tests pass, build clean.
- Full offline e2e set green (47 tests), including the `@couch` hermetic docker
  tier: `daemon m1-requirements mcp-daemon mcp-stdio memory-offline sync
  vault-offline integrity mcp-contract account-vault couch-sync`.

## Note - concurrency assertion deliberately not added

Considered tightening `integrity`/`couch` to assert **zero** transient
`git commit`/`sync failed` errors under a write+sync storm. Skipped it: it's a
negative, timing-dependent assertion whose real risk is a false RED (the
lock-retry is bounded; contended runners could exhaust it), and transient sync
errors are "recorded, not crashed" so surfacing them deterministically at the
e2e level is indirect/vacuous. The existing integrity tests already lock the
structural invariants the fix protects (clean tree, no `index.lock`, `fsck`
clean under 10/30 concurrent ops) and `couch-sync` exercises concurrent
write+sync convergence - all green on 0.3.2. Kept this a clean one-line bump.
