### PR TITLE
feat: start the daemon after a successful setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "@agentage/memory-core": "^0.3.2",
         "@agentage/server-memory": "^0.0.3",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "chalk": "latest",
-        "commander": "latest",
-        "open": "latest"
+        "chalk": "^5.6.2",
+        "commander": "^14.0.3",
+        "open": "^11.0.0"
       },
       "bin": {
         "agentage": "dist/cli.js"

--- a/src/commands/auth/setup.test.ts
+++ b/src/commands/auth/setup.test.ts
@@ -28,6 +28,7 @@ const makeDeps = () => {
     startServer: vi.fn().mockResolvedValue(server),
     openBrowser: vi.fn().mockResolvedValue(undefined),
     printStatus: vi.fn().mockResolvedValue(undefined),
+    ensureDaemon: vi.fn().mockResolvedValue({}),
   };
   return { deps, server, close };
 };
@@ -45,6 +46,7 @@ describe('runSetup', () => {
   afterEach(() => {
     delete process.env['AGENTAGE_CONFIG_DIR'];
     delete process.env['AGENTAGE_SITE_FQDN'];
+    delete process.env['AGENTAGE_NO_DAEMON'];
     rmSync(dir, { recursive: true, force: true });
     vi.restoreAllMocks();
   });
@@ -64,6 +66,27 @@ describe('runSetup', () => {
     expect(auth?.siteFqdn).toBe('dev.agentage.io');
     expect(close).toHaveBeenCalled();
     expect(deps.printStatus).toHaveBeenCalled();
+  });
+
+  it('starts the daemon once on the successful sign-in path', async () => {
+    const { deps } = makeDeps();
+    await runSetup({}, deps);
+    expect(deps.ensureDaemon).toHaveBeenCalledOnce();
+  });
+
+  it('does not start the daemon on --disconnect', async () => {
+    saveAuth(existingAuth);
+    const { deps } = makeDeps();
+    await runSetup({ disconnect: true }, deps);
+    expect(deps.ensureDaemon).not.toHaveBeenCalled();
+  });
+
+  it('does not start the daemon when AGENTAGE_NO_DAEMON is set', async () => {
+    process.env['AGENTAGE_NO_DAEMON'] = '1';
+    const { deps } = makeDeps();
+    await runSetup({}, deps);
+    expect(deps.ensureDaemon).not.toHaveBeenCalled();
+    expect(readAuth()?.tokens.accessToken).toBe('at-1');
   });
 
   it('passes the authorize url with the registered client to the browser', async () => {

--- a/src/commands/auth/setup.ts
+++ b/src/commands/auth/setup.ts
@@ -1,6 +1,8 @@
 import chalk from 'chalk';
 import { type Command } from 'commander';
 import { startCallbackServer } from '../../lib/auth/callback-server.js';
+import { ensureDaemon } from '../../lib/daemon/daemon-client.js';
+import { daemonDisabled } from '../../lib/daemon/daemon-pref.js';
 import {
   deleteAuth,
   ensureConfigDir,
@@ -34,6 +36,7 @@ export interface SetupDeps {
   startServer: typeof startCallbackServer;
   openBrowser: (url: string) => Promise<void>;
   printStatus: () => Promise<void>;
+  ensureDaemon: typeof ensureDaemon;
 }
 
 const defaultDeps: SetupDeps = {
@@ -46,6 +49,7 @@ const defaultDeps: SetupDeps = {
     await open(url);
   },
   printStatus: () => runStatus({}),
+  ensureDaemon,
 };
 
 const toAuthState = (fqdn: string, clientId: string, tokens: TokenResponse): AuthState => ({
@@ -57,6 +61,19 @@ const toAuthState = (fqdn: string, clientId: string, tokens: TokenResponse): Aut
     expiresAt: tokens.expires_in ? Date.now() + tokens.expires_in * 1000 : undefined,
   },
 });
+
+// After sign-in, bring the daemon up so account sync starts immediately; ensureDaemon reuses a
+// live daemon and starts a stopped one (idempotent). Honor the --no-daemon / AGENTAGE_NO_DAEMON
+// disable switches.
+const startDaemon = async (deps: SetupDeps): Promise<void> => {
+  if (daemonDisabled()) {
+    console.log('Daemon disabled - account sync will run in-process on demand.');
+    return;
+  }
+  const client = await deps.ensureDaemon();
+  const fail = 'Could not start the daemon - run: agentage daemon start';
+  console.log(client ? 'Daemon running.' : fail);
+};
 
 const disconnect = async (deps: SetupDeps): Promise<void> => {
   const auth = readAuth();
@@ -115,6 +132,7 @@ export const runSetup = async (
     });
     await mutateAuth(() => toAuthState(fqdn, clientId, tokens));
     console.log(chalk.green('\nSigned in.\n'));
+    await startDaemon(deps);
     await deps.printStatus();
   } finally {
     server.close();


### PR DESCRIPTION
## What changed

After `agentage setup` completes a sign-in, the daemon is now started so account sync begins immediately and the next `agentage status` shows daemon/mcp/sync as healthy. Previously setup signed in but left the daemon stopped (it only autostarted lazily on the first memory verb).

The success path (`src/commands/auth/setup.ts`, after credentials are saved) calls the same `ensureDaemon()` the memory verbs use, via a new `startDaemon` helper and a mockable `ensureDaemon` dep on `SetupDeps`. `ensureDaemon` is idempotent: it reuses a live daemon (no restart) and starts a stopped one (detached), returning a client or null. Version-mismatch handling is unchanged (it already lives inside `ensureDaemon`).

Output lines match the existing no-emoji tone:
- daemon started or reused -> `Daemon running.`
- spawn failed -> `Could not start the daemon - run: agentage daemon start`
- disabled -> `Daemon disabled - account sync will run in-process on demand.`

## Disable-switch behavior

- `--no-daemon` / `AGENTAGE_NO_DAEMON=1` (`daemonDisabled()`): short-circuits, does NOT start the daemon, prints the one-line disabled note.
- `--disconnect` (sign-out): returns before the sign-in flow, never reaches `startDaemon`.
- Only the successful sign-in path starts the daemon. `--no-browser` still reaches it (it is a normal sign-in).

## Test coverage

New unit tests beside `setup.ts`:
- success path calls `ensureDaemon` exactly once
- `--disconnect` does NOT call `ensureDaemon`
- `AGENTAGE_NO_DAEMON=1` short-circuits (no `ensureDaemon` call) while auth is still persisted

`npm run verify` green (type-check + e2e type-check + lint + prettier + 442 tests + build).

Smoke (isolated `AGENTAGE_CONFIG_DIR`): `node dist/cli.js setup --disconnect` -> "Nothing to disconnect." (no daemon touched); `node dist/cli.js --no-daemon status` -> clean. A real OAuth sign-in cannot be driven headless, so the daemon-start line is unit-verified (mocked `ensureDaemon`) and needs a real login to confirm end-to-end.

## Observation (not implemented) - status auth line shows UTC absolute expiry

The status auth line renders `token valid until <ISO-Z>` in UTC. For a user in CEST near midnight this reads as "yesterday" even when the token is valid ~1h into the future (UTC-vs-local confusion).

Findings:
- The expiry shown is `accessTokenExpiresAt` from the OAuth introspection endpoint (`/api/auth/mcp/get-session`), surfaced via `introspectToken` -> `report.auth.tokenExpiresAt` -> `authLine` in `status.ts`. It is the ACCESS-token expiry, not the session lifetime.
- Access tokens are short-lived. Fresh-login TTL in the token exchange is `expires_in` seconds (see `toAuthState`); the CLI refreshes proactively when past expiry. Practically this is a short window (roughly minutes-to-an-hour class), which makes an absolute timestamp both noisy and easy to misread. `status.ts` already downgrades a past/unrefreshable expiry to `(session active)`.

Proposed display (owner to pick, not implemented here):
1. Relative: `signed in (token expires in 47m)` - clearest, no timezone ambiguity, honest about the short TTL.
2. Local time: `signed in (token valid until 01:12 local)` - fixes the UTC confusion but still exposes a short-lived, noisy absolute time.
3. Drop the token time entirely: `signed in (session active)` - introspection already proves the session is live server-side; the access-token expiry is an implementation detail the user rarely needs.

Recommendation: option 3 (or option 1 if a countdown is desired). The access token is refreshed automatically, so its exact expiry is low-value to surface; showing it invites the "why does it say yesterday" confusion for little benefit.
