### PR TITLE
feat: drop noisy UTC expiry from status auth line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "@agentage/memory-core": "^0.3.2",
         "@agentage/server-memory": "^0.0.3",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "chalk": "latest",
-        "commander": "latest",
-        "open": "latest"
+        "chalk": "^5.6.2",
+        "commander": "^14.0.3",
+        "open": "^11.0.0"
       },
       "bin": {
         "agentage": "dist/cli.js"

--- a/src/commands/status/status.test.ts
+++ b/src/commands/status/status.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { type StatusReport } from '../../lib/status/status-info.js';
 import { printStatus } from './status.js';
 
-// A future expiry so the truthful-display guard (past expiry -> "session active") does not rot.
+// A future expiry proves the report can carry it while the human line still ignores it.
 const futureExpiry = new Date(Date.now() + 3_600_000).toISOString();
 
 const baseReport: StatusReport = {
@@ -29,18 +29,19 @@ describe('printStatus', () => {
     const out = captureLines(baseReport);
     expect(out).toContain('0.25.0');
     expect(out).toContain('agentage.io (production)');
-    expect(out).toContain('signed in');
-    expect(out).toContain(futureExpiry);
+    expect(out).toContain('signed in (session active)');
     expect(out).toContain('reachable');
   });
 
-  it('shows a future token expiry verbatim next to the checkmark', () => {
+  it('shows session active for a future-expiry session, never the timestamp', () => {
     const future = new Date(Date.now() + 3_600_000).toISOString();
     const out = captureLines({ ...baseReport, auth: { signedIn: true, tokenExpiresAt: future } });
-    expect(out).toContain(`token valid until ${future}`);
+    expect(out).toContain('signed in (session active)');
+    expect(out).not.toContain(future);
+    expect(out).not.toContain('token valid until');
   });
 
-  it('never prints a past token expiry next to the signed-in checkmark', () => {
+  it('shows session active for a past-expiry session, never the timestamp', () => {
     const past = new Date(Date.now() - 60_000).toISOString();
     const out = captureLines({ ...baseReport, auth: { signedIn: true, tokenExpiresAt: past } });
     expect(out).not.toContain(past);

--- a/src/commands/status/status.ts
+++ b/src/commands/status/status.ts
@@ -16,21 +16,12 @@ const row = (label: string, value: string): void => {
   console.log(`${label.padEnd(10)} ${value}`);
 };
 
-// Never print a past timestamp next to the signed-in checkmark: introspection proved the session
-// is active server-side, so a stale/past access-token expiry we could not refresh becomes a plain
-// "signed in (session active)" rather than a contradictory past "valid until".
-const expiryInFuture = (iso?: string): boolean => {
-  if (!iso) return false;
-  const t = Date.parse(iso);
-  return !Number.isNaN(t) && t > Date.now();
-};
-
+// The signed-in line never shows an absolute expiry: it is the short-lived, auto-refreshed
+// access-token expiry, which misreads as "yesterday" near midnight in positive-UTC zones.
+// Introspection already proved the session is active server-side.
 const authLine = (auth: StatusReport['auth']): string => {
   if (!auth.signedIn) return `${mark(false)} ${auth.note ?? 'not signed in'}`;
-  const until = expiryInFuture(auth.tokenExpiresAt)
-    ? ` (token valid until ${auth.tokenExpiresAt})`
-    : ' (session active)';
-  return `${mark(true)} signed in${until}`;
+  return `${mark(true)} signed in (session active)`;
 };
 
 const updateLine = (update: UpdateInfo): string => {


### PR DESCRIPTION
## What

The `agentage status` auth line no longer prints an absolute UTC timestamp for a signed-in session.

**Before:**
```
auth       ✓ signed in (token valid until 2026-07-08T23:50:53.133Z)
```

**After:**
```
auth       ✓ signed in (session active)
```

## Why

The timestamp was the short-lived, auto-refreshed access-token expiry, not the session lifetime. For users in positive-UTC timezones near midnight it misreads as "yesterday", implying the session is stale when introspection has already proven it active server-side. Owner decision: always show `(session active)` for a valid session and drop the timestamp from the human line.

## Notes

- `tokenExpiresAt` is kept on the JSON report (`status --json`) - only the rendered human line changed.
- The not-signed-in and expired literals e2e greps (`not signed in - run: agentage setup`, `session expired - run: agentage setup`) are untouched.
- Dead `expiryInFuture` helper removed (had no other callers).
- Unit tests updated: former `token valid until` cases now assert `session active`; a future-expiry session is proven to render `session active` with no timestamp.
