### PR TITLE
feat(ci): ANTHROPIC_BASE_URL override for changelog generation

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -98,6 +98,8 @@ jobs:
         id: changelog
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Optional Anthropic-compatible endpoint override (e.g. Azure); SDK reads it natively.
+          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
         run: |
           CHANGELOG=$(node scripts/generate-changelog.js ${{ steps.bump.outputs.new_version }})
           echo "$CHANGELOG" > changelog-content.md


### PR DESCRIPTION
## Why
Moving changelog generation off the org Anthropic key (spend-capped) to the Azure AI Foundry resource, which serves `claude-sonnet-4-6` over the Anthropic Messages API.

## What
One workflow line: pass `vars.ANTHROPIC_BASE_URL` into the changelog step. `@anthropic-ai/sdk` reads `ANTHROPIC_BASE_URL` natively; empty/unset var falls back to `api.anthropic.com` (verified). The script's `claude-sonnet-4-6` model id matches the Azure deployment name exactly - no code change.

## Ops (done alongside)
- repo var `ANTHROPIC_BASE_URL` = `https://vreshch-2142-resource.services.ai.azure.com/anthropic`
- repo secret `ANTHROPIC_API_KEY` = Azure key (shadows the org secret for this repo)

## Verified
Ran the exact SDK call `generate-changelog.js` makes with the new env locally - pong from `claude-sonnet-4-6` via Azure, usage accounted. Full flow validates on the next release-prepare dispatch.
