### PR TITLE
fix(lock): never steal a live-but-slow holder under CPU contention

### DIFF
--- a/src/lib/file-lock.test.ts
+++ b/src/lib/file-lock.test.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'node:child_process';
+import { execFile, spawn, spawnSync } from 'node:child_process';
 import {
   chmodSync,
   existsSync,
@@ -111,10 +111,23 @@ describe('file lock', () => {
   });
 
   it('takes over a stale lock left by a crashed holder, never wedging', async () => {
-    writeFileSync(lockFile(), `999 ${Date.now() - 11_000}`); // 11s old = crashed holder
+    const deadPid = spawnSync(process.execPath, ['-e', '0']).pid; // spawned + reaped => pid is dead
+    writeFileSync(lockFile(), `${deadPid} ${Date.now() - 11_000}`); // 11s old + dead pid = crashed
     const result = await withFileLock(target, () => 'recovered');
     expect(result).toBe('recovered');
     expect(existsSync(lockFile())).toBe(false);
+  });
+
+  it('refuses a stale-looking lock whose holder is still alive (never steals a slow holder)', () => {
+    // A live-but-CPU-starved holder can look older than the TTL on a loaded CI runner. Stealing it
+    // would put two writers in the critical section and drop an append (issue #249). It must refuse.
+    const holder = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 60000)']);
+    try {
+      writeFileSync(lockFile(), `${holder.pid} ${1_000_000}`);
+      expect(acquireFileLock(target, 1_000_000 + 11_000)).toBe(false); // 11s old but pid is alive
+    } finally {
+      holder.kill('SIGKILL');
+    }
   });
 
   it('serializes many concurrent in-process read-modify-writes, losing none', async () => {

--- a/src/lib/file-lock.ts
+++ b/src/lib/file-lock.ts
@@ -2,25 +2,54 @@ import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
 // A cross-process advisory lock keyed to a target file (`<target>.lock`). Config read-modify-writes
-// are sub-millisecond, so a lock older than this is a crashed holder to be taken over.
+// are sub-millisecond, so a lock past this age whose holder is gone is a crashed holder to take over.
 const LOCK_TTL_MS = 10_000;
 // A caller blocks up to this long for a contended lock. Past the TTL so a crashed holder is taken
 // over rather than wedging the caller; a throw only happens if the lock is genuinely stuck.
 const MAX_WAIT_MS = 15_000;
+// Past this age a holder is taken over even if its pid still resolves - the only explanation left is
+// pid reuse after a crash. Far beyond any real critical section or plausible scheduler pause, so a
+// live-but-CPU-starved holder is never mistaken for crashed below it.
+const STALE_HARD_MS = 60_000;
 const STEP_MS = 25;
 
 const lockPath = (target: string): string => `${target}.lock`;
 
-// The lock file holds "<pid> <timestamp>"; the trailing token is the acquisition time used for
-// staleness. pid is there for debuggability only.
-const heldAt = (path: string): number | null => {
+// The lock file holds "<pid> <timestamp>": pid gates crash-takeover, the trailing token is the
+// acquisition time used for staleness. A legacy single-token file parses as pid 0 (unknown holder).
+const holderOf = (path: string): { pid: number; at: number } | null => {
   try {
     const parts = readFileSync(path, 'utf-8').trim().split(/\s+/);
-    const n = Number.parseInt(parts[parts.length - 1] ?? '', 10);
-    return Number.isNaN(n) ? null : n;
+    const at = Number.parseInt(parts[parts.length - 1] ?? '', 10);
+    if (Number.isNaN(at)) return null;
+    const pid = parts.length >= 2 ? Number.parseInt(parts[0] ?? '', 10) : 0;
+    return { pid: Number.isNaN(pid) ? 0 : pid, at };
   } catch {
     return null;
   }
+};
+
+// Same-host liveness probe. ESRCH = the holder is gone (crashed); EPERM = alive but owned by another
+// user. pid 0/unknown counts as gone so a legacy or malformed lock still ages out on the TTL.
+const holderAlive = (pid: number): boolean => {
+  if (pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+};
+
+// A holder is safe to take over only once it is past the TTL AND provably gone: a dead pid, our own
+// leftover pid (we cannot be inside our own synchronous section while here), or so old that pid reuse
+// is the only explanation. A live holder merely starved of CPU is NEVER stolen - stealing it would
+// put two writers in the critical section and silently drop an append (issue #249).
+const isCrashed = (holder: { pid: number; at: number }, now: number): boolean => {
+  const age = now - holder.at;
+  if (age < LOCK_TTL_MS) return false;
+  if (age >= STALE_HARD_MS) return true;
+  return holder.pid === process.pid || !holderAlive(holder.pid);
 };
 
 const unlinkQuiet = (path: string): void => {
@@ -38,16 +67,16 @@ const unlinkQuiet = (path: string): void => {
 const takeOverStale = (target: string, now: number): boolean => {
   const path = lockPath(target);
   const guard = `${path}.takeover`;
-  const guardHeld = heldAt(guard);
-  if (guardHeld !== null && now - guardHeld >= LOCK_TTL_MS) unlinkQuiet(guard);
+  const guardHeld = holderOf(guard);
+  if (guardHeld !== null && isCrashed(guardHeld, now)) unlinkQuiet(guard);
   try {
     writeFileSync(guard, `${process.pid} ${now}`, { flag: 'wx' });
   } catch {
     return false; // another taker is mid-takeover; let it win
   }
   try {
-    const held = heldAt(path);
-    if (held !== null && now - held < LOCK_TTL_MS) return false; // became fresh meanwhile
+    const holder = holderOf(path);
+    if (holder !== null && !isCrashed(holder, now)) return false; // fresh or a live-but-slow holder
     unlinkQuiet(path);
     return true;
   } finally {
@@ -56,8 +85,8 @@ const takeOverStale = (target: string, now: number): boolean => {
 };
 
 // One-shot acquire: the O_EXCL ('wx') create IS the mutex - concurrent callers cannot both win it,
-// unlike a check-then-write. A fresh holder refuses; a stale one (crashed holder) is cleared under
-// the takeover guard and re-raced once. `now` is injectable for tests.
+// unlike a check-then-write. A fresh or live holder refuses; a crashed one (dead holder past the
+// TTL) is cleared under the takeover guard and re-raced once. `now` is injectable for tests.
 export const acquireFileLock = (target: string, now: number = Date.now()): boolean => {
   mkdirSync(dirname(target), { recursive: true });
   for (let attempt = 0; attempt < 2; attempt++) {
@@ -76,8 +105,8 @@ export const acquireFileLock = (target: string, now: number = Date.now()): boole
             : `could not write lock file ${path}${code ? ` (${code})` : ''}`
         );
       }
-      const held = heldAt(lockPath(target));
-      if (held !== null && now - held < LOCK_TTL_MS) return false;
+      const holder = holderOf(lockPath(target));
+      if (holder !== null && !isCrashed(holder, now)) return false;
       if (!takeOverStale(target, now)) return false;
     }
   }

--- a/src/lib/update-lock.ts
+++ b/src/lib/update-lock.ts
@@ -3,17 +3,47 @@ import { join } from 'node:path';
 import { ensureConfigDir, getConfigDir } from './config.js';
 
 const LOCK_FILE = 'update.lock';
-const LOCK_TTL_MS = 10 * 60 * 1000; // a lock older than this is treated as stale (crashed run)
+const LOCK_TTL_MS = 10 * 60 * 1000; // a lock older than this whose holder is gone is a crashed run
+// Past this age a holder is taken over even if its pid still resolves (pid reuse after a crash); far
+// beyond any real run or scheduler pause, so a live-but-slow holder is never mistaken for crashed.
+const STALE_HARD_MS = 30 * 60 * 1000;
 
 const lockPath = (): string => join(getConfigDir(), LOCK_FILE);
 
-const heldAt = (path: string): number | null => {
+// The lock file holds "<pid> <timestamp>": pid gates crash-takeover, the trailing token is the
+// acquisition time. A legacy single-token file parses as pid 0 (unknown holder), aging out on TTL.
+const holderOf = (path: string): { pid: number; at: number } | null => {
   try {
-    const n = Number.parseInt(readFileSync(path, 'utf-8').trim(), 10);
-    return Number.isNaN(n) ? null : n;
+    const parts = readFileSync(path, 'utf-8').trim().split(/\s+/);
+    const at = Number.parseInt(parts[parts.length - 1] ?? '', 10);
+    if (Number.isNaN(at)) return null;
+    const pid = parts.length >= 2 ? Number.parseInt(parts[0] ?? '', 10) : 0;
+    return { pid: Number.isNaN(pid) ? 0 : pid, at };
   } catch {
     return null;
   }
+};
+
+// Same-host liveness probe. ESRCH = the holder is gone (crashed); EPERM = alive but owned by another
+// user. pid 0/unknown counts as gone so a legacy or malformed lock still ages out on the TTL.
+const holderAlive = (pid: number): boolean => {
+  if (pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+};
+
+// A holder is safe to take over only once it is past the TTL AND provably gone: a dead pid, our own
+// leftover pid, or so old that pid reuse is the only explanation. A live holder merely starved of
+// CPU is never stolen - stealing it would let two writers run concurrently.
+const isCrashed = (holder: { pid: number; at: number }, now: number): boolean => {
+  const age = now - holder.at;
+  if (age < LOCK_TTL_MS) return false;
+  if (age >= STALE_HARD_MS) return true;
+  return holder.pid === process.pid || !holderAlive(holder.pid);
 };
 
 const unlinkQuiet = (path: string): void => {
@@ -31,16 +61,16 @@ const unlinkQuiet = (path: string): void => {
 // crashed taker expires like the lock itself. Returns whether to re-race the create.
 const takeOverStale = (now: number): boolean => {
   const guard = `${lockPath()}.takeover`;
-  const guardHeld = heldAt(guard);
-  if (guardHeld !== null && now - guardHeld >= LOCK_TTL_MS) unlinkQuiet(guard);
+  const guardHeld = holderOf(guard);
+  if (guardHeld !== null && isCrashed(guardHeld, now)) unlinkQuiet(guard);
   try {
-    writeFileSync(guard, String(now), { flag: 'wx' });
+    writeFileSync(guard, `${process.pid} ${now}`, { flag: 'wx' });
   } catch {
     return false; // another taker is mid-takeover; let it win
   }
   try {
-    const held = heldAt(lockPath());
-    if (held !== null && now - held < LOCK_TTL_MS) return false; // became fresh meanwhile
+    const holder = holderOf(lockPath());
+    if (holder !== null && !isCrashed(holder, now)) return false; // fresh or a live-but-slow holder
     unlinkQuiet(lockPath());
     return true;
   } finally {
@@ -56,11 +86,11 @@ export const acquireUpdateLock = (now: number = Date.now()): boolean => {
   ensureConfigDir();
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
-      writeFileSync(lockPath(), String(now), { flag: 'wx' });
+      writeFileSync(lockPath(), `${process.pid} ${now}`, { flag: 'wx' });
       return true;
     } catch {
-      const held = heldAt(lockPath());
-      if (held !== null && now - held < LOCK_TTL_MS) return false;
+      const holder = holderOf(lockPath());
+      if (holder !== null && !isCrashed(holder, now)) return false;
       if (!takeOverStale(now)) return false;
     }
   }


### PR DESCRIPTION
## Root cause (issue #249)

`src/lib/file-lock.ts` decided lock takeover from **age alone**. A holder that acquires
the lock, then gets descheduled by the OS for longer than `LOCK_TTL_MS` (10s) - realistic
on a 2-core GitHub runner running 20 child processes **plus** V8 coverage (added to both
lanes in #245; `NODE_V8_COVERAGE` is inherited by the `execFile` children, so every child
pays the tax) - still has its `<pid> <timestamp>` lock look *stale*.

`acquireFileLock` (old `file-lock.ts:79-81`) then treated that live holder as crashed:

```
const held = heldAt(lockPath(target));
if (held !== null && now - held < LOCK_TTL_MS) return false; // fresh -> refuse
if (!takeOverStale(target, now)) return false;               // else STEAL it
```

`takeOverStale` deletes the "stale" lock and a second process enters the critical section
while the original holder is still mid read-modify-write. Both `readFileSync` the array,
both `push`, the later `writeFileSync` clobbers the earlier - exactly one append is lost.
The holder was never dead, so it still prints `ok`: hence **all 20 children succeed yet the
array is 19/20** (`expected [0..18] to deeply equal Array(20)`). This is a **product bug**,
not a test bug.

## Mechanism, reproduced

Standalone harness: the 20-process append race with process 0's critical section paused
11s (simulating the CPU-starvation the runner produces), against the two `file-lock.ts`:

```
ORIG  pause=11000  iters=8   lostWrites=8   throwPath=0   # incl. an exact 19/20 iter
FIX   pause=11000  iters=10  lostWrites=0   throwPath=0
```

The original loses an append on **every** iteration (all children still report `ok`,
matching the CI signature); the fix loses none.

## The fix

Takeover is now gated on **same-host pid liveness**, not age alone
(`file-lock.ts` `isCrashed`):

- A holder is stolen only once it is past the TTL **and** provably gone - its pid returns
  `ESRCH` from `process.kill(pid, 0)`, or it is our own leftover pid (we cannot be inside
  our own synchronous section while trying to acquire), or it is past a 60s hard backstop
  (guards against pid reuse after a genuine crash).
- A live-but-CPU-starved holder is **waited out** by the caller's bounded backoff, never
  stolen. If it is genuinely wedged past `MAX_WAIT_MS`, the caller throws a loud
  `could not acquire lock` - a safe, visible failure, never silent corruption.

Why correct: the only way two processes can be in the critical section is if a takeover
fires while the first is alive. Liveness makes that impossible for any alive holder,
regardless of how long the scheduler pauses it. Crash recovery is preserved (dead pid ->
takeover) and the ABA takeover guard is unchanged.

The lock file format stays `<pid> <timestamp>`; parsing is tolerant of legacy single-token
files (parsed as pid 0 -> ages out on the TTL, so old on-disk locks still recover).

Same hardening applied to `src/lib/update-lock.ts` (same lock family). It is far less
exposed (10-min TTL, single-writer), but the fix is symmetric and its parser is now
backward-compatible with existing bare-timestamp `update.lock` files.

## Evidence / verify

- `npm run verify` green (406 tests, 48 files).
- `file-lock.test.ts` looped **20x = 20/20**; **5x pinned to 2 cores** (`taskset -c 0,1`) = 5/5.
- All existing tests kept, including the fail-fast-on-EACCES cases (#240) and the 20-process
  zero-lost-writes proof. The crashed-holder test now seeds a reaped (deterministically dead)
  pid instead of a hardcoded `999`, so the liveness check is exercised reliably. Added a test
  proving a stale-looking lock whose holder is **alive** is refused, not stolen.

Closes #249
