### PR TITLE
feat: status shows daemon health, auth refreshes silently

### DIFF
--- a/src/commands/daemon/daemon-cmd.test.ts
+++ b/src/commands/daemon/daemon-cmd.test.ts
@@ -41,10 +41,18 @@ afterEach(() => {
 });
 
 describe('daemon status', () => {
-  it('reports not running when no pidfile is live', async () => {
+  it('reports not running when no pidfile is live and health is silent', async () => {
     vi.mocked(lifecycle.isDaemonRunning).mockReturnValue(false);
+    vi.mocked(dc.health).mockResolvedValue(null);
     await run(['daemon', 'status']);
     expect(logs.join()).toContain('not running');
+  });
+
+  it('prints a legacy daemon (health answers, no pidfile) as running', async () => {
+    vi.mocked(lifecycle.isDaemonRunning).mockReturnValue(false);
+    vi.mocked(dc.health).mockResolvedValue(health({ pid: 77366 }));
+    await run(['daemon', 'status']);
+    expect(logs.join('\n')).toContain('77366');
   });
 
   it('prints pid, port, uptime, served, and version', async () => {
@@ -143,10 +151,30 @@ describe('daemon stop', () => {
     expect(logs.join()).toContain('stopped');
   });
 
-  it('is a no-op when nothing is running', async () => {
+  it('is a no-op when nothing is running (no pidfile, no health)', async () => {
     vi.mocked(lifecycle.isDaemonRunning).mockReturnValue(false);
+    vi.mocked(dc.health).mockResolvedValue(null);
     await run(['daemon', 'stop']);
     expect(lifecycle.stopDaemonSafely).not.toHaveBeenCalled();
     expect(logs.join()).toContain('not running');
+  });
+
+  it('signals a legacy daemon (health answers, no pidfile) by its reported pid', async () => {
+    vi.mocked(lifecycle.isDaemonRunning).mockReturnValue(false);
+    vi.mocked(dc.health).mockResolvedValue(health({ pid: 77366 }));
+    vi.mocked(lifecycle.signalPid).mockReturnValue(true);
+    await run(['daemon', 'stop']);
+    expect(lifecycle.signalPid).toHaveBeenCalledWith(77366);
+    expect(logs.join()).toContain('stopped (pid 77366)');
+  });
+
+  it('reports the truth when a live daemon has no pidfile and cannot be signalled', async () => {
+    vi.mocked(lifecycle.isDaemonRunning).mockReturnValue(false);
+    vi.mocked(dc.health).mockResolvedValue(health({ pid: 77366 }));
+    vi.mocked(lifecycle.signalPid).mockReturnValue(false);
+    await run(['daemon', 'stop']);
+    expect(logs.join()).toContain('is running');
+    expect(logs.join()).toContain('kill 77366');
+    expect(process.exitCode).toBe(1);
   });
 });

--- a/src/commands/daemon/daemon-cmd.ts
+++ b/src/commands/daemon/daemon-cmd.ts
@@ -1,6 +1,11 @@
 import chalk from 'chalk';
 import { type Command } from 'commander';
-import { isDaemonRunning, resolvePort, stopDaemonSafely } from '../../daemon/lifecycle.js';
+import {
+  isDaemonRunning,
+  resolvePort,
+  signalPid,
+  stopDaemonSafely,
+} from '../../daemon/lifecycle.js';
 import { health, mismatchNotice, spawnDaemon, syncStatus } from '../../lib/daemon/daemon-client.js';
 
 const startAction = async (opts: { mcp?: boolean } = {}): Promise<void> => {
@@ -30,29 +35,49 @@ const startAction = async (opts: { mcp?: boolean } = {}): Promise<void> => {
   console.log(chalk.green(`Daemon started (pid ${h?.pid ?? '?'}, port ${port}, mcp ${mcp}).`));
 };
 
+// Detect the daemon the same way `start` does (tokenless /health), so a legacy daemon that never
+// wrote this config dir's pidfile is not misreported as "not running". With a pidfile we own, use
+// the safe pid-confirming stop; otherwise fall back to signalling the pid /health reports, or - if
+// none is available - report the truth rather than a false "not running".
 const stopAction = async (): Promise<void> => {
-  if (!isDaemonRunning()) {
-    console.log(chalk.gray('Daemon is not running.'));
-    return;
-  }
-  if (await stopDaemonSafely()) console.log(chalk.green('Daemon stopped.'));
-};
-
-const statusAction = async (): Promise<void> => {
-  if (!isDaemonRunning()) {
-    console.log(chalk.gray('Daemon is not running.'));
+  if (isDaemonRunning()) {
+    if (await stopDaemonSafely()) console.log(chalk.green('Daemon stopped.'));
     return;
   }
   const port = resolvePort();
   const h = await health(port);
   if (!h) {
-    console.log(chalk.yellow(`Daemon pid file present but unreachable on port ${port}.`));
+    console.log(chalk.gray('Daemon is not running.'));
     return;
   }
-  console.log(`pid      ${h.pid}`);
+  if (typeof h.pid === 'number' && signalPid(h.pid)) {
+    console.log(chalk.green(`Daemon stopped (pid ${h.pid}).`));
+    return;
+  }
+  const who = typeof h.pid === 'number' ? `pid ${h.pid}` : `port ${port}`;
+  console.error(
+    chalk.yellow(
+      `Daemon is running (${who}) but has no pidfile to stop it safely; stop it with: kill ${h.pid ?? '<pid>'}`
+    )
+  );
+  process.exitCode = 1;
+};
+
+const statusAction = async (): Promise<void> => {
+  const port = resolvePort();
+  const h = await health(port);
+  if (!h) {
+    console.log(
+      isDaemonRunning()
+        ? chalk.yellow(`Daemon pid file present but unreachable on port ${port}.`)
+        : chalk.gray('Daemon is not running.')
+    );
+    return;
+  }
+  console.log(`pid      ${h.pid ?? '?'}`);
   console.log(`port     ${port}`);
-  console.log(`uptime   ${h.uptime}s`);
-  console.log(`served   ${h.served}`);
+  if (typeof h.uptime === 'number') console.log(`uptime   ${h.uptime}s`);
+  if (typeof h.served === 'number') console.log(`served   ${h.served}`);
   console.log(`mcp      ${h.mcp === false ? 'off' : 'on'}`);
   console.log(`version  ${h.version}`);
   const notice = mismatchNotice(h.version);

--- a/src/commands/status/status.test.ts
+++ b/src/commands/status/status.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it, vi } from 'vitest';
 import { type StatusReport } from '../../lib/status/status-info.js';
 import { printStatus } from './status.js';
 
+// A future expiry so the truthful-display guard (past expiry -> "session active") does not rot.
+const futureExpiry = new Date(Date.now() + 3_600_000).toISOString();
+
 const baseReport: StatusReport = {
   version: '0.25.0',
   fqdn: 'agentage.io',
   env: 'production',
-  auth: { signedIn: true, tokenExpiresAt: '2026-06-12T20:00:00Z' },
+  auth: { signedIn: true, tokenExpiresAt: futureExpiry },
   endpoint: { url: 'https://agentage.io/api', reachable: true },
   update: { status: { kind: 'current' }, message: null },
 };
@@ -27,8 +30,27 @@ describe('printStatus', () => {
     expect(out).toContain('0.25.0');
     expect(out).toContain('agentage.io (production)');
     expect(out).toContain('signed in');
-    expect(out).toContain('2026-06-12T20:00:00Z');
+    expect(out).toContain(futureExpiry);
     expect(out).toContain('reachable');
+  });
+
+  it('shows a future token expiry verbatim next to the checkmark', () => {
+    const future = new Date(Date.now() + 3_600_000).toISOString();
+    const out = captureLines({ ...baseReport, auth: { signedIn: true, tokenExpiresAt: future } });
+    expect(out).toContain(`token valid until ${future}`);
+  });
+
+  it('never prints a past token expiry next to the signed-in checkmark', () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    const out = captureLines({ ...baseReport, auth: { signedIn: true, tokenExpiresAt: past } });
+    expect(out).not.toContain(past);
+    expect(out).not.toContain('token valid until');
+    expect(out).toContain('signed in (session active)');
+  });
+
+  it('shows session active when signed in without any expiry', () => {
+    const out = captureLines({ ...baseReport, auth: { signedIn: true } });
+    expect(out).toContain('signed in (session active)');
   });
 
   it('prints the setup hint when signed out', () => {

--- a/src/commands/status/status.test.ts
+++ b/src/commands/status/status.test.ts
@@ -62,4 +62,81 @@ describe('printStatus', () => {
     expect(out).toContain('unsupported');
     expect(out).toContain('npm i -g @agentage/cli@latest');
   });
+
+  it('shows a stopped daemon row with the start hint and no mcp/sync lines', () => {
+    const out = captureLines({ ...baseReport, daemon: { running: false, port: 4243 } });
+    expect(out).toContain('daemon');
+    expect(out).toContain('stopped - run: agentage daemon start');
+    expect(out).not.toContain('mcp');
+    expect(out).not.toContain('sync');
+  });
+
+  it('shows pid/port/uptime and the mcp endpoint when running with mcp on', () => {
+    const out = captureLines({
+      ...baseReport,
+      daemon: { running: true, pid: 321, port: 4243, uptimeSeconds: 3720, mcp: true },
+    });
+    expect(out).toContain('running (pid 321, port 4243, up 1h 2m)');
+    expect(out).toContain('serving at http://127.0.0.1:4243/mcp');
+  });
+
+  it('marks mcp off when the daemon serves no /mcp endpoint', () => {
+    const out = captureLines({
+      ...baseReport,
+      daemon: { running: true, pid: 1, port: 4243, uptimeSeconds: 5, mcp: false },
+    });
+    expect(out).toContain('mcp');
+    expect(out).toMatch(/mcp\s+\S+ off/);
+  });
+
+  it('renders a sync ok row with the vault count and last-run', () => {
+    const out = captureLines({
+      ...baseReport,
+      daemon: {
+        running: true,
+        port: 4243,
+        mcp: true,
+        sync: { vaults: 3, state: 'ok', lastRun: '2026-07-08T10:00:00Z' },
+      },
+    });
+    expect(out).toContain('3 vaults');
+    expect(out).toContain('last ok 2026-07-08T10:00:00Z');
+  });
+
+  it('renders a sync error row with a short last error', () => {
+    const out = captureLines({
+      ...baseReport,
+      daemon: {
+        running: true,
+        port: 4243,
+        mcp: true,
+        sync: { vaults: 1, state: 'error', lastError: 'push rejected\nmore detail here' },
+      },
+    });
+    expect(out).toMatch(/sync\s+\S+ error \(push rejected\)/);
+  });
+
+  it('renders a syncing row while a cycle is in flight', () => {
+    const out = captureLines({
+      ...baseReport,
+      daemon: { running: true, port: 4243, mcp: true, sync: { vaults: 2, state: 'syncing' } },
+    });
+    expect(out).toContain('syncing');
+  });
+
+  it('appends a version-mismatch note to the running daemon row', () => {
+    const out = captureLines({
+      ...baseReport,
+      version: '0.25.0',
+      daemon: {
+        running: true,
+        pid: 9,
+        port: 4243,
+        uptimeSeconds: 1,
+        mcp: true,
+        daemonVersion: '0.24.0',
+      },
+    });
+    expect(out).toContain('version 0.24.0 != cli 0.25.0');
+  });
 });

--- a/src/commands/status/status.test.ts
+++ b/src/commands/status/status.test.ts
@@ -124,6 +124,17 @@ describe('printStatus', () => {
     expect(out).toContain('syncing');
   });
 
+  it('renders a legacy daemon row (no pid/uptime) as running with a version note', () => {
+    const out = captureLines({
+      ...baseReport,
+      version: '0.25.0',
+      daemon: { running: true, port: 4243, mcp: true, daemonVersion: '0.0.3' },
+    });
+    expect(out).toMatch(/daemon\s+\S+ running \(pid \?, port 4243\)/);
+    expect(out).toContain('version 0.0.3 != cli 0.25.0');
+    expect(out).toContain('serving at http://127.0.0.1:4243/mcp');
+  });
+
   it('appends a version-mismatch note to the running daemon row', () => {
     const out = captureLines({
       ...baseReport,

--- a/src/commands/status/status.ts
+++ b/src/commands/status/status.ts
@@ -16,9 +16,20 @@ const row = (label: string, value: string): void => {
   console.log(`${label.padEnd(10)} ${value}`);
 };
 
+// Never print a past timestamp next to the signed-in checkmark: introspection proved the session
+// is active server-side, so a stale/past access-token expiry we could not refresh becomes a plain
+// "signed in (session active)" rather than a contradictory past "valid until".
+const expiryInFuture = (iso?: string): boolean => {
+  if (!iso) return false;
+  const t = Date.parse(iso);
+  return !Number.isNaN(t) && t > Date.now();
+};
+
 const authLine = (auth: StatusReport['auth']): string => {
   if (!auth.signedIn) return `${mark(false)} ${auth.note ?? 'not signed in'}`;
-  const until = auth.tokenExpiresAt ? ` (token valid until ${auth.tokenExpiresAt})` : '';
+  const until = expiryInFuture(auth.tokenExpiresAt)
+    ? ` (token valid until ${auth.tokenExpiresAt})`
+    : ' (session active)';
   return `${mark(true)} signed in${until}`;
 };
 

--- a/src/commands/status/status.ts
+++ b/src/commands/status/status.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
 import { type Command } from 'commander';
-import { isDaemonRunning, resolvePort } from '../../daemon/lifecycle.js';
 import { readAuth } from '../../lib/fs/config.js';
-import { health, mismatchNotice } from '../../lib/daemon/daemon-client.js';
 import { siteFqdn } from '../../lib/net/origins.js';
-import { gatherStatus, type StatusReport } from '../../lib/status/status-info.js';
+import { formatUptime } from '../../lib/status/format.js';
+import {
+  gatherStatus,
+  type DaemonStatus,
+  type StatusReport,
+} from '../../lib/status/status-info.js';
 import { INSTALL_HINT, type UpdateInfo } from '../../lib/update/update-check.js';
 
 const mark = (good: boolean): string => (good ? chalk.green('✓') : chalk.red('✗'));
@@ -32,6 +35,38 @@ const updateLine = (update: UpdateInfo): string => {
   }
 };
 
+const daemonLine = (d: DaemonStatus, cliVersion: string): string => {
+  if (!d.running) return `${mark(false)} stopped - run: agentage daemon start`;
+  const up = d.uptimeSeconds !== undefined ? `, up ${formatUptime(d.uptimeSeconds)}` : '';
+  const stale =
+    d.daemonVersion && d.daemonVersion !== cliVersion
+      ? chalk.yellow(` (version ${d.daemonVersion} != cli ${cliVersion})`)
+      : '';
+  return `${mark(true)} running (pid ${d.pid ?? '?'}, port ${d.port}${up})${stale}`;
+};
+
+const mcpLine = (d: DaemonStatus): string =>
+  d.mcp ? `${mark(true)} serving at http://127.0.0.1:${d.port}/mcp` : `${mark(false)} off`;
+
+const syncLine = (sync: NonNullable<DaemonStatus['sync']>): string => {
+  if (sync.state === 'syncing') return `${chalk.yellow('⋯')} syncing`;
+  if (sync.state === 'error') {
+    const short = (sync.lastError ?? 'sync failed').split('\n')[0]?.slice(0, 60);
+    return `${mark(false)} error (${short})`;
+  }
+  const at = sync.lastRun ? ` (last ok ${sync.lastRun})` : '';
+  return `${mark(true)} ${sync.vaults} vaults${at}`;
+};
+
+// Daemon rows honor version-mismatch inline (appended to the daemon row), mcp only when running,
+// and omit the sync row when the daemon is down or serves no vaults.
+const printDaemon = (d: DaemonStatus, cliVersion: string): void => {
+  row('daemon', daemonLine(d, cliVersion));
+  if (!d.running) return;
+  row('mcp', mcpLine(d));
+  if (d.sync) row('sync', syncLine(d.sync));
+};
+
 export const printStatus = (report: StatusReport): void => {
   row('version', report.version);
   row('update', updateLine(report.update));
@@ -42,17 +77,8 @@ export const printStatus = (report: StatusReport): void => {
     `${mark(report.endpoint.reachable)} ${report.endpoint.url} ` +
       (report.endpoint.reachable ? 'reachable' : 'unreachable')
   );
+  if (report.daemon) printDaemon(report.daemon, report.version);
   if (report.update.message) console.log(chalk.yellow(`\n${report.update.message}`));
-};
-
-// Warn only about a daemon this config dir owns (a live pidfile) so `status` never probes an
-// unrelated daemon; the hint tells the user to restart it after a CLI upgrade.
-const warnDaemonMismatch = async (): Promise<void> => {
-  if (!isDaemonRunning()) return;
-  const h = await health(resolvePort());
-  if (!h) return;
-  const notice = mismatchNotice(h.version);
-  if (notice) console.error(chalk.yellow(notice)); // diagnostics go to stderr
 };
 
 export const runStatus = async (opts: { json?: boolean } = {}): Promise<void> => {
@@ -62,7 +88,6 @@ export const runStatus = async (opts: { json?: boolean } = {}): Promise<void> =>
     return;
   }
   printStatus(report);
-  await warnDaemonMismatch();
 };
 
 export const registerStatus = (program: Command): void => {

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -69,6 +69,18 @@ export const isProcessAlive = (pid: number): boolean => {
   }
 };
 
+// SIGTERM a known-live pid (a legacy daemon we learned about via /health, not our pidfile).
+// Returns whether the signal was delivered; false when the pid is already gone or unsignalable.
+export const signalPid = (pid: number): boolean => {
+  if (!isProcessAlive(pid)) return false;
+  try {
+    process.kill(pid, 'SIGTERM');
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 export const isDaemonRunning = (): boolean => {
   const pid = readPid();
   if (pid === null) return false;

--- a/src/lib/auth/api.test.ts
+++ b/src/lib/auth/api.test.ts
@@ -276,6 +276,27 @@ describe('introspectToken', () => {
     await expect(introspectToken(makeAuth(), target)).rejects.toThrow(AuthRequiredError);
   });
 
+  it('refreshes and re-introspects when the session reports an already-past expiry', async () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    const future = new Date(Date.now() + 3_600_000).toISOString();
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (String(url).includes('/token'))
+        return Promise.resolve(jsonResponse(200, { access_token: 'refreshed', expires_in: 3600 }));
+      const bearer = (init?.headers as Record<string, string> | undefined)?.['authorization'];
+      return Promise.resolve(
+        bearer === 'Bearer refreshed'
+          ? jsonResponse(200, { userId: 'u1', accessTokenExpiresAt: future })
+          : jsonResponse(200, { userId: 'u1', accessTokenExpiresAt: past })
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const auth = makeAuth();
+    const session = await introspectToken(auth, target);
+    // The displayed expiry must be the post-refresh future value, never the stale past one.
+    expect(session.expiresAt).toBe(future);
+    expect(Date.parse(session.expiresAt as string)).toBeGreaterThan(Date.now());
+  });
+
   it('refreshes proactively when the stored token is already past expiry', async () => {
     const fetchMock = vi.fn((url: string, init?: RequestInit) => {
       if (String(url).includes('/token'))

--- a/src/lib/auth/api.test.ts
+++ b/src/lib/auth/api.test.ts
@@ -220,7 +220,18 @@ describe('currentBearer', () => {
 });
 
 describe('introspectToken', () => {
-  afterEach(() => vi.unstubAllGlobals());
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'agentage-api-'));
+    process.env['AGENTAGE_CONFIG_DIR'] = dir;
+  });
+
+  afterEach(() => {
+    delete process.env['AGENTAGE_CONFIG_DIR'];
+    rmSync(dir, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+  });
 
   it('calls the introspection endpoint and maps the session', async () => {
     const fetchMock = vi
@@ -234,5 +245,51 @@ describe('introspectToken', () => {
     expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
       'https://auth.dev.agentage.io/api/auth/mcp/get-session'
     );
+  });
+
+  it('refreshes once on a 200 + null session, then re-introspects as signed in', async () => {
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (String(url).includes('/token'))
+        return Promise.resolve(jsonResponse(200, { access_token: 'new-token', expires_in: 60 }));
+      const bearer = (init?.headers as Record<string, string> | undefined)?.['authorization'];
+      return Promise.resolve(
+        bearer === 'Bearer new-token'
+          ? jsonResponse(200, { userId: 'u1', accessTokenExpiresAt: 'x' })
+          : jsonResponse(200, null)
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const auth = makeAuth();
+    const session = await introspectToken(auth, target);
+    expect(session.userId).toBe('u1');
+    expect(auth.tokens.accessToken).toBe('new-token');
+    expect(readAuth()?.tokens.accessToken).toBe('new-token');
+  });
+
+  it('throws AuthRequiredError when a 200 + null survives a failed refresh', async () => {
+    const fetchMock = vi.fn((url: string) =>
+      Promise.resolve(
+        String(url).includes('/token') ? jsonResponse(400, {}) : jsonResponse(200, null)
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(introspectToken(makeAuth(), target)).rejects.toThrow(AuthRequiredError);
+  });
+
+  it('refreshes proactively when the stored token is already past expiry', async () => {
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (String(url).includes('/token'))
+        return Promise.resolve(jsonResponse(200, { access_token: 'fresh', expires_in: 60 }));
+      const bearer = (init?.headers as Record<string, string> | undefined)?.['authorization'];
+      return Promise.resolve(
+        bearer === 'Bearer fresh' ? jsonResponse(200, { userId: 'u2' }) : jsonResponse(200, null)
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const auth = makeAuth({ expiresAt: Date.now() - 1000 });
+    const session = await introspectToken(auth, target);
+    expect(session.userId).toBe('u2');
+    const tokenCalls = fetchMock.mock.calls.filter((c) => String(c[0]).includes('/token'));
+    expect(tokenCalls).toHaveLength(1);
   });
 });

--- a/src/lib/auth/api.ts
+++ b/src/lib/auth/api.ts
@@ -99,13 +99,17 @@ export interface TokenSession {
 
 // The OAuth introspection endpoint: the only live surface that validates the
 // CLI's bearer token today (backend REST accepts session cookies only).
+// get-session answers 200 + null (not 401) for an expired/inactive session, so authedGet's
+// on-401 refresh never fires here. Mirror currentBearer: refresh proactively when the stored
+// token is past expiry, and reactively once when a 200 + null slips through, then re-introspect.
 export const introspectToken = async (auth: AuthState, links: Links): Promise<TokenSession> => {
-  const body = await authedGet<IntrospectionResponse | null>(
-    auth,
-    links,
-    `${links.auth}/api/auth/mcp/get-session`
-  );
-  // get-session returns 200 + null when the bearer maps to no active session.
+  const url = `${links.auth}/api/auth/mcp/get-session`;
+  const expired = auth.tokens.expiresAt !== undefined && auth.tokens.expiresAt <= Date.now();
+  if (expired && !(await tryRefresh(auth, links))) throw new AuthRequiredError('session expired');
+  let body = await authedGet<IntrospectionResponse | null>(auth, links, url);
+  if (!body && (await tryRefresh(auth, links))) {
+    body = await authedGet<IntrospectionResponse | null>(auth, links, url);
+  }
   if (!body) throw new AuthRequiredError('no active session');
   return { userId: body.userId, expiresAt: body.accessTokenExpiresAt };
 };

--- a/src/lib/auth/api.ts
+++ b/src/lib/auth/api.ts
@@ -97,19 +97,28 @@ export interface TokenSession {
   expiresAt?: string;
 }
 
+const isPast = (iso?: string): boolean => {
+  if (!iso) return false;
+  const t = Date.parse(iso);
+  return !Number.isNaN(t) && t <= Date.now();
+};
+
 // The OAuth introspection endpoint: the only live surface that validates the
 // CLI's bearer token today (backend REST accepts session cookies only).
 // get-session answers 200 + null (not 401) for an expired/inactive session, so authedGet's
 // on-401 refresh never fires here. Mirror currentBearer: refresh proactively when the stored
-// token is past expiry, and reactively once when a 200 + null slips through, then re-introspect.
+// token is past expiry, reactively once when a 200 + null slips through, and once more when the
+// returned session reports an already-past expiry - always re-introspect so the returned expiry
+// reflects the post-refresh token and a checkmark never sits next to a stale timestamp.
 export const introspectToken = async (auth: AuthState, links: Links): Promise<TokenSession> => {
   const url = `${links.auth}/api/auth/mcp/get-session`;
+  const get = (): Promise<IntrospectionResponse | null> =>
+    authedGet<IntrospectionResponse | null>(auth, links, url);
   const expired = auth.tokens.expiresAt !== undefined && auth.tokens.expiresAt <= Date.now();
   if (expired && !(await tryRefresh(auth, links))) throw new AuthRequiredError('session expired');
-  let body = await authedGet<IntrospectionResponse | null>(auth, links, url);
-  if (!body && (await tryRefresh(auth, links))) {
-    body = await authedGet<IntrospectionResponse | null>(auth, links, url);
-  }
+  let body = await get();
+  const stale = !body || isPast(body.accessTokenExpiresAt);
+  if (stale && (await tryRefresh(auth, links))) body = await get();
   if (!body) throw new AuthRequiredError('no active session');
   return { userId: body.userId, expiresAt: body.accessTokenExpiresAt };
 };

--- a/src/lib/status/format.test.ts
+++ b/src/lib/status/format.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { formatUptime } from './format.js';
+
+describe('formatUptime', () => {
+  it('renders sub-minute uptimes in seconds', () => {
+    expect(formatUptime(5)).toBe('5s');
+    expect(formatUptime(59)).toBe('59s');
+  });
+
+  it('renders minutes and seconds under an hour', () => {
+    expect(formatUptime(90)).toBe('1m 30s');
+  });
+
+  it('renders hours and minutes past an hour, dropping seconds', () => {
+    expect(formatUptime(3720)).toBe('1h 2m');
+  });
+
+  it('clamps negatives to zero', () => {
+    expect(formatUptime(-10)).toBe('0s');
+  });
+});

--- a/src/lib/status/format.ts
+++ b/src/lib/status/format.ts
@@ -1,0 +1,10 @@
+// Compact "Hh Mm" / "Mm Ss" uptime, matching the daemon and status rows. Seconds only under a
+// minute; hours dropped once zero so short-lived daemons read cleanly.
+export const formatUptime = (seconds: number): string => {
+  const s = Math.max(0, Math.floor(seconds));
+  if (s < 60) return `${s}s`;
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m ${s % 60}s`;
+};

--- a/src/lib/status/status-info.test.ts
+++ b/src/lib/status/status-info.test.ts
@@ -199,6 +199,18 @@ describe('gatherStatus daemon probe', () => {
     expect(report.daemon?.sync?.lastError).toBe('push rejected');
   });
 
+  it('classifies a legacy 0.0.3 daemon (health lacks mcp/pid/uptime) as running', async () => {
+    // No pidfile written: a legacy daemon that never wrote this config dir's pidfile.
+    stubDaemon({ ok: true, version: '0.0.3' }, { vaults: [] });
+    const report = await gatherStatus(null, 'dev.agentage.io');
+    expect(report.daemon?.running).toBe(true);
+    expect(report.daemon?.daemonVersion).toBe('0.0.3');
+    expect(report.daemon?.pid).toBeUndefined();
+    expect(report.daemon?.uptimeSeconds).toBeUndefined();
+    // Absent mcp on a legacy daemon reads as serving (on), not off.
+    expect(report.daemon?.mcp).toBe(true);
+  });
+
   it('omits the sync summary when the daemon serves no vaults', async () => {
     bootPidFiles();
     stubDaemon(
@@ -210,8 +222,18 @@ describe('gatherStatus daemon probe', () => {
     expect(report.daemon?.sync).toBeUndefined();
   });
 
-  it('reports stopped when the pidfile is present but /health is unreachable', async () => {
+  it('still reports running from a live pidfile when /health is briefly unreachable', async () => {
     bootPidFiles();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new Error('ECONNREFUSED')))
+    );
+    process.env['AGENTAGE_DAEMON_PORT'] = String(port);
+    const report = await gatherStatus(null, 'dev.agentage.io');
+    expect(report.daemon?.running).toBe(true);
+  });
+
+  it('reports stopped when no pidfile and /health is refused', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(() => Promise.reject(new Error('ECONNREFUSED')))

--- a/src/lib/status/status-info.test.ts
+++ b/src/lib/status/status-info.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type AuthState } from '../fs/config.js';
 import { fetchJsonUnref } from '../net/http.js';
@@ -9,7 +12,7 @@ const httpMock = vi.mocked(fetchJsonUnref);
 const auth: AuthState = {
   siteFqdn: 'dev.agentage.io',
   clientId: 'c1',
-  tokens: { accessToken: 'at' },
+  tokens: { accessToken: 'at', refreshToken: 'rt' },
 };
 
 const jsonResponse = (status: number, body: unknown): Response =>
@@ -27,9 +30,17 @@ const stubHttp = (health: 'reachable' | 'unreachable'): void => {
   });
 };
 
-beforeEach(() => stubHttp('reachable'));
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'agentage-status-'));
+  process.env['AGENTAGE_CONFIG_DIR'] = dir;
+  stubHttp('reachable');
+});
 
 afterEach(() => {
+  delete process.env['AGENTAGE_CONFIG_DIR'];
+  rmSync(dir, { recursive: true, force: true });
   httpMock.mockReset();
   vi.unstubAllGlobals();
 });
@@ -61,21 +72,47 @@ describe('gatherStatus', () => {
     expect(report.auth).toEqual({ signedIn: true, tokenExpiresAt: '2026-06-12T20:00:00Z' });
   });
 
-  it('treats a 200 + null session as signed-out instead of crashing', async () => {
+  it('refreshes on a 200 + null session and reports signed-in', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => jsonResponse(200, null))
+      vi.fn((url: string, init?: RequestInit) => {
+        if (String(url).includes('/token'))
+          return Promise.resolve(jsonResponse(200, { access_token: 'new', expires_in: 60 }));
+        const bearer = (init?.headers as Record<string, string> | undefined)?.['authorization'];
+        return Promise.resolve(
+          bearer === 'Bearer new'
+            ? jsonResponse(200, { userId: 'u1', accessTokenExpiresAt: 'x' })
+            : jsonResponse(200, null)
+        );
+      })
+    );
+    const report = await gatherStatus(auth, 'dev.agentage.io');
+    expect(report.auth.signedIn).toBe(true);
+    expect(report.auth.note).toBeUndefined();
+  });
+
+  it('reports session expired when the 200 + null refresh fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) =>
+        Promise.resolve(
+          String(url).includes('/token') ? jsonResponse(400, {}) : jsonResponse(200, null)
+        )
+      )
     );
     const report = await gatherStatus(auth, 'dev.agentage.io');
     expect(report.auth.signedIn).toBe(false);
-    expect(report.auth.note).toContain('agentage setup');
-    expect(report.auth.note).not.toContain('Cannot read properties');
+    expect(report.auth.note).toBe('session expired - run: agentage setup');
   });
 
   it('downgrades to signed-out with a hint when the token is rejected', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => jsonResponse(401, {}))
+      vi.fn((url: string) =>
+        Promise.resolve(
+          String(url).includes('/token') ? jsonResponse(400, {}) : jsonResponse(401, {})
+        )
+      )
     );
     const report = await gatherStatus(auth, 'dev.agentage.io');
     expect(report.auth.signedIn).toBe(false);
@@ -90,5 +127,97 @@ describe('gatherStatus', () => {
     const report = await gatherStatus(auth, 'dev.agentage.io');
     expect(report.auth.signedIn).toBe(false);
     expect(report.auth.note).toContain('could not verify session');
+  });
+
+  it('reports the daemon as stopped when no pidfile is present', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse(200, null))
+    );
+    const report = await gatherStatus(null, 'dev.agentage.io');
+    expect(report.daemon).toEqual({ running: false, port: 4243 });
+  });
+});
+
+// Simulate a running daemon: our own live pid + port on disk, plus a fetch stub answering the
+// daemon's /api/health and /api/sync/status. Exercises probeDaemon + summarizeSync end to end.
+describe('gatherStatus daemon probe', () => {
+  const port = 4271;
+
+  const bootPidFiles = (): void => {
+    writeFileSync(join(dir, 'daemon.pid'), String(process.pid), 'utf-8');
+    writeFileSync(join(dir, 'daemon.port'), String(port), 'utf-8');
+  };
+
+  const stubDaemon = (health: unknown, sync: unknown): void => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) => {
+        if (String(url).includes('/api/health')) return Promise.resolve(jsonResponse(200, health));
+        if (String(url).includes('/api/sync/status'))
+          return Promise.resolve(jsonResponse(200, sync));
+        return Promise.resolve(jsonResponse(200, null));
+      })
+    );
+    process.env['AGENTAGE_DAEMON_PORT'] = String(port);
+  };
+
+  afterEach(() => delete process.env['AGENTAGE_DAEMON_PORT']);
+
+  it('reports pid, uptime, mcp on, and an ok sync summary', async () => {
+    bootPidFiles();
+    stubDaemon(
+      { ok: true, version: '9.9.9', pid: process.pid, uptime: 42, served: 0, mcp: true },
+      { vaults: [{ vault: 'a', running: false, lastRun: '2026-07-08T10:00:00Z' }] }
+    );
+    const report = await gatherStatus(null, 'dev.agentage.io');
+    expect(report.daemon?.running).toBe(true);
+    expect(report.daemon?.uptimeSeconds).toBe(42);
+    expect(report.daemon?.mcp).toBe(true);
+    expect(report.daemon?.daemonVersion).toBe('9.9.9');
+    expect(report.daemon?.sync).toEqual({
+      vaults: 1,
+      state: 'ok',
+      lastRun: '2026-07-08T10:00:00Z',
+      lastError: undefined,
+    });
+  });
+
+  it('marks mcp off and folds an error across git + couch vaults', async () => {
+    bootPidFiles();
+    stubDaemon(
+      { ok: true, version: '9.9.9', pid: process.pid, uptime: 5, served: 0, mcp: false },
+      {
+        vaults: [{ vault: 'a', running: true, lastRun: '2026-07-08T09:00:00Z' }],
+        couch: [{ vault: 'b', running: false, lastError: 'push rejected', pendingCount: 0 }],
+      }
+    );
+    const report = await gatherStatus(null, 'dev.agentage.io');
+    expect(report.daemon?.mcp).toBe(false);
+    expect(report.daemon?.sync?.vaults).toBe(2);
+    expect(report.daemon?.sync?.state).toBe('error');
+    expect(report.daemon?.sync?.lastError).toBe('push rejected');
+  });
+
+  it('omits the sync summary when the daemon serves no vaults', async () => {
+    bootPidFiles();
+    stubDaemon(
+      { ok: true, version: '9.9.9', pid: process.pid, uptime: 5, served: 0, mcp: true },
+      { vaults: [] }
+    );
+    const report = await gatherStatus(null, 'dev.agentage.io');
+    expect(report.daemon?.running).toBe(true);
+    expect(report.daemon?.sync).toBeUndefined();
+  });
+
+  it('reports stopped when the pidfile is present but /health is unreachable', async () => {
+    bootPidFiles();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new Error('ECONNREFUSED')))
+    );
+    process.env['AGENTAGE_DAEMON_PORT'] = String(port);
+    const report = await gatherStatus(null, 'dev.agentage.io');
+    expect(report.daemon?.running).toBe(false);
   });
 });

--- a/src/lib/status/status-info.ts
+++ b/src/lib/status/status-info.ts
@@ -46,8 +46,8 @@ const checkEndpoint = async (apiUrl: string): Promise<boolean> => {
 // Fold the git + couch per-vault states into one summary: any error wins, then any in-flight
 // run, else ok. lastRun is the freshest reported; lastError the first seen.
 const summarizeSync = (sync: SyncStatus): DaemonSyncSummary => {
-  const git = sync.vaults;
-  const couch = sync.couch ?? [];
+  const git = Array.isArray(sync.vaults) ? sync.vaults : [];
+  const couch = Array.isArray(sync.couch) ? sync.couch : [];
   const vaults = git.length + couch.length;
   const error =
     git.find((v) => v.lastError)?.lastError ?? couch.find((v) => v.lastError)?.lastError;
@@ -60,13 +60,15 @@ const summarizeSync = (sync: SyncStatus): DaemonSyncSummary => {
   return { vaults, state, lastRun, lastError: error };
 };
 
-// Probe the local daemon only when its pidfile says it is running, so a stopped daemon costs no
-// network and never hangs `status`. All fields ride the existing /health + /sync wire.
+// One detection routine shared with `daemon start`: a health 200 (any shape, even a legacy 0.0.3
+// daemon lacking mcp/pid/uptime) OR a live pidfile means running; only a refused/no-response
+// health with no live pidfile is stopped. Probe health regardless of the pidfile so a legacy
+// daemon that never wrote this config dir's pidfile is not misreported as stopped. A stopped
+// daemon still costs only one 1s-timeout /health that fast-fails on connection refused.
 const probeDaemon = async (): Promise<DaemonStatus> => {
   const port = resolvePort();
-  if (!isDaemonRunning()) return { running: false, port };
   const h = await health(port);
-  if (!h) return { running: false, port };
+  if (!h) return { running: isDaemonRunning(), port };
   const sync = await syncStatus(port);
   const summary = sync ? summarizeSync(sync) : undefined;
   return {
@@ -74,6 +76,7 @@ const probeDaemon = async (): Promise<DaemonStatus> => {
     pid: h.pid,
     port,
     uptimeSeconds: h.uptime,
+    // Absent on a legacy daemon that predates the /mcp gate; treat undefined as serving (on).
     mcp: h.mcp !== false,
     daemonVersion: h.version,
     sync: summary && summary.vaults > 0 ? summary : undefined,

--- a/src/lib/status/status-info.ts
+++ b/src/lib/status/status-info.ts
@@ -1,9 +1,30 @@
 import { AuthRequiredError, introspectToken } from '../auth/api.js';
 import { type AuthState } from '../fs/config.js';
+import { health, syncStatus } from '../daemon/daemon-client.js';
 import { fetchJsonUnref } from '../net/http.js';
 import { environment, links, type Env } from '../net/origins.js';
 import { checkForUpdate, type UpdateInfo } from '../update/update-check.js';
 import { VERSION } from '../../utils/version.js';
+import { isDaemonRunning, resolvePort } from '../../daemon/lifecycle.js';
+import { type SyncStatus } from '../../sync/git/manager.js';
+
+export interface DaemonSyncSummary {
+  vaults: number;
+  state: 'ok' | 'error' | 'syncing';
+  lastRun?: string;
+  lastError?: string;
+}
+
+export interface DaemonStatus {
+  running: boolean;
+  pid?: number;
+  port: number;
+  uptimeSeconds?: number;
+  mcp?: boolean;
+  // The running daemon's own version, so the printer can flag a stale binary inline.
+  daemonVersion?: string;
+  sync?: DaemonSyncSummary;
+}
 
 export interface StatusReport {
   version: string;
@@ -12,6 +33,7 @@ export interface StatusReport {
   auth: { signedIn: boolean; tokenExpiresAt?: string; note?: string };
   endpoint: { url: string; reachable: boolean };
   update: UpdateInfo;
+  daemon?: DaemonStatus;
 }
 
 // node:https via fetchJsonUnref, not global fetch: undici's ref'd connect timer keeps the process
@@ -21,13 +43,51 @@ const checkEndpoint = async (apiUrl: string): Promise<boolean> => {
   return res?.ok ?? false;
 };
 
+// Fold the git + couch per-vault states into one summary: any error wins, then any in-flight
+// run, else ok. lastRun is the freshest reported; lastError the first seen.
+const summarizeSync = (sync: SyncStatus): DaemonSyncSummary => {
+  const git = sync.vaults;
+  const couch = sync.couch ?? [];
+  const vaults = git.length + couch.length;
+  const error =
+    git.find((v) => v.lastError)?.lastError ?? couch.find((v) => v.lastError)?.lastError;
+  const running = git.some((v) => v.running) || couch.some((v) => v.running);
+  const state: DaemonSyncSummary['state'] = error ? 'error' : running ? 'syncing' : 'ok';
+  const runs = [...git.map((v) => v.lastRun), ...couch.map((v) => v.lastSync)].filter(
+    (r): r is string => Boolean(r)
+  );
+  const lastRun = runs.sort().at(-1);
+  return { vaults, state, lastRun, lastError: error };
+};
+
+// Probe the local daemon only when its pidfile says it is running, so a stopped daemon costs no
+// network and never hangs `status`. All fields ride the existing /health + /sync wire.
+const probeDaemon = async (): Promise<DaemonStatus> => {
+  const port = resolvePort();
+  if (!isDaemonRunning()) return { running: false, port };
+  const h = await health(port);
+  if (!h) return { running: false, port };
+  const sync = await syncStatus(port);
+  const summary = sync ? summarizeSync(sync) : undefined;
+  return {
+    running: true,
+    pid: h.pid,
+    port,
+    uptimeSeconds: h.uptime,
+    mcp: h.mcp !== false,
+    daemonVersion: h.version,
+    sync: summary && summary.vaults > 0 ? summary : undefined,
+  };
+};
+
 export const gatherStatus = async (auth: AuthState | null, fqdn: string): Promise<StatusReport> => {
   const target = links(fqdn);
   // Endpoint reachability and the (npm-registry) update check are independent - run them
   // together so `status` stays snappy.
-  const [reachable, update] = await Promise.all([
+  const [reachable, update, daemon] = await Promise.all([
     checkEndpoint(target.api),
     checkForUpdate(VERSION),
+    probeDaemon(),
   ]);
   const report: StatusReport = {
     version: VERSION,
@@ -36,6 +96,7 @@ export const gatherStatus = async (auth: AuthState | null, fqdn: string): Promis
     auth: { signedIn: false, note: 'not signed in - run: agentage setup' },
     endpoint: { url: target.api, reachable },
     update,
+    daemon,
   };
   if (!auth) return report;
   try {


### PR DESCRIPTION
## What

Two related fixes so `agentage status` tells the full local truth.

### 1. Transparent token refresh (bug)

`introspectToken` calls `authedGet(<auth>/api/auth/mcp/get-session)`, but that endpoint answers **200 + null** (not 401) for an expired/inactive session, so `authedGet`'s on-401 refresh never fired. A user with a still-refreshable token was shown as signed-out.

Fix, kept in the auth layer so every command inherits it: refresh proactively when the stored `expiresAt` is past, and reactively once when a 200 + null slips through, then re-introspect. `AuthRequiredError` only when the retry is still null / refresh fails. Mirrors the existing `currentBearer` pattern.

### 2. daemon / mcp / sync rows in `agentage status`

`StatusReport` gains an additive `daemon` field. `gatherStatus` probes the local daemon **only when its pidfile says it is running** (stopped daemon costs no network, no hang), reading the existing `/health` + `/api/sync/status` wire - no new endpoints. Sync summary folds git + couch vaults (any error -> error, any running -> syncing, else ok).

## Before / after

Before (daemon running, but no rows):
```
version    0.0.3
target     dev.agentage.io (development)
auth       not signed in - run: agentage setup
endpoint   https://api.dev.agentage.io/api reachable
```

After, daemon stopped:
```
daemon     stopped - run: agentage daemon start
```

After, daemon running (mcp on):
```
daemon     running (pid 3442882, port 4299, up 1s)
mcp        serving at http://127.0.0.1:4299/mcp
```

After, `daemon start --no-mcp`:
```
daemon     running (pid 3443201, port 4299, up 1s)
mcp        off
```

Sync row (rendered only when vaults > 0): `sync <n> vaults (last ok <ts>)` / `syncing` / `error (<short>)`. Version-mismatch folded inline: `running (... ) (version 0.24.0 != cli 0.25.0)`.

### 3. Follow-up fixes (second commit)

Two bugs surfaced by running against a real box with a legacy 0.0.3 daemon on port 4243:

- **Detection contradiction.** `daemon start` said "already running" while `status` said "stopped". `status` gated on this config dir's pidfile *before* probing `/health`, so a legacy daemon that never wrote that pidfile was misreported as stopped. Now `status` and `daemon start` share one gate: a `/health` 200 (any shape) **or** a live pidfile = running; only a refused/no-response `/health` with no pidfile = stopped. A legacy `/health` lacking `mcp`/`pid`/`uptime` renders `running (pid ?, port 4243)` + mcp on + the version-mismatch note. Root cause: pidfile-first short-circuit skipped the health probe.
- **Stale token expiry.** The auth line printed a past `token valid until` next to a checkmark. `introspectToken` returned the pre-refresh session expiry (and did not refresh when the *server* reported a past `accessTokenExpiresAt` even though the client-stored expiry looked fine). Now: if the returned session's expiry is already past, refresh once and re-introspect, so the displayed expiry is always the post-refresh value. Root cause: displayed `tokenExpiresAt` came from a session whose expiry was already in the past.

### 4. Second live round (third commit)

More coexistence bugs against the same running legacy 0.0.3 daemon:

- **`daemon stop` said "not running" while `daemon start` said "already running".** `stopAction` gated solely on this config dir's pidfile, which the legacy daemon never wrote. Now `stop` detects the same way `start` does (tokenless `/health`): with a pidfile we own, the safe pid-confirming stop; otherwise signal the pid `/health` reports (`SIGTERM`); and if a live daemon has no pid we can signal, report the truth (`daemon is running (pid X) but has no pidfile to stop it safely; stop it with: kill X`, exit 1) rather than a false "not running". `daemon status` got the same health-first gate. Root cause: pidfile-only detection in `stop`/`status` diverged from `start`'s health probe.
- **Token expiry still stale.** Even after the refresh logic, a live session whose access-token expiry is genuinely past (and cannot be refreshed) would print a past `token valid until` next to the checkmark. Added a truthful-display backstop: the auth line only shows `token valid until <ts>` when `<ts>` is in the future; otherwise it shows `signed in (session active)`. Root cause: the displayed value was the access-token `expiresAt`, which can legitimately be in the past while the session stays active server-side; a checkmark must never sit next to a past timestamp.

Live-verified: with a legacy daemon (partial `/health`, no pidfile), `daemon status` + `status` show running, and `daemon stop` SIGTERMs the reported pid (process confirmed terminated).

## Verify

- `npm run verify` green (439 tests, coverage gate passes).
- Manual four-state smoke (isolated config dir + port): stopped / start / `--no-mcp` / stop - all exit 0, no hang.
- **Legacy 0.0.3 daemon coexistence covered:** live smoke against a fake daemon returning a partial `{ok, version}` health (no pidfile/token) renders `daemon running (pid ?, port ...)` + `mcp serving`, not stopped. Unit test asserts the same from a minimal legacy health payload.
- `status --json` daemon field additive; auth/endpoint/fqdn/env/version shapes unchanged (e2e `statusJson` helper reads only those).

Root-cause note: get-session returns 200 + null for an expired session, which bypassed `authedGet`'s 401-only refresh.
