### PR TITLE
chore: prepare release v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.0.4] - 2026-07-09
+
+### Breaking
+
+- Removed the standalone `agentage mcp` stdio command. MCP is now served by the local daemon over Streamable HTTP at `http://127.0.0.1:4243/mcp` (on by default; disable with `daemon start --no-mcp` or `AGENTAGE_DAEMON_NO_MCP=1`). Point clients at the daemon URL: `claude mcp add --transport http agentage http://127.0.0.1:4243/mcp`.
+
+### New Features
+
+- Account sync: the daemon syncs account (cloud) vaults, with live autodiscovery of new vaults and account-vault provisioning.
+- `setup` now starts the daemon after a successful sign-in, so sync and MCP are ready immediately.
+- `status` now reports the daemon (pid, port, uptime), MCP serving state, a `target` reachability check, and a per-vault breakdown (name, sync channel, status).
+- Outgoing requests now identify the caller with `User-Agent` and CLI/daemon version headers.
+
+### Improvements
+
+- Auth: sessions refresh silently; a transient auth-server hiccup (429/5xx/network) is retried instead of being reported as a signed-out session.
+- A credential for a different environment than the current target is now reported as an env mismatch (with a recovery hint), not a misleading "session expired".
+- `status` auth line reads `signed in (session active)` rather than a raw UTC token-expiry timestamp.
+- README rewritten for non-technical readers, with the full command and integration reference moved to `docs/reference.md`.
+- Daemon hardened against CSRF and DNS rebinding on its local API; lifecycle and port-in-use races fixed.
+- Sync: remote-URL allowlist and redaction; channel-based internal structure.
+- Offline commands no longer hang; cleaner stdout/stderr discipline.
+
+### Fixed
+
+- Data integrity: concurrent writers can no longer silently drop registry updates. The advisory file lock now creates atomically (write-then-link) and never steals a live holder's lock under CPU contention.
+- Packaging hygiene: dependency pins, trimmed npm tarball, removed tracked build artifacts.
+
+### Internal
+
+- `src/lib` and `src/commands` regrouped into domain folders; oversized modules split.
+
 ## [0.0.3] - 2026-06-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentage/cli",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentage/cli",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "@agentage/memory-core": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentage/cli",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "The agentage CLI - connect this machine to agentage from the terminal",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Release v0.0.4 - prepared manually (the release-prepare workflow failed only on the AI changelog step: the repo ANTHROPIC_API_KEY hit its usage limit until 2026-08-01; version bump + changelog done by hand).

Version 0.0.3 -> 0.0.4. Covers everything merged since v0.0.3 (#221-#263). Highlights:
- BREAKING: removed the `agentage mcp` stdio command; MCP now served by the daemon over HTTP.
- Account sync + autodiscovery; setup starts the daemon.
- status overhaul (daemon/mcp/target/vaults rows, silent refresh, version headers).
- Data-integrity fix: atomic file-lock create (no more silent lost registry writes).
- Auth resilience: transient handling + env-mismatch reporting.

Merge (squash) to publish 0.0.4 to npm via publish.yml. Squash subject stays `chore: prepare release v0.0.4` to pass the release gate.
