### PR TITLE
feat: send cli and daemon version headers on requests

### DIFF
--- a/src/lib/auth/api.test.ts
+++ b/src/lib/auth/api.test.ts
@@ -5,8 +5,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { authedGet, authedPost, AuthRequiredError, currentBearer, introspectToken } from './api.js';
 import { readAuth, type AuthState } from '../fs/config.js';
 import { links } from '../net/origins.js';
+import { VERSION } from '../../utils/version.js';
 
 const target = links('dev.agentage.io');
+
+// The CLI version headers requestHeaders() adds to every authed request.
+const versionHeaders = {
+  'User-Agent': `agentage-cli/${VERSION}`,
+  'X-Agentage-CLI-Version': VERSION,
+  'X-Agentage-Daemon-Version': 'none',
+};
 
 const makeAuth = (overrides: Partial<AuthState['tokens']> = {}): AuthState => ({
   siteFqdn: 'dev.agentage.io',
@@ -37,9 +45,19 @@ describe('authedGet', () => {
     const result = await authedGet<{ ok: boolean }>(makeAuth(), target, 'https://x.example/me');
     expect(result.ok).toBe(true);
     expect(fetchMock).toHaveBeenCalledWith('https://x.example/me', {
-      headers: { authorization: 'Bearer old-token' },
+      headers: { authorization: 'Bearer old-token', ...versionHeaders },
       redirect: 'manual',
     });
+  });
+
+  it('sends the CLI version identification headers alongside the bearer', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, {}));
+    vi.stubGlobal('fetch', fetchMock);
+    await authedGet(makeAuth(), target, 'https://x.example/me');
+    const headers = (fetchMock.mock.calls[0]?.[1] as RequestInit).headers as Record<string, string>;
+    expect(headers['User-Agent']).toBe(`agentage-cli/${VERSION}`);
+    expect(headers['X-Agentage-CLI-Version']).toBe(VERSION);
+    expect(headers['X-Agentage-Daemon-Version']).toBe('none');
   });
 
   it('refreshes once on 401, persists the new tokens, and retries', async () => {
@@ -88,7 +106,7 @@ describe('authedGet', () => {
       'refused redirect (302)'
     );
     expect(fetchMock).toHaveBeenCalledWith('https://x.example/me', {
-      headers: { authorization: 'Bearer old-token' },
+      headers: { authorization: 'Bearer old-token', ...versionHeaders },
       redirect: 'manual',
     });
   });
@@ -118,7 +136,11 @@ describe('authedPost', () => {
     expect(res.status).toBe(201);
     expect(fetchMock).toHaveBeenCalledWith('https://x.example/api/memories', {
       method: 'POST',
-      headers: { authorization: 'Bearer old-token', 'content-type': 'application/json' },
+      headers: {
+        authorization: 'Bearer old-token',
+        'content-type': 'application/json',
+        ...versionHeaders,
+      },
       body: JSON.stringify({ name: 'acct', channel: 'couch' }),
       redirect: 'manual',
     });

--- a/src/lib/auth/api.ts
+++ b/src/lib/auth/api.ts
@@ -1,6 +1,10 @@
 import { mutateAuth, type AuthState, type StoredTokens } from '../fs/config.js';
 import { refreshTokens } from './oauth.js';
 import { type Links } from '../net/origins.js';
+import { requestHeaders } from '../net/user-agent.js';
+
+// Every authed call is CLI-originated; identify the caller alongside the bearer.
+const cliHeaders = (): Record<string, string> => requestHeaders({ component: 'cli' });
 
 export class AuthRequiredError extends Error {
   constructor(message = 'not signed in') {
@@ -53,7 +57,7 @@ const isRedirect = (res: Response): boolean =>
 export const authedGet = async <T>(auth: AuthState, links: Links, url: string): Promise<T> => {
   const call = (): Promise<Response> =>
     fetch(url, {
-      headers: { authorization: `Bearer ${auth.tokens.accessToken}` },
+      headers: { authorization: `Bearer ${auth.tokens.accessToken}`, ...cliHeaders() },
       redirect: 'manual',
     });
   let res = await call();
@@ -78,6 +82,7 @@ export const authedPost = async (
       headers: {
         authorization: `Bearer ${auth.tokens.accessToken}`,
         'content-type': 'application/json',
+        ...cliHeaders(),
       },
       body: JSON.stringify(body),
       redirect: 'manual',

--- a/src/lib/auth/oauth.ts
+++ b/src/lib/auth/oauth.ts
@@ -1,4 +1,8 @@
 import { createHash, randomBytes } from 'node:crypto';
+import { requestHeaders } from '../net/user-agent.js';
+
+// OAuth register/token/revoke are all CLI-originated; identify the caller on each.
+const cliHeaders = (): Record<string, string> => requestHeaders({ component: 'cli' });
 
 export interface PkcePair {
   verifier: string;
@@ -31,7 +35,7 @@ export const randomState = (): string => randomBytes(16).toString('base64url');
 export const registerClient = async (authUrl: string, redirectUri: string): Promise<string> => {
   const res = await fetch(`${authUrl}${REGISTER_PATH}`, {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', ...cliHeaders() },
     body: JSON.stringify({
       client_name: 'agentage CLI',
       redirect_uris: [redirectUri],
@@ -70,7 +74,7 @@ export const buildAuthorizeUrl = (
 const postForm = async (url: string, form: Record<string, string>): Promise<TokenResponse> => {
   const res = await fetch(url, {
     method: 'POST',
-    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    headers: { 'content-type': 'application/x-www-form-urlencoded', ...cliHeaders() },
     body: new URLSearchParams(form).toString(),
   });
   if (!res.ok) throw new Error(`token request failed (${res.status})`);
@@ -110,7 +114,7 @@ export const revokeToken = async (
   try {
     await fetch(`${authUrl}${REVOKE_PATH}`, {
       method: 'POST',
-      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      headers: { 'content-type': 'application/x-www-form-urlencoded', ...cliHeaders() },
       body: new URLSearchParams({ token }).toString(),
       signal: AbortSignal.timeout(timeoutMs),
     });

--- a/src/lib/net/http.test.ts
+++ b/src/lib/net/http.test.ts
@@ -1,13 +1,55 @@
-import { describe, expect, it } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { OutgoingHttpHeaders } from 'node:http';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fetchJsonUnref } from './http.js';
 
+const mocks = vi.hoisted(() => ({ get: vi.fn() }));
+vi.mock('node:https', () => ({ get: mocks.get }));
+
 describe('fetchJsonUnref', () => {
+  afterEach(() => vi.restoreAllMocks());
+
   it('resolves null within the timeout bound on an unreachable host', async () => {
-    const started = Date.now();
-    // 192.0.2.1 (TEST-NET-1) either blackholes (the destroy timer fires) or refuses fast.
-    const result = await fetchJsonUnref('https://192.0.2.1/x', 500);
-    expect(result).toBeNull();
-    // Generous CI bound (timers stretch under load); still well under undici's ~10s floor.
-    expect(Date.now() - started).toBeLessThan(8000);
+    // The mocked get emits an immediate error so the unreachable path resolves null.
+    mocks.get.mockImplementation(() => {
+      const req = new EventEmitter() as EventEmitter & { destroy: () => void };
+      req.destroy = () => {};
+      queueMicrotask(() => req.emit('error', new Error('unreachable')));
+      return req;
+    });
+    await expect(fetchJsonUnref('https://192.0.2.1/x', 500)).resolves.toBeNull();
+  });
+
+  it('merges the supplied headers with the default Accept', async () => {
+    let captured: OutgoingHttpHeaders | undefined;
+    mocks.get.mockImplementation(
+      (_url: string, opts: { headers: OutgoingHttpHeaders }, cb: (res: EventEmitter) => void) => {
+        captured = opts.headers;
+        const res = new EventEmitter() as EventEmitter & {
+          setEncoding: () => void;
+          statusCode: number;
+        };
+        res.setEncoding = () => {};
+        res.statusCode = 200;
+        const req = new EventEmitter() as EventEmitter & { destroy: () => void };
+        req.destroy = () => {};
+        cb(res);
+        queueMicrotask(() => {
+          res.emit('data', '{"ok":true}');
+          res.emit('end');
+        });
+        return req;
+      }
+    );
+    const result = await fetchJsonUnref('https://x.example/x', 2000, {
+      'X-Agentage-CLI-Version': '9.9.9',
+      'User-Agent': 'agentage-cli/9.9.9',
+    });
+    expect(result).toEqual({ ok: true, status: 200, json: { ok: true } });
+    expect(captured).toMatchObject({
+      Accept: 'application/json',
+      'X-Agentage-CLI-Version': '9.9.9',
+      'User-Agent': 'agentage-cli/9.9.9',
+    });
   });
 });

--- a/src/lib/net/http.ts
+++ b/src/lib/net/http.ts
@@ -10,9 +10,13 @@ export interface UnrefResponse {
 // its AbortSignal fires, stalling process exit on an unreachable network. req.destroy() from an
 // unref'd timer caps the whole attempt and frees the event loop the moment it settles. Never
 // throws: an unreachable host or malformed body resolves null (unreachable) or json:null.
-export const fetchJsonUnref = (url: string, timeoutMs: number): Promise<UnrefResponse | null> =>
+export const fetchJsonUnref = (
+  url: string,
+  timeoutMs: number,
+  headers: Record<string, string> = {}
+): Promise<UnrefResponse | null> =>
   new Promise((resolve) => {
-    const req = get(url, { headers: { Accept: 'application/json' } }, (res) => {
+    const req = get(url, { headers: { Accept: 'application/json', ...headers } }, (res) => {
       let body = '';
       res.setEncoding('utf8');
       res.on('data', (chunk: string) => {

--- a/src/lib/net/user-agent.test.ts
+++ b/src/lib/net/user-agent.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { requestHeaders } from './user-agent.js';
+import { VERSION } from '../../utils/version.js';
+
+describe('requestHeaders', () => {
+  it('identifies a CLI request and reports the daemon version when present', () => {
+    const headers = requestHeaders({ component: 'cli', daemonVersion: '1.2.3' });
+    expect(headers['User-Agent']).toBe(`agentage-cli/${VERSION}`);
+    expect(headers['X-Agentage-CLI-Version']).toBe(VERSION);
+    expect(headers['X-Agentage-Daemon-Version']).toBe('1.2.3');
+  });
+
+  it('reports the daemon version as none on a CLI request when the daemon is stopped', () => {
+    const headers = requestHeaders({ component: 'cli' });
+    expect(headers['User-Agent']).toBe(`agentage-cli/${VERSION}`);
+    expect(headers['X-Agentage-Daemon-Version']).toBe('none');
+  });
+
+  it('identifies a daemon request and reports its own version for both fields', () => {
+    const headers = requestHeaders({ component: 'daemon' });
+    expect(headers['User-Agent']).toBe(`agentage-daemon/${VERSION}`);
+    expect(headers['X-Agentage-CLI-Version']).toBe(VERSION);
+    expect(headers['X-Agentage-Daemon-Version']).toBe(VERSION);
+  });
+});

--- a/src/lib/net/user-agent.ts
+++ b/src/lib/net/user-agent.ts
@@ -1,0 +1,17 @@
+import { VERSION } from '../../utils/version.js';
+
+export type RequestComponent = 'cli' | 'daemon';
+
+export interface RequestHeaderOptions {
+  component: RequestComponent;
+  // The local daemon's version from loopback /health; omitted or 'none' when stopped.
+  daemonVersion?: string;
+}
+
+// Identify the caller + versions so the server can observe which CLI + daemon connect.
+export const requestHeaders = (opts: RequestHeaderOptions): Record<string, string> => ({
+  'User-Agent': `agentage-${opts.component}/${VERSION}`,
+  'X-Agentage-CLI-Version': VERSION,
+  'X-Agentage-Daemon-Version':
+    opts.component === 'daemon' ? VERSION : (opts.daemonVersion ?? 'none'),
+});

--- a/src/lib/status/status-info.ts
+++ b/src/lib/status/status-info.ts
@@ -2,6 +2,7 @@ import { AuthRequiredError, introspectToken } from '../auth/api.js';
 import { type AuthState } from '../fs/config.js';
 import { health, syncStatus } from '../daemon/daemon-client.js';
 import { fetchJsonUnref } from '../net/http.js';
+import { requestHeaders } from '../net/user-agent.js';
 import { environment, links, type Env } from '../net/origins.js';
 import { checkForUpdate, type UpdateInfo } from '../update/update-check.js';
 import { VERSION } from '../../utils/version.js';
@@ -41,15 +42,15 @@ export interface StatusReport {
 
 // node:https via fetchJsonUnref, not global fetch: undici's ref'd connect timer keeps the process
 // alive ~10s after an aborted request on a packet-drop network, stalling `status` exit.
-const checkEndpoint = async (apiUrl: string): Promise<boolean> => {
-  const res = await fetchJsonUnref(`${apiUrl}/health`, 3000);
+const checkEndpoint = async (apiUrl: string, headers: Record<string, string>): Promise<boolean> => {
+  const res = await fetchJsonUnref(`${apiUrl}/health`, 3000, headers);
   return res?.ok ?? false;
 };
 
 // Host reachability, not app health: the site root answers any HTTP status (200/3xx/4xx) when the
 // host is up, so any non-null response counts as reachable; only a refused/timed-out connect fails.
-const checkSite = async (siteUrl: string): Promise<boolean> => {
-  const res = await fetchJsonUnref(siteUrl, 3000);
+const checkSite = async (siteUrl: string, headers: Record<string, string>): Promise<boolean> => {
+  const res = await fetchJsonUnref(siteUrl, 3000, headers);
   return res !== null;
 };
 
@@ -102,14 +103,16 @@ const probeDaemon = async (): Promise<DaemonProbe> => {
 
 export const gatherStatus = async (auth: AuthState | null, fqdn: string): Promise<StatusReport> => {
   const target = links(fqdn);
+  const env = environment(fqdn);
+  // Probe the local daemon first (fast, 1s-capped /health) so its version can ride the probe headers.
+  const probe = await probeDaemon();
+  const headers = requestHeaders({ component: 'cli', daemonVersion: probe.status.daemonVersion });
   // Endpoint reachability and the (npm-registry) update check are independent - run them
   // together so `status` stays snappy.
-  const env = environment(fqdn);
-  const [reachable, siteReachable, update, probe] = await Promise.all([
-    checkEndpoint(target.api),
-    checkSite(target.site),
+  const [reachable, siteReachable, update] = await Promise.all([
+    checkEndpoint(target.api, headers),
+    checkSite(target.site, headers),
     checkForUpdate(VERSION),
-    probeDaemon(),
   ]);
   const report: StatusReport = {
     version: VERSION,

--- a/src/sync/couch/manager.ts
+++ b/src/sync/couch/manager.ts
@@ -2,6 +2,7 @@ import { CouchSync, type FetchLike, type FetchJson } from '@agentage/memory-core
 import { currentBearer } from '../../lib/auth/api.js';
 import { getConfigDir, readAuth } from '../../lib/fs/config.js';
 import { links, siteFqdn } from '../../lib/net/origins.js';
+import { requestHeaders } from '../../lib/net/user-agent.js';
 import { defaultProvisionDeps, provisionAccountVault } from '../../lib/auth/provision.js';
 import { loadVaultsConfig } from '../../lib/vault/vaults.js';
 import { intervalMs } from '../git/planner.js';
@@ -31,10 +32,19 @@ export {
 } from './manager.types.js';
 export { resolveMutationTarget } from './mutation-target.js';
 
-const defaultFetch: FetchLike = (url, init) => globalThis.fetch(url, init as RequestInit);
+// Couch sync runs inside the daemon; identify the caller as the daemon on every outbound request.
+const daemonHeaders = (): Record<string, string> => requestHeaders({ component: 'daemon' });
+
+const defaultFetch: FetchLike = (url, init) => {
+  const base = init as RequestInit | undefined;
+  const merged: RequestInit = { ...base, headers: { ...daemonHeaders(), ...base?.headers } };
+  return globalThis.fetch(url, merged);
+};
 
 const defaultFetchJson: FetchJson = async (url, token) => {
-  const res = await globalThis.fetch(url, { headers: { authorization: `Bearer ${token}` } });
+  const res = await globalThis.fetch(url, {
+    headers: { authorization: `Bearer ${token}`, ...daemonHeaders() },
+  });
   const json = await res.json().catch(() => null);
   return { status: res.status, json };
 };


### PR DESCRIPTION
## What

Outgoing HTTP requests from the CLI now identify the caller with its version, so the server can observe which CLI + daemon versions are connecting. Requested for the status reachability probes; applied to all CLI request paths.

## Exact header set

Every outgoing request carries three headers built by `requestHeaders({ component, daemonVersion? })` in `src/lib/net/user-agent.ts`:

| Header | CLI request (daemon running) | CLI request (daemon stopped) | Daemon request |
|---|---|---|---|
| `User-Agent` | `agentage-cli/0.0.3` | `agentage-cli/0.0.3` | `agentage-daemon/0.0.3` |
| `X-Agentage-CLI-Version` | `0.0.3` | `0.0.3` | `0.0.3` |
| `X-Agentage-Daemon-Version` | `0.0.3` (running daemon's version) | `none` | `0.0.3` (daemon's own) |

Version is read from the canonical source (`src/utils/version.js` -> `package.json`), never hardcoded.

## How the daemon version is resolved (CLI probe path)

`gatherStatus` probes the local daemon first via `health(port)` (loopback `/api/health`, 1s-capped, already-existing call), then builds the probe headers with `daemonVersion: probe.status.daemonVersion`. A stopped/unreachable daemon yields `undefined` -> `requestHeaders` sends `none`. The daemon probe already ran as part of status, so no extra latency or hang is introduced; the remote site/endpoint probes still run together in `Promise.all` after it.

## Covered call sites

CLI-originated (component `cli`):
- `src/lib/net/http.ts` `fetchJsonUnref` - now accepts/merges a headers arg; used by the status endpoint + site/target reachability probes.
- `src/lib/status/status-info.ts` - `checkEndpoint` / `checkSite` thread the resolved daemon version into the probe headers.
- `src/lib/auth/api.ts` `authedGet` / `authedPost` - headers merged alongside the bearer (introspection, refresh-retry, provisioning).
- `src/lib/auth/oauth.ts` register / token (exchange + refresh) / revoke.

Daemon-originated (component `daemon`):
- `src/sync/couch/manager.ts` `defaultFetch` / `defaultFetchJson` - the daemon's couch sync + discovery outbound calls now send `agentage-daemon/<v>`.

## Deferred / notes

- Git sync (`src/sync/git/*`) shells out to the `git` binary over smart-HTTP; it does not go through a JS fetch helper, so no header hook here. If per-request identification of git sync is wanted, that is a separate follow-up (git `http.extraHeader` config).
- `provisionAccountVault` routes through `authedPost` (component `cli`). It is invoked both from CLI setup and from the daemon's couch discovery; the shared authed layer tags it `cli`. If daemon-initiated provisioning should read `daemon`, thread a component through `authedPost` as a follow-up.

## Tests

- `src/lib/net/user-agent.test.ts` (new): cli vs daemon component, version present, daemonVersion none vs a value.
- `src/lib/net/http.test.ts`: asserts `fetchJsonUnref` merges supplied headers with the default `Accept` (mocked `node:https.get` captures the outgoing headers).
- `src/lib/auth/api.test.ts`: new case asserting `authedGet` sends the three version headers; existing exact-header assertions updated to include them.
- All 463 tests green, `npm run verify` green.

## Verify (for human)

Open the PR diff. Merge when CI is green - no runtime action needed; headers are additive and do not change request behavior (bearer, timeouts, unref, refresh-once all unchanged).
