### PR TITLE
chore(release): 0.25.0 - jump over npm-burned 0.1.x-0.24.x versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentage/cli",
-  "version": "0.1.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentage/cli",
-      "version": "0.1.0",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "@agentage/memory-core": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentage/cli",
-  "version": "0.1.0",
+  "version": "0.25.0",
   "description": "The agentage CLI - connect this machine to agentage from the terminal",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Tonight's train released 0.1.0 (PR #275) but npm rejected the publish: the pre-reboot @agentage/cli published and unpublished 0.1.0 through 0.24.6, and npm forbids reusing those version numbers forever. 0.25.0 clears the entire burned range in one jump, so future always-minor bumps (0.26.0, 0.27.0, ...) can never collide again. After merge: tag 0.25.0 + dispatch publish.yml (idempotent).