### PR TITLE
fix: atomic lock create so a live holder is never stolen (lost update)

### DIFF
--- a/src/lib/fs/file-lock.test.ts
+++ b/src/lib/fs/file-lock.test.ts
@@ -130,6 +130,28 @@ describe('file lock', () => {
     }
   });
 
+  it('never steals a lock whose content reads empty (mid-create window, issue #231)', () => {
+    // The exact state a concurrent holderOf saw before the fix: the lock inode exists but its
+    // "<pid> <at>" bytes are not there yet (create-then-write was non-atomic). Reading it yields
+    // no parseable holder. Treating that as "absent/crashed" once let a fresh acquirer unlink a
+    // live holder's lock and enter the critical section twice, silently dropping a write.
+    writeFileSync(lockFile(), ''); // holderOf(...) === null, but the lock IS held
+    expect(acquireFileLock(target, 1_000_000 + 11_000)).toBe(false); // past TTL, still must refuse
+    expect(existsSync(lockFile())).toBe(true); // the live holder's lock was not stolen
+  });
+
+  it('lock content is always complete the instant the file appears (atomic create)', () => {
+    // Poll the lock across many acquire/release cycles: a reader must never observe an empty or
+    // half-written lock file. With the atomic link create the content is present before the inode is.
+    for (let i = 0; i < 5_000; i++) {
+      expect(acquireFileLock(target)).toBe(true);
+      const parts = readFileSync(lockFile(), 'utf-8').trim().split(/\s+/);
+      expect(parts).toHaveLength(2); // "<pid> <at>", never empty
+      expect(Number.isNaN(Number.parseInt(parts[1]!, 10))).toBe(false);
+      releaseFileLock(target);
+    }
+  });
+
   it('serializes many concurrent in-process read-modify-writes, losing none', async () => {
     writeFileSync(target, JSON.stringify([]));
     await Promise.all(

--- a/src/lib/fs/file-lock.ts
+++ b/src/lib/fs/file-lock.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
+import { linkSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
 // A cross-process advisory lock keyed to a target file (`<target>.lock`). Config read-modify-writes
@@ -60,6 +61,20 @@ const unlinkQuiet = (path: string): void => {
   }
 };
 
+// Atomic exclusive create: writeFileSync('wx') is create-then-write, so a concurrent holderOf can
+// read the freshly created but still-empty lock and mistake a live holder for absent (issue #231
+// lost-update). Instead write the full "<pid> <at>" to a unique temp, then linkSync it into place:
+// link is atomic and fails EEXIST if held, so the content is always complete when the lock appears.
+const createLockExclusive = (path: string, content: string): void => {
+  const tmp = `${path}.${process.pid}.${randomBytes(4).toString('hex')}.new`;
+  writeFileSync(tmp, content);
+  try {
+    linkSync(tmp, path);
+  } finally {
+    unlinkQuiet(tmp);
+  }
+};
+
 // Serialize stale-lock takeover behind its own exclusive create so no taker can delete a lock that
 // turned FRESH mid-takeover (the ABA race: a reader sees the stale timestamp, a winner re-creates
 // the lock, the reader deletes the winner's file). Same O_EXCL-guard design proven in
@@ -70,13 +85,16 @@ const takeOverStale = (target: string, now: number): boolean => {
   const guardHeld = holderOf(guard);
   if (guardHeld !== null && isCrashed(guardHeld, now)) unlinkQuiet(guard);
   try {
-    writeFileSync(guard, `${process.pid} ${now}`, { flag: 'wx' });
+    createLockExclusive(guard, `${process.pid} ${now}`);
   } catch {
     return false; // another taker is mid-takeover; let it win
   }
   try {
     const holder = holderOf(path);
-    if (holder !== null && !isCrashed(holder, now)) return false; // fresh or a live-but-slow holder
+    // A null holder means the lock file exists but its content did not read cleanly. Never treat that
+    // as absent: clearing it here would steal a live holder still writing its bytes. Only a holder we
+    // can positively prove crashed is taken over.
+    if (holder === null || !isCrashed(holder, now)) return false;
     unlinkQuiet(path);
     return true;
   } finally {
@@ -84,14 +102,15 @@ const takeOverStale = (target: string, now: number): boolean => {
   }
 };
 
-// One-shot acquire: the O_EXCL ('wx') create IS the mutex - concurrent callers cannot both win it,
-// unlike a check-then-write. A fresh or live holder refuses; a crashed one (dead holder past the
-// TTL) is cleared under the takeover guard and re-raced once. `now` is injectable for tests.
+// One-shot acquire: the atomic link IS the mutex - concurrent callers cannot both win it, and the
+// linked content is always complete so no reader sees an empty lock. A fresh or live holder refuses;
+// a crashed one (dead holder past the TTL) is cleared under the takeover guard and re-raced once.
+// `now` is injectable for tests.
 export const acquireFileLock = (target: string, now: number = Date.now()): boolean => {
   mkdirSync(dirname(target), { recursive: true });
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
-      writeFileSync(lockPath(target), `${process.pid} ${now}`, { flag: 'wx' });
+      createLockExclusive(lockPath(target), `${process.pid} ${now}`);
       return true;
     } catch (err) {
       // Only EEXIST means contention. A permission/read-only error never clears, so failing fast
@@ -106,7 +125,9 @@ export const acquireFileLock = (target: string, now: number = Date.now()): boole
         );
       }
       const holder = holderOf(lockPath(target));
-      if (holder !== null && !isCrashed(holder, now)) return false;
+      // Refuse unless the holder is positively crashed. A null holder (unreadable content) is NOT
+      // proof of a crash: attempting takeover on it once stole a live holder's lock (issue #231).
+      if (holder === null || !isCrashed(holder, now)) return false;
       if (!takeOverStale(target, now)) return false;
     }
   }


### PR DESCRIPTION
## Verdict: A - REAL data-integrity lost-update bug

The e2e "30 concurrent vault-add" test (`e2e/integrity.test.ts:279`) failing once and passing on rerun is NOT a flake. Under CPU contention the advisory file lock silently lets two writers into the critical section and drops committed writes, while every `vault add` still exits 0. This is the same class of bug as cli#252/#231.

## Root cause

`src/lib/fs/file-lock.ts` acquired the lock with `writeFileSync(lockPath, "<pid> <at>", { flag: 'wx' })`. The `wx` create is atomic for the inode but **not for the content**: the file exists (O_CREAT|O_EXCL) before its `<pid> <at>` bytes are written.

A concurrent `holderOf()` that reads the lock in that window sees empty content, `Number.parseInt` yields NaN, and `holderOf` returns `null`. The acquire/takeover logic then treated a `null` holder as "not a live holder" and proceeded to `takeOverStale`, which `unlinkQuiet(path)`'d a **live, fresh** holder's lock and let the second writer in. The pid-liveness gate from cli#252 was bypassed because it never ran on a null holder.

Cross-process read-race proof (one writer create/unlink loop + one reader loop on the same path, 8s):
```
reader: emptyContentReads=169808 totalSeen=534559
```
~32% of concurrent reads observed the lock file mid-create with empty content.

Instrumented subprocess repro (30 concurrent `vault add`, 40 runs, 2 cores under load) - every lost-write run is preceded by a `stole holder=null` takeover, all with `addFail=0`:
```
run 4:  [TAKEOVER pid=... stole holder=null ...]
run 4:  LOST want 30 got 18 missing cli1,cli12,cli16,cli17,cli18,cli4,cli7,other4,other5,other6,other8,other9
run 24: LOST want 30 got 24 missing cli14,cli18,cli19,cli6,cli9,other3
RUNS=40 lost=5 takeovers=16
```

## Fix

1. **Atomic lock create** - `createLockExclusive` writes the full `<pid> <at>` to a unique temp then `linkSync`s it into place. `link` is atomic and fails EEXIST if held (still the mutex), so the content is always complete the instant the lock inode appears. No reader can ever see an empty lock.
2. **Defense in depth** - a `null` holder is now treated as "unknown, refuse", never "absent/crashed". A lock is taken over only when a holder is positively proven crashed (dead pid / our own pid / past the 60s hard-stale bound).

## Tests (deterministic, before-fail / after-pass)

- `never steals a lock whose content reads empty (mid-create window)` - reproduces the exact null-holder state and asserts a fresh acquirer refuses. Fails on old code (`true`), passes after (`false`).
- `lock content is always complete the instant the file appears` - 5000 acquire cycles, the lock never reads empty/half-written.
- The stochastic 30-process e2e test is kept.

## Verification

- `npm run verify` green (type-check + e2e types + eslint + prettier + 444 unit tests + build).
- New unit test proven to fail on the pre-fix source (`git stash` of the fix -> test returns `true`).
- Stochastic subprocess repro (30 concurrent adds x many runs, under CPU load) -> zero lost writes after the fix.
