### PR TITLE
docs: README overhaul with architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The offline-first terminal client for [agentage](https://agentage.io) Memory.
 **One memory. Every AI. Owned by you.** Your memory is plain markdown on your own
 disk. Read and write it from the terminal, serve it to Claude / Cursor / any MCP
 client on this machine, and sync it to a git remote you control. Everything works
-offline; the cloud is optional.
+offline; the cloud account is optional.
 
 ## Install
 
@@ -20,25 +20,55 @@ Requires Node.js >= 22.
 
 ## Quickstart
 
+No sign-in required. Register a local vault and start writing:
+
 ```bash
-agentage vault add notes --local        # register a vault at ~/vaults/notes
+agentage vault add notes --local        # a plain folder at ~/vaults/notes
 echo "# My first note" | agentage memory write welcome.md --vault notes
 agentage memory list --vault notes
-agentage memory search "first" --vault notes
+agentage memory search first --vault notes
 agentage memory read @notes/welcome.md
 ```
 
-No sign-in required. Each vault is a plain folder of `.md` files backed by git; every
-write commits, so nothing is lost and deletes are recoverable from history.
+Each vault is a folder of `.md` files backed by git. Every write commits, so nothing
+is lost and deletes are recoverable from history.
 
-## Memory
+Want the same memory on more machines, or reachable by AI beyond this box? Connect an
+account (optional, still offline-first):
+
+```bash
+agentage setup                           # browser OAuth 2.1 sign-in
+agentage status                          # version, target, sign-in state, endpoint
+```
+
+## Architecture
+
+![Architecture](https://github.com/agentage/cli/raw/master/docs/architecture.svg)
+
+AI clients read and write your memory over MCP: stdio (`agentage mcp`) for a client
+you spawn, or the local daemon's HTTP `/mcp` on `127.0.0.1:4243`. The CLI's memory
+verbs go through the same daemon, which is the single writer over the vault engine
+([`@agentage/memory-core`](https://www.npmjs.com/package/@agentage/memory-core)) and
+schedules background sync. Vaults are plain markdown folders on disk, one git repo
+per vault. From there they sync out to git remotes you host and, when you sign in, to
+your agentage account.
+
+See [`docs/architecture.md`](docs/architecture.md) for a walk-through of the diagram.
+
+## Command reference
+
+Run `agentage <command> --help` for the authoritative options. Global flags:
+`--no-daemon` runs memory verbs in-process instead of via the daemon, `-V/--version`
+prints the version.
+
+### memory
 
 Six offline verbs over your local vaults. Reference a document as `@<vault>/<path>`
 or as `<path> --vault <name>`; omit `--vault` to use the default vault. Every verb
 accepts `--json` for machine-readable output.
 
 ```bash
-agentage memory search <query...>   # search a vault (git grep); --limit <n>
+agentage memory search <query...>   # search a vault (git grep); --limit <n> (default 20)
 agentage memory read <ref>          # print a document
 agentage memory write <ref>         # create or overwrite (--body <text>, or stdin)
 agentage memory edit <ref>          # --old/--new (str_replace), or --body (--append)
@@ -47,14 +77,83 @@ agentage memory delete <ref>        # delete (recoverable from git history)
 ```
 
 `write` reads the body from `--body` or, when omitted (or `--body -`), from stdin;
-pass `--frontmatter '<json>'` to set YAML frontmatter. Documents larger than 64 KB
-are clamped on read, and the engine refuses to store obvious secrets.
+pass `--frontmatter '<json>'` to set YAML frontmatter as a JSON object. `edit` either
+replaces an exact, unique substring (`--old`/`--new`, omit `--new` to delete the
+match) or replaces the whole body (`--body`, add `--append` to append instead).
+Documents larger than 64 KB are clamped on read, and the engine refuses to store
+obvious secrets. Errors are friendly: an unknown vault, a missing document, or a
+non-unique `--old` match report what went wrong and exit non-zero.
 
-## Connect your AI (MCP)
+### vault
 
-`agentage mcp` serves your local vaults to any on-machine AI client over stdio, as
-the same frozen six `memory__{search,read,write,edit,list,delete}` tools the cloud
-endpoint exposes. Point a client at it by spawning the command:
+```bash
+agentage vault add <name>                  # register a vault (account by default)
+agentage vault add <name> --local [path]   # a local folder (default ~/vaults/<name>)
+agentage vault add <name> --git <remote>   # synced to an external git remote
+agentage vault list                        # list registered vaults (--json)
+agentage vault remove <name>               # unregister (files stay on disk)
+agentage vault sync [name]                 # sync now; all vaults, or just one
+```
+
+`vault add` registers an account vault by default; pass `--local` for a folder that
+never leaves this machine, or `--git <remote>` to bind it to a remote you host. For
+an account vault, `--path <dir>` sets the local mirror directory.
+
+### setup and status
+
+```bash
+agentage setup                      # browser OAuth 2.1 sign-in (PKCE), then prints status
+agentage setup --no-browser         # print the sign-in URL instead of opening a browser
+agentage setup --reauth             # force a fresh sign-in
+agentage setup --disconnect         # sign out and remove local credentials
+agentage status                     # CLI version, target, sign-in state, endpoint (--json)
+```
+
+No passwords touch the terminal; tokens are stored in `~/.agentage/auth.json`
+(mode 0600). `status` also surfaces a passive hint when a newer version is available.
+
+### daemon
+
+```bash
+agentage daemon status              # pid, uptime, version
+agentage daemon start               # start it explicitly (idempotent)
+agentage daemon stop                # stop it
+```
+
+### mcp and update
+
+```bash
+agentage mcp                        # serve local vaults to on-machine AI over stdio
+agentage update                     # install the latest published version
+agentage update --check             # report whether an update is available, don't install
+```
+
+## Sync
+
+Two channels keep your markdown in sync, and both are optional.
+
+**Git remotes.** Bind a vault to an external remote you host, and the daemon commits
+and pushes local changes and pulls remote ones on an interval.
+
+```bash
+agentage vault add work --git git@github.com:you/memory.git
+agentage vault sync work            # force a cycle now; progress prints per vault
+```
+
+**Account sync.** Sign in with `agentage setup` and your account vaults sync to the
+agentage cloud, so the same memory follows you across machines.
+
+Conflicts never lose a write. When both sides changed the same file, the remote copy
+is kept alongside yours as `<file>.conflict.md` for you to reconcile.
+
+## MCP integration
+
+Any AI client on this machine can read and write your memory through the same frozen
+six tools the cloud endpoint exposes: `memory__search`, `memory__read`,
+`memory__write`, `memory__edit`, `memory__list`, and `memory__delete`.
+
+**stdio.** `agentage mcp` serves your local vaults over stdio. Point a client at it
+by spawning the command:
 
 ```json
 {
@@ -70,65 +169,21 @@ endpoint exposes. Point a client at it by spawning the command:
 Drop that into your client's MCP config (for example `~/.cursor/mcp.json`, or via
 `claude mcp add`) and the assistant reads and writes the same markdown you do.
 
-Clients that speak Streamable HTTP can instead use the daemon's endpoint at
+**HTTP.** Clients that speak Streamable HTTP can use the daemon's endpoint at
 `http://127.0.0.1:4243/mcp`. The cloud MCP endpoint, for AI outside this machine, is
 `memory.agentage.io/mcp`.
-
-## Git sync
-
-Register a vault against an external git remote and the daemon keeps it in sync,
-committing and pushing local changes and pulling remote ones on an interval.
-
-```bash
-agentage vault add work --git git@github.com:you/memory.git
-agentage vault list
-agentage vault sync            # sync every git-backed vault now
-agentage vault sync work       # sync just one
-```
-
-Conflicts never lose a write: the remote copy is kept alongside yours as
-`<file>.conflict.md` for you to reconcile.
 
 ## The daemon
 
 A small local daemon (loopback only, `127.0.0.1:4243` by default) owns the engine so
-vault writes are serialized and git sync runs in the background. It autostarts on the
-first memory verb; you rarely touch it directly.
-
-```bash
-agentage daemon status         # pid, uptime, version, per-vault sync state
-agentage daemon start          # start it explicitly (idempotent)
-agentage daemon stop           # stop it
-```
+vault writes are serialized and sync runs in the background. It autostarts on the
+first memory verb; you rarely touch it directly. Its API is bound to `127.0.0.1`,
+token-guarded, and rejects cross-origin requests, so nothing off the machine can
+reach it. If the port is already in use it reports the conflict rather than failing
+silently.
 
 To skip the daemon and run verbs in-process, pass `--no-daemon` or set
 `AGENTAGE_NO_DAEMON=1`.
-
-## Cloud account
-
-Sign in to connect this machine to your agentage account. This is optional; the
-memory verbs above work fully offline without it.
-
-```bash
-agentage setup                 # browser OAuth 2.1 sign-in (PKCE), then prints status
-agentage setup --no-browser    # print the sign-in URL instead of opening a browser
-agentage setup --reauth        # force a fresh sign-in
-agentage setup --disconnect    # sign out and remove local credentials
-
-agentage status                # CLI version, target, sign-in state, endpoint (--json)
-```
-
-No passwords touch the terminal; tokens are stored in `~/.agentage/auth.json`
-(mode 0600).
-
-## Update
-
-```bash
-agentage update                # install the latest published version
-agentage update --check        # report whether an update is available, don't install
-```
-
-`status` also surfaces a passive hint when a newer version is available.
 
 ## Environment
 
@@ -143,8 +198,16 @@ agentage update --check        # report whether an update is available, don't in
 
 ```bash
 npm ci
-npm run verify                    # type-check + lint + format + unit tests + build
-npm run build && npm run test:e2e # live e2e (Playwright) against the dev stack
+npm run verify                    # type-check + lint + format:check + unit tests + build
+```
+
+End-to-end tests (Playwright) run in tiers. The offline tiers drive the built
+`dist/cli.js` in-process and need no network or account; the live tiers exercise the
+full OAuth round trip against a running stack.
+
+```bash
+npm run build && npm run test:e2e                      # all e2e tiers
+npm run build && npm run test:e2e -- --grep @offline   # offline tiers only
 ```
 
 ## License

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,27 @@
+# Architecture
+
+![Architecture](https://github.com/agentage/cli/raw/master/docs/architecture.svg)
+
+The pieces, top to bottom.
+
+- **AI tools** (Claude Code, Cursor, editors) reach your memory over MCP through one
+  of two entry points:
+  - **stdio** - a client you spawn with `agentage mcp`.
+  - **HTTP** - the local daemon's `/mcp` endpoint on `127.0.0.1:4243`.
+  Both expose the same frozen six tools: `memory__search`, `memory__read`,
+  `memory__write`, `memory__edit`, `memory__list`, `memory__delete`.
+- **agentage CLI** - the `memory`, `vault`, `setup`, `status`, `daemon`, and `mcp`
+  commands. Memory verbs default to the daemon; `--no-daemon` runs them in-process.
+- **Local daemon** (`127.0.0.1:4243`) - the single writer over the vault engine, so
+  concurrent writes are serialized. It also schedules background sync. The API is
+  loopback-only and token-guarded.
+- **Local vaults** - plain markdown folders on disk, one git repo per vault, backed
+  by the [`@agentage/memory-core`](https://www.npmjs.com/package/@agentage/memory-core)
+  engine. Every write commits; deletes are recoverable from history.
+- **Sync channels** (both optional):
+  - **Git remotes** you host - the daemon commits, pushes, and pulls on an interval.
+  - **Account sync** to the agentage cloud after `agentage setup` (OAuth 2.1 sign-in
+    at `auth.agentage.io`), so the same memory follows you across machines.
+
+Conflicts never lose a write: when both sides change the same file, the remote copy
+is kept alongside yours as `<file>.conflict.md`.

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 680" width="880" height="680" font-family="Segoe UI, Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#57606a"/>
+    </marker>
+  </defs>
+
+  <!-- neutral background so dark text stays legible in both GitHub themes -->
+  <rect x="0" y="0" width="880" height="680" rx="10" fill="#f6f8fa"/>
+
+  <!-- AI tools -->
+  <rect x="250" y="30" width="380" height="62" rx="8" fill="#ffffff" stroke="#d0d7de" stroke-width="1.5"/>
+  <text x="440" y="58" text-anchor="middle" font-size="16" font-weight="700" fill="#1f2328">AI tools</text>
+  <text x="440" y="80" text-anchor="middle" font-size="13" fill="#57606a">Claude Code / Cursor / editors</text>
+
+  <!-- MCP entry arrows -->
+  <line x1="370" y1="92" x2="212" y2="176" stroke="#57606a" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="176" y="128" text-anchor="middle" font-size="12" fill="#1f2328">MCP - stdio</text>
+  <text x="176" y="144" text-anchor="middle" font-size="12" fill="#57606a">(agentage mcp)</text>
+
+  <line x1="510" y1="92" x2="668" y2="176" stroke="#57606a" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="700" y="128" text-anchor="middle" font-size="12" fill="#1f2328">MCP - HTTP /mcp</text>
+  <text x="700" y="144" text-anchor="middle" font-size="12" fill="#57606a">127.0.0.1:4243</text>
+
+  <!-- agentage CLI -->
+  <rect x="60" y="178" width="300" height="88" rx="8" fill="#ffffff" stroke="#d0d7de" stroke-width="1.5"/>
+  <text x="210" y="206" text-anchor="middle" font-size="15" font-weight="700" fill="#1f2328">agentage CLI</text>
+  <text x="210" y="230" text-anchor="middle" font-size="12.5" fill="#57606a">memory   vault   setup</text>
+  <text x="210" y="250" text-anchor="middle" font-size="12.5" fill="#57606a">status   daemon   mcp</text>
+
+  <!-- local daemon -->
+  <rect x="520" y="178" width="300" height="88" rx="8" fill="#ffffff" stroke="#d0d7de" stroke-width="1.5"/>
+  <text x="670" y="206" text-anchor="middle" font-size="15" font-weight="700" fill="#1f2328">local daemon - 127.0.0.1:4243</text>
+  <text x="670" y="230" text-anchor="middle" font-size="12.5" fill="#57606a">single writer over the vault engine</text>
+  <text x="670" y="250" text-anchor="middle" font-size="12.5" fill="#57606a">serializes writes, schedules sync</text>
+
+  <!-- CLI -> daemon -->
+  <line x1="360" y1="222" x2="518" y2="222" stroke="#57606a" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="440" y="212" text-anchor="middle" font-size="11.5" fill="#1f2328">memory verbs</text>
+  <text x="440" y="240" text-anchor="middle" font-size="11.5" fill="#57606a">--no-daemon bypasses</text>
+
+  <!-- daemon -> vaults -->
+  <line x1="600" y1="266" x2="472" y2="356" stroke="#57606a" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="574" y="318" text-anchor="middle" font-size="12" fill="#57606a">vault engine</text>
+
+  <!-- CLI -> vaults (in-process fallback) -->
+  <line x1="200" y1="266" x2="330" y2="356" stroke="#8c959f" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#arrow)"/>
+  <text x="222" y="318" text-anchor="middle" font-size="12" fill="#8c959f">in-process</text>
+
+  <!-- local vaults -->
+  <rect x="230" y="358" width="420" height="88" rx="8" fill="#ffffff" stroke="#d0d7de" stroke-width="1.5"/>
+  <text x="440" y="388" text-anchor="middle" font-size="15" font-weight="700" fill="#1f2328">local vaults - plain markdown folders on disk</text>
+  <text x="440" y="412" text-anchor="middle" font-size="12.5" fill="#57606a">one git repo per vault</text>
+  <text x="440" y="432" text-anchor="middle" font-size="12.5" fill="#57606a">git-per-vault store (@agentage/memory-core)</text>
+
+  <!-- sync arrows -->
+  <line x1="360" y1="446" x2="242" y2="536" stroke="#57606a" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="286" y="500" text-anchor="middle" font-size="12" fill="#57606a">sync</text>
+
+  <line x1="520" y1="446" x2="648" y2="536" stroke="#57606a" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="602" y="500" text-anchor="middle" font-size="12" fill="#57606a">sync</text>
+
+  <!-- git remotes -->
+  <rect x="92" y="538" width="300" height="86" rx="8" fill="#ffffff" stroke="#d0d7de" stroke-width="1.5"/>
+  <text x="242" y="568" text-anchor="middle" font-size="14" font-weight="700" fill="#1f2328">git remotes (external)</text>
+  <text x="242" y="590" text-anchor="middle" font-size="12.5" fill="#57606a">commit / push / pull on an interval</text>
+  <text x="242" y="610" text-anchor="middle" font-size="12.5" fill="#57606a">you host the remote</text>
+
+  <!-- account sync -->
+  <rect x="488" y="538" width="320" height="86" rx="8" fill="#ffffff" stroke="#d0d7de" stroke-width="1.5"/>
+  <text x="648" y="568" text-anchor="middle" font-size="14" font-weight="700" fill="#1f2328">agentage cloud - account sync</text>
+  <text x="648" y="590" text-anchor="middle" font-size="12.5" fill="#57606a">OAuth 2.1 sign-in at auth.agentage.io</text>
+  <text x="648" y="610" text-anchor="middle" font-size="12.5" fill="#57606a">optional; everything works offline</text>
+</svg>


### PR DESCRIPTION
## What

README overhaul plus a hand-authored architecture diagram, aligned to master after #238-#245. Ready as the npm landing page.

Touches only `README.md` and `docs/**` - no `src/`, `package.json`, or workflows.

## Changes

- **`docs/architecture.svg`** - hand-written SVG (no render tooling). Neutral background with dark text on light boxes, so it reads in both light and dark GitHub themes and on npm. Shows AI tools -> MCP (stdio `agentage mcp` + daemon HTTP `/mcp` on `127.0.0.1:4243`) -> CLI + local daemon (single writer) -> local vaults (git-per-vault, `@agentage/memory-core`) -> sync out to git remotes and account sync (labeled protocol-neutrally, no internal tech named).
- **`README.md`** restructured for a first-time reader: What is this -> Install -> Quickstart (local-only first, then optional `agentage setup`) -> Architecture (diagram) -> Command reference -> Sync -> MCP integration -> Daemon -> Env vars -> Development.
- **`docs/architecture.md`** - short walk-through of the diagram.

## Reality-check vs master

Built the CLI (`npm run build`) and verified every command and flag against the live `--help` output. Corrected drift from the merged PRs:

- `vault add` now defaults to an **account** vault; `--local [path]`, `--git <remote>`, `--path <dir>` are the alternatives.
- `vault sync [name]` now covers git and the account channel; progress prints per vault.
- Documented the `update` command and `--no-daemon` global flag.
- Daemon section notes the loopback-only, token-guarded, cross-origin-rejecting API and port-in-use reporting (#243, #244).
- Friendly memory errors + non-zero exits (#240); 64 KB read clamp and secret refusal.
- Describes no specific `src/` file paths (a sibling PR is moving `src/sync/` paths).

## Verification

- `npm run verify` green: 405 unit tests pass, type-check + lint + format:check + build clean.
- Ran the offline quickstart end-to-end against the built `dist/cli.js` (vault add --local, write via stdin, list, search, read `@vault/path`) - all pass.
- Rendered `docs/architecture.svg` to PNG and eyeballed legibility.

Note: `format:check` only globs `{src,e2e}/**/*.ts`, so it does not lint markdown; README changes are prose-only.
