### PR TITLE
feat: enrich status with target reachability and per-vault sync

### DIFF
--- a/src/commands/status/status.test.ts
+++ b/src/commands/status/status.test.ts
@@ -9,9 +9,11 @@ const baseReport: StatusReport = {
   version: '0.25.0',
   fqdn: 'agentage.io',
   env: 'production',
+  target: { fqdn: 'agentage.io', env: 'production', reachable: true },
   auth: { signedIn: true, tokenExpiresAt: futureExpiry },
   endpoint: { url: 'https://agentage.io/api', reachable: true },
   update: { status: { kind: 'current' }, message: null },
+  vaults: [],
 };
 
 const captureLines = (report: StatusReport): string => {
@@ -31,6 +33,20 @@ describe('printStatus', () => {
     expect(out).toContain('agentage.io (production)');
     expect(out).toContain('signed in (session active)');
     expect(out).toContain('reachable');
+  });
+
+  it('marks the target line reachable with a check when the site is up', () => {
+    const out = captureLines(baseReport);
+    expect(out).toMatch(/target\s+\S+ agentage\.io \(production\)/);
+    expect(out).not.toContain('agentage.io (production) - unreachable');
+  });
+
+  it('marks the target line unreachable with a cross when the site is down', () => {
+    const out = captureLines({
+      ...baseReport,
+      target: { fqdn: 'agentage.io', env: 'production', reachable: false },
+    });
+    expect(out).toContain('agentage.io (production) - unreachable');
   });
 
   it('shows session active for a future-expiry session, never the timestamp', () => {
@@ -112,39 +128,62 @@ describe('printStatus', () => {
     expect(out).toMatch(/mcp\s+\S+ off/);
   });
 
-  it('renders a sync ok row with the vault count and last-run', () => {
+  it('renders a per-vault block with name, channel, and status', () => {
     const out = captureLines({
       ...baseReport,
-      daemon: {
-        running: true,
-        port: 4243,
-        mcp: true,
-        sync: { vaults: 3, state: 'ok', lastRun: '2026-07-08T10:00:00Z' },
-      },
+      daemon: { running: true, port: 4243, mcp: true },
+      vaults: [
+        { name: 'notes', channel: 'cloud', status: 'ok', lastRun: '2026-07-08T18:40:00Z' },
+        { name: 'work', channel: 'git', status: 'error', lastError: 'auth failed\ndetail' },
+      ],
     });
-    expect(out).toContain('3 vaults');
-    expect(out).toContain('last ok 2026-07-08T10:00:00Z');
+    expect(out).toMatch(/vaults\s+2 connected/);
+    expect(out).toMatch(/notes\s+cloud\s+\S+ last ok/);
+    expect(out).toMatch(/work\s+git\s+\S+ error \(auth failed\)/);
   });
 
-  it('renders a sync error row with a short last error', () => {
+  it('renders a syncing vault while a cycle is in flight', () => {
     const out = captureLines({
       ...baseReport,
-      daemon: {
-        running: true,
-        port: 4243,
-        mcp: true,
-        sync: { vaults: 1, state: 'error', lastError: 'push rejected\nmore detail here' },
-      },
+      daemon: { running: true, port: 4243, mcp: true },
+      vaults: [{ name: 'work', channel: 'git', status: 'syncing' }],
     });
-    expect(out).toMatch(/sync\s+\S+ error \(push rejected\)/);
+    expect(out).toMatch(/work\s+git\s+\S+ syncing/);
   });
 
-  it('renders a syncing row while a cycle is in flight', () => {
+  it('marks a local-only vault as idle, not connected, with a singular count', () => {
     const out = captureLines({
       ...baseReport,
-      daemon: { running: true, port: 4243, mcp: true, sync: { vaults: 2, state: 'syncing' } },
+      vaults: [{ name: 'scratch', channel: 'local', status: 'idle' }],
     });
-    expect(out).toContain('syncing');
+    expect(out).toMatch(/vaults\s+1 vault\b/);
+    expect(out).not.toContain('1 vaults');
+    expect(out).toMatch(/scratch\s+local\s+.*local only/);
+  });
+
+  it('pluralizes the count for multiple local-only vaults', () => {
+    const out = captureLines({
+      ...baseReport,
+      vaults: [
+        { name: 'a', channel: 'local', status: 'idle' },
+        { name: 'b', channel: 'local', status: 'idle' },
+      ],
+    });
+    expect(out).toMatch(/vaults\s+2 vaults\b/);
+  });
+
+  it('lists configured vaults as unknown when the daemon is stopped', () => {
+    const out = captureLines({
+      ...baseReport,
+      daemon: { running: false, port: 4243 },
+      vaults: [{ name: 'notes', channel: 'cloud', status: 'unknown' }],
+    });
+    expect(out).toMatch(/notes\s+cloud\s+.*unknown \(daemon stopped\)/);
+  });
+
+  it('prints an actionable hint when there are zero vaults', () => {
+    const out = captureLines({ ...baseReport, vaults: [] });
+    expect(out).toMatch(/vaults\s+none - run: agentage vault add/);
   });
 
   it('renders a legacy daemon row (no pid/uptime) as running with a version note', () => {

--- a/src/commands/status/status.ts
+++ b/src/commands/status/status.ts
@@ -8,6 +8,7 @@ import {
   type DaemonStatus,
   type StatusReport,
 } from '../../lib/status/status-info.js';
+import { vaultLines } from '../../lib/status/vaults-format.js';
 import { INSTALL_HINT, type UpdateInfo } from '../../lib/update/update-check.js';
 
 const mark = (good: boolean): string => (good ? chalk.green('✓') : chalk.red('✗'));
@@ -50,29 +51,20 @@ const daemonLine = (d: DaemonStatus, cliVersion: string): string => {
 const mcpLine = (d: DaemonStatus): string =>
   d.mcp ? `${mark(true)} serving at http://127.0.0.1:${d.port}/mcp` : `${mark(false)} off`;
 
-const syncLine = (sync: NonNullable<DaemonStatus['sync']>): string => {
-  if (sync.state === 'syncing') return `${chalk.yellow('⋯')} syncing`;
-  if (sync.state === 'error') {
-    const short = (sync.lastError ?? 'sync failed').split('\n')[0]?.slice(0, 60);
-    return `${mark(false)} error (${short})`;
-  }
-  const at = sync.lastRun ? ` (last ok ${sync.lastRun})` : '';
-  return `${mark(true)} ${sync.vaults} vaults${at}`;
-};
-
-// Daemon rows honor version-mismatch inline (appended to the daemon row), mcp only when running,
-// and omit the sync row when the daemon is down or serves no vaults.
+// Daemon rows honor version-mismatch inline (appended to the daemon row) and print mcp only when
+// running; the per-vault sync breakdown now lives in its own `vaults` block (printStatus).
 const printDaemon = (d: DaemonStatus, cliVersion: string): void => {
   row('daemon', daemonLine(d, cliVersion));
   if (!d.running) return;
   row('mcp', mcpLine(d));
-  if (d.sync) row('sync', syncLine(d.sync));
 };
 
 export const printStatus = (report: StatusReport): void => {
   row('version', report.version);
   row('update', updateLine(report.update));
-  row('target', `${report.fqdn} (${report.env})`);
+  const t = report.target;
+  const targetSuffix = t.reachable ? '' : ' - unreachable';
+  row('target', `${mark(t.reachable)} ${t.fqdn} (${t.env})${targetSuffix}`);
   row('auth', authLine(report.auth));
   row(
     'endpoint',
@@ -80,6 +72,7 @@ export const printStatus = (report: StatusReport): void => {
       (report.endpoint.reachable ? 'reachable' : 'unreachable')
   );
   if (report.daemon) printDaemon(report.daemon, report.version);
+  for (const line of vaultLines(report.vaults)) console.log(line);
   if (report.update.message) console.log(chalk.yellow(`\n${report.update.message}`));
 };
 

--- a/src/lib/status/status-info.test.ts
+++ b/src/lib/status/status-info.test.ts
@@ -18,15 +18,17 @@ const auth: AuthState = {
 const jsonResponse = (status: number, body: unknown): Response =>
   new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
 
-// health + the npm-registry update check go through fetchJsonUnref (node:https); introspection
-// (get-session) still uses global fetch via authedGet.
+// health, the site-root reachability probe, and the npm-registry update check all go through
+// fetchJsonUnref (node:https); introspection (get-session) still uses global fetch via authedGet.
+// The site probe hits the bare origin (no /health, no /latest) and counts any non-null response.
 const stubHttp = (health: 'reachable' | 'unreachable'): void => {
   httpMock.mockImplementation((url: string) => {
     if (url.endsWith('/latest'))
       return Promise.resolve({ ok: true, status: 200, json: { version: '0.0.0' } });
     if (url.endsWith('/health'))
       return Promise.resolve(health === 'reachable' ? { ok: true, status: 200, json: {} } : null);
-    return Promise.resolve(null);
+    // Site root: a 4xx still proves the host is up, so mirror it as a non-null response.
+    return Promise.resolve(health === 'reachable' ? { ok: false, status: 404, json: null } : null);
   });
 };
 
@@ -52,13 +54,28 @@ describe('gatherStatus', () => {
     expect(report.auth.signedIn).toBe(false);
     expect(report.auth.note).toContain('agentage setup');
     expect(report.endpoint.reachable).toBe(true);
+    expect(report.target).toEqual({ fqdn: 'dev.agentage.io', env: 'development', reachable: true });
     expect(report.version).toMatch(/^\d+\.\d+\.\d+/);
   });
 
-  it('marks the endpoint unreachable on network failure', async () => {
+  it('marks the endpoint and target unreachable on network failure', async () => {
     stubHttp('unreachable');
     const report = await gatherStatus(null, 'agentage.io');
     expect(report.endpoint.reachable).toBe(false);
+    expect(report.target.reachable).toBe(false);
+  });
+
+  it('treats a non-2xx site response as a reachable target', async () => {
+    // A 4xx from the site root still proves the host is up: reachability, not app health.
+    httpMock.mockImplementation((url: string) =>
+      Promise.resolve(
+        url.endsWith('/health') || url.endsWith('/latest')
+          ? { ok: true, status: 200, json: {} }
+          : { ok: false, status: 403, json: null }
+      )
+    );
+    const report = await gatherStatus(null, 'agentage.io');
+    expect(report.target.reachable).toBe(true);
   });
 
   it('reports signed-in with token expiry when introspection succeeds', async () => {

--- a/src/lib/status/status-info.ts
+++ b/src/lib/status/status-info.ts
@@ -7,6 +7,7 @@ import { checkForUpdate, type UpdateInfo } from '../update/update-check.js';
 import { VERSION } from '../../utils/version.js';
 import { isDaemonRunning, resolvePort } from '../../daemon/lifecycle.js';
 import { type SyncStatus } from '../../sync/git/manager.js';
+import { buildVaultStatuses, type VaultStatus } from './vaults-status.js';
 
 export interface DaemonSyncSummary {
   vaults: number;
@@ -30,10 +31,12 @@ export interface StatusReport {
   version: string;
   fqdn: string;
   env: Env;
+  target: { fqdn: string; env: Env; reachable: boolean };
   auth: { signedIn: boolean; tokenExpiresAt?: string; note?: string };
   endpoint: { url: string; reachable: boolean };
   update: UpdateInfo;
   daemon?: DaemonStatus;
+  vaults: VaultStatus[];
 }
 
 // node:https via fetchJsonUnref, not global fetch: undici's ref'd connect timer keeps the process
@@ -41,6 +44,13 @@ export interface StatusReport {
 const checkEndpoint = async (apiUrl: string): Promise<boolean> => {
   const res = await fetchJsonUnref(`${apiUrl}/health`, 3000);
   return res?.ok ?? false;
+};
+
+// Host reachability, not app health: the site root answers any HTTP status (200/3xx/4xx) when the
+// host is up, so any non-null response counts as reachable; only a refused/timed-out connect fails.
+const checkSite = async (siteUrl: string): Promise<boolean> => {
+  const res = await fetchJsonUnref(siteUrl, 3000);
+  return res !== null;
 };
 
 // Fold the git + couch per-vault states into one summary: any error wins, then any in-flight
@@ -65,13 +75,19 @@ const summarizeSync = (sync: SyncStatus): DaemonSyncSummary => {
 // health with no live pidfile is stopped. Probe health regardless of the pidfile so a legacy
 // daemon that never wrote this config dir's pidfile is not misreported as stopped. A stopped
 // daemon still costs only one 1s-timeout /health that fast-fails on connection refused.
-const probeDaemon = async (): Promise<DaemonStatus> => {
+interface DaemonProbe {
+  status: DaemonStatus;
+  // The raw per-vault sync report, kept so the caller can build the full vaults breakdown.
+  sync: SyncStatus | null;
+}
+
+const probeDaemon = async (): Promise<DaemonProbe> => {
   const port = resolvePort();
   const h = await health(port);
-  if (!h) return { running: isDaemonRunning(), port };
+  if (!h) return { status: { running: isDaemonRunning(), port }, sync: null };
   const sync = await syncStatus(port);
   const summary = sync ? summarizeSync(sync) : undefined;
-  return {
+  const status: DaemonStatus = {
     running: true,
     pid: h.pid,
     port,
@@ -81,25 +97,30 @@ const probeDaemon = async (): Promise<DaemonStatus> => {
     daemonVersion: h.version,
     sync: summary && summary.vaults > 0 ? summary : undefined,
   };
+  return { status, sync };
 };
 
 export const gatherStatus = async (auth: AuthState | null, fqdn: string): Promise<StatusReport> => {
   const target = links(fqdn);
   // Endpoint reachability and the (npm-registry) update check are independent - run them
   // together so `status` stays snappy.
-  const [reachable, update, daemon] = await Promise.all([
+  const env = environment(fqdn);
+  const [reachable, siteReachable, update, probe] = await Promise.all([
     checkEndpoint(target.api),
+    checkSite(target.site),
     checkForUpdate(VERSION),
     probeDaemon(),
   ]);
   const report: StatusReport = {
     version: VERSION,
     fqdn,
-    env: environment(fqdn),
+    env,
+    target: { fqdn, env, reachable: siteReachable },
     auth: { signedIn: false, note: 'not signed in - run: agentage setup' },
     endpoint: { url: target.api, reachable },
     update,
-    daemon,
+    daemon: probe.status,
+    vaults: buildVaultStatuses(probe.sync, probe.status.running),
   };
   if (!auth) return report;
   try {

--- a/src/lib/status/vaults-format.ts
+++ b/src/lib/status/vaults-format.ts
@@ -1,0 +1,52 @@
+import chalk from 'chalk';
+import { type VaultStatus } from './vaults-status.js';
+
+const mark = (good: boolean): string => (good ? chalk.green('✓') : chalk.red('✗'));
+
+// HH:MM in local time; a malformed timestamp falls back to the raw string so we never crash.
+const shortTime = (iso?: string): string => {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime())
+    ? iso
+    : `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+};
+
+const shortError = (err?: string): string =>
+  (err ?? 'sync failed').split('\n')[0]?.slice(0, 40) ?? 'sync failed';
+
+// One right-hand status cell per vault, sharing the check/cross marks with the other status rows.
+const statusCell = (v: VaultStatus): string => {
+  switch (v.status) {
+    case 'ok':
+      return `${mark(true)} last ok ${shortTime(v.lastRun)}`.trimEnd();
+    case 'syncing':
+      return `${chalk.yellow('⋯')} syncing`;
+    case 'error':
+      return `${mark(false)} error (${shortError(v.lastError)})`;
+    case 'unknown':
+      return chalk.dim('- unknown (daemon stopped)');
+    case 'idle':
+      return v.channel === 'local' ? chalk.dim('- local only') : chalk.dim('- idle');
+  }
+};
+
+const countLabel = (vaults: VaultStatus[]): string => {
+  const connected = vaults.filter((v) => v.channel !== 'local').length;
+  if (connected > 0) return `${connected} connected`;
+  const n = vaults.length;
+  return `${n} ${n === 1 ? 'vault' : 'vaults'}`;
+};
+
+// The `vaults` block: a header count line then one aligned `<name> <channel> <status>` row per vault.
+// Zero vaults prints a single actionable hint instead of an empty block.
+export const vaultLines = (vaults: VaultStatus[]): string[] => {
+  if (vaults.length === 0)
+    return [`${'vaults'.padEnd(10)} none - run: agentage vault add <name> --local`];
+  const nameW = Math.max(...vaults.map((v) => v.name.length));
+  const header = `${'vaults'.padEnd(10)} ${countLabel(vaults)}`;
+  const rows = vaults.map(
+    (v) => `  ${v.name.padEnd(nameW)}  ${v.channel.padEnd(6)} ${statusCell(v)}`
+  );
+  return [header, ...rows];
+};

--- a/src/lib/status/vaults-status.test.ts
+++ b/src/lib/status/vaults-status.test.ts
@@ -1,0 +1,100 @@
+import { type VaultsConfig } from '@agentage/memory-core';
+import { describe, expect, it } from 'vitest';
+import { type SyncStatus } from '../../sync/git/manager.js';
+import { buildVaultStatuses } from './vaults-status.js';
+
+const config = (vaults: VaultsConfig['vaults']): VaultsConfig => ({ version: 1, vaults });
+
+const emptySync: SyncStatus = { vaults: [] };
+
+describe('buildVaultStatuses channel classification', () => {
+  it('classifies an agentage-origin vault as cloud', () => {
+    const [v] = buildVaultStatuses(
+      emptySync,
+      true,
+      config({ notes: { path: '~/notes', origin: [{ remote: 'agentage' }] } })
+    );
+    expect(v?.channel).toBe('cloud');
+  });
+
+  it('classifies an external-remote vault as git', () => {
+    const [v] = buildVaultStatuses(
+      emptySync,
+      true,
+      config({ work: { path: '~/work', origin: [{ remote: 'https://git.example/x.git' }] } })
+    );
+    expect(v?.channel).toBe('git');
+  });
+
+  it('classifies an origin-less vault as local', () => {
+    const [v] = buildVaultStatuses(emptySync, true, config({ scratch: { path: '~/s' } }));
+    expect(v?.channel).toBe('local');
+  });
+});
+
+describe('buildVaultStatuses status states', () => {
+  const gitVault = config({ work: { path: '~/work', origin: [{ remote: 'https://g/x.git' }] } });
+
+  it('reports ok when the daemon has a last run and no error', () => {
+    const sync: SyncStatus = {
+      vaults: [{ vault: 'work', remote: 'r', intervalSeconds: 60, running: false, lastRun: 't' }],
+    };
+    expect(buildVaultStatuses(sync, true, gitVault)[0]?.status).toBe('ok');
+  });
+
+  it('reports error when the daemon reports a last error', () => {
+    const sync: SyncStatus = {
+      vaults: [
+        { vault: 'work', remote: 'r', intervalSeconds: 60, running: false, lastError: 'boom' },
+      ],
+    };
+    const [v] = buildVaultStatuses(sync, true, gitVault);
+    expect(v?.status).toBe('error');
+    expect(v?.lastError).toBe('boom');
+  });
+
+  it('reports syncing when a cycle is running', () => {
+    const sync: SyncStatus = {
+      vaults: [{ vault: 'work', remote: 'r', intervalSeconds: 60, running: true }],
+    };
+    expect(buildVaultStatuses(sync, true, gitVault)[0]?.status).toBe('syncing');
+  });
+
+  it('reports idle for a local-only vault even with the daemon up', () => {
+    expect(buildVaultStatuses(emptySync, true, config({ s: { path: '~/s' } }))[0]?.status).toBe(
+      'idle'
+    );
+  });
+
+  it('reports unknown for a synced vault when the daemon is down', () => {
+    expect(buildVaultStatuses(null, false, gitVault)[0]?.status).toBe('unknown');
+  });
+
+  it('folds couch-channel state (lastSync) into the cloud vault', () => {
+    const sync: SyncStatus = {
+      vaults: [],
+      couch: [
+        {
+          vault: 'notes',
+          channel: 'couch',
+          intervalSeconds: 60,
+          running: false,
+          lastSync: '2026-07-08T18:40:00Z',
+          pendingCount: 0,
+        },
+      ],
+    };
+    const [v] = buildVaultStatuses(
+      sync,
+      true,
+      config({ notes: { path: '~/n', origin: [{ remote: 'agentage' }] } })
+    );
+    expect(v?.channel).toBe('cloud');
+    expect(v?.status).toBe('ok');
+    expect(v?.lastRun).toBe('2026-07-08T18:40:00Z');
+  });
+
+  it('returns an empty array when no vaults are configured', () => {
+    expect(buildVaultStatuses(emptySync, true, config({}))).toEqual([]);
+  });
+});

--- a/src/lib/status/vaults-status.ts
+++ b/src/lib/status/vaults-status.ts
@@ -1,0 +1,73 @@
+import { isAccountVault, type VaultEntry, type VaultsConfig } from '@agentage/memory-core';
+import { loadVaultsConfig } from '../vault/vaults.js';
+import { type SyncStatus } from '../../sync/git/manager.js';
+
+export type VaultChannel = 'local' | 'git' | 'cloud';
+export type VaultSyncState = 'ok' | 'syncing' | 'error' | 'idle' | 'unknown';
+
+export interface VaultStatus {
+  name: string;
+  channel: VaultChannel;
+  status: VaultSyncState;
+  lastRun?: string;
+  lastError?: string;
+}
+
+// Config alone decides the channel: an `agentage` origin is the cloud (couch) channel, any other
+// origin is an external git remote, and no origin at all is a local-only vault (nothing to sync).
+const channelOf = (entry: VaultEntry): VaultChannel => {
+  if (isAccountVault(entry)) return 'cloud';
+  return entry.origin?.some((o) => o.remote.trim() && o.remote.trim() !== 'agentage')
+    ? 'git'
+    : 'local';
+};
+
+// Live state from the daemon wins; a local-only vault is `idle` (nothing to sync), and any synced
+// vault with no daemon report is `unknown` (daemon down or the vault not yet scheduled).
+const stateFrom = (
+  channel: VaultChannel,
+  live: { running?: boolean; lastError?: string; lastRun?: string } | undefined,
+  daemonUp: boolean
+): VaultSyncState => {
+  if (channel === 'local') return 'idle';
+  if (!daemonUp) return 'unknown';
+  if (!live) return 'unknown';
+  if (live.lastError) return 'error';
+  if (live.running) return 'syncing';
+  return live.lastRun ? 'ok' : 'idle';
+};
+
+// Index the daemon's per-vault reports by name across both channels into one lookup.
+const indexLive = (
+  sync: SyncStatus | null
+): Map<string, { running?: boolean; lastError?: string; lastRun?: string }> => {
+  const map = new Map<string, { running?: boolean; lastError?: string; lastRun?: string }>();
+  for (const v of sync?.vaults ?? [])
+    map.set(v.vault, { running: v.running, lastError: v.lastError, lastRun: v.lastRun });
+  for (const c of sync?.couch ?? [])
+    map.set(c.vault, { running: c.running, lastError: c.lastError, lastRun: c.lastSync });
+  return map;
+};
+
+// The full per-vault picture: every configured vault (so local-only vaults are never hidden),
+// classified by channel and annotated with the daemon's live sync state when available.
+export const buildVaultStatuses = (
+  sync: SyncStatus | null,
+  daemonUp: boolean,
+  config: VaultsConfig = loadVaultsConfig().config
+): VaultStatus[] => {
+  const live = indexLive(sync);
+  return Object.entries(config.vaults ?? {})
+    .map(([name, entry]): VaultStatus => {
+      const channel = channelOf(entry);
+      const l = live.get(name);
+      return {
+        name,
+        channel,
+        status: stateFrom(channel, l, daemonUp),
+        lastRun: l?.lastRun,
+        lastError: l?.lastError,
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+};


### PR DESCRIPTION
## What

Two additions to `agentage status`, both surfaced in the human table and additively in `--json`.

### 1. Target line reachability mark

The `target` row was the only line without a check/cross. It now carries one, mirroring `endpoint`.

Before / after (reachable):
```
target     agentage.io (production)
target     ✓ agentage.io (production)
```
Before / after (unreachable):
```
target     agentage.io (production)
target     ✗ agentage.io (production) - unreachable
```

**Probed URL:** the SITE root (`links(fqdn).site`, e.g. `https://agentage.io`) - NOT the API host. The `endpoint` row already checks `api.<fqdn>/health`; `target` checks the site the FQDN names. We treat **any HTTP response (2xx / 3xx / 4xx) as reachable** because this is host reachability, not app health - a 403/404 from the origin still proves the host is up. Only a refused/timed-out connect is `unreachable`. The probe reuses `fetchJsonUnref` (node:https, unref'd timer, 3s cap) - the same discipline as `checkEndpoint`, so `status` never hangs on a dead network.

### 2. Per-vault sync breakdown

Replaces the single-line `sync` summary with a per-vault block: each vault's **name**, **channel** ("sync way"), and **status**.

Channel is classified from `vaults.json` config (so local-only vaults are never hidden):
- `cloud` - agentage account vault (`agentage` origin, the couch channel)
- `git` - external git remote origin
- `local` - no origin, nothing to sync

Status merges the daemon's live `GET /api/sync/status` (git `vaults[]` + `couch[]`) per vault: `ok` / `syncing` / `error (reason)` / `idle` (local) / `unknown (daemon stopped)`.

**Daemon UP:**
```
vaults     3 connected
  notes    cloud  ✓ last ok 20:40
  work     git    ✗ error (auth failed)
  scratch  local  - local only
  docs     git    ⋯ syncing
```
**Daemon DOWN** (still lists every configured vault, does not hide them):
```
vaults     2 connected
  notes    cloud  - unknown (daemon stopped)
  scratch  local  - local only
  work     git    - unknown (daemon stopped)
```
**Zero vaults:**
```
vaults     none - run: agentage vault add <name> --local
```

## Parallelism

The new site probe runs inside the existing `Promise.all` alongside `checkEndpoint`, the update check, and the daemon probe - no added series latency. The per-vault build reuses the sync report already fetched by the daemon probe (no extra round trip).

## JSON

`status --json` gains `target: { fqdn, env, reachable }` and `vaults: [{ name, channel, status, lastRun?, lastError? }]`. All existing fields (`version`, `fqdn`, `env`, `auth`, `endpoint`, `update`, `daemon`) keep identical shapes; e2e helpers read those unchanged.

## e2e offline behavior

Offline the site is unreachable, so `target` shows `✗ ... - unreachable` and every configured vault shows `unknown (daemon stopped)`. The command still exits 0, prints the setup hint, and never throws - `e2e/status.test.ts` (`@offline`) greps `not signed in - run: agentage setup` and asserts no stack trace, both still hold. No e2e edit needed (nothing asserted the old markless target line).

## Layout

Extracted `src/lib/status/vaults-status.ts` (channel + state classifier) and `src/lib/status/vaults-format.ts` (renderer) to keep every file < 200 lines and functions < 20.

## Tests

- status-info: target reachable / unreachable / non-2xx-still-reachable.
- vaults-status: each channel (cloud/git/local), each state (ok/syncing/error/idle/unknown), couch lastSync fold, empty config.
- status printer: target check/cross lines; vaults block name+channel+status; syncing; local-idle; daemon-down unknown; zero-vaults hint.
- `npm run verify` green (457 tests). Smoked the built CLI for daemon-down (offline, exits 0, no hang) and daemon-up rendering.
