### PR TITLE
chore(e2e): tag suite traffic with x-client-type: test

### DIFF
--- a/e2e/client-type.ts
+++ b/e2e/client-type.ts
@@ -1,0 +1,7 @@
+// Estate test-traffic contract: the edge classifier keys on this exact header to keep e2e out of real-user metrics.
+export const CLIENT_TYPE_HEADER = 'x-client-type';
+export const CLIENT_TYPE_TEST = 'test';
+
+export const testClientHeader = (): Record<string, string> => ({
+  [CLIENT_TYPE_HEADER]: CLIENT_TYPE_TEST,
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -14,6 +14,7 @@ import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect, request as apiRequest, type APIRequestContext } from '@playwright/test';
+import { testClientHeader } from './client-type.js';
 
 export const TARGET_FQDN = process.env['AGENTAGE_SITE_FQDN'] ?? 'dev.agentage.io';
 export const AUTH_URL = `https://auth.${TARGET_FQDN}`;
@@ -150,7 +151,10 @@ export const testAccount = (): TestAccount => {
 
 // Better Auth 403s cookie-bearing POSTs without a same-origin Origin header.
 export const newBrowserContext = (): Promise<APIRequestContext> =>
-  apiRequest.newContext({ baseURL: AUTH_URL, extraHTTPHeaders: { Origin: AUTH_URL } });
+  apiRequest.newContext({
+    baseURL: AUTH_URL,
+    extraHTTPHeaders: { Origin: AUTH_URL, ...testClientHeader() },
+  });
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 

--- a/e2e/mcp-contract.test.ts
+++ b/e2e/mcp-contract.test.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { assertCliBuilt, createCliMachine, freePort, type CliMachine } from './helpers.js';
+import { testClientHeader } from './client-type.js';
 
 // Frozen MCP contract behavior tier. mcp-daemon.test.ts proves the tool surface exists (6 tools,
 // dual-channel output); this proves the BEHAVIORS a bad @agentage/server-memory or
@@ -28,7 +29,11 @@ const rpc = async (
 ): Promise<{ result?: ToolResult; error?: { message: string } }> => {
   const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      ...testClientHeader(),
+    },
     body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
   });
   expect(res.ok, `POST /mcp ${method} -> ${res.status}`).toBe(true);

--- a/e2e/mcp-daemon.test.ts
+++ b/e2e/mcp-daemon.test.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { assertCliBuilt, createCliMachine, freePort, type CliMachine } from './helpers.js';
+import { testClientHeader } from './client-type.js';
 
 // M3 daemon MCP tier: the daemon exposes the frozen 6 memory__* tools at POST /mcp (stateless
 // Streamable HTTP). An ephemeral port + isolated AGENTAGE_CONFIG_DIR keep it off the real daemon /
@@ -36,7 +37,11 @@ interface RpcResult {
 const mcpRpc = async (port: number, method: string, params: unknown): Promise<RpcResult> => {
   const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      ...testClientHeader(),
+    },
     body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
   });
   expect(res.ok, `POST /mcp ${method} -> ${res.status}`).toBe(true);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@playwright/test';
+import { testClientHeader } from './e2e/client-type.js';
 
 export default defineConfig({
   testDir: './e2e',
@@ -8,4 +9,5 @@ export default defineConfig({
   retries: process.env['CI'] ? 1 : 0,
   workers: 1,
   reporter: process.env['CI'] ? [['list'], ['html', { open: 'never' }]] : 'list',
+  use: { extraHTTPHeaders: { ...testClientHeader() } },
 });


### PR DESCRIPTION
## Why

Estate test-traffic contract: every e2e/synthetic request must carry `x-client-type: test`. The edge classifier (Traefik -> Vector) and `@agentage/observability` span stamping key on exactly this header; UA sniffing is only a fallback. This suite signs up throwaway accounts against a live Better Auth AS (`auth.<AGENTAGE_SITE_FQDN>`), all of it untagged today.

## What

- New `e2e/client-type.ts` - single source for the header (local const; no shared package here).
- `playwright.config.ts` gains a `use.extraHTTPHeaders` default (the config had no `use` block at all).
- `e2e/helpers.ts` `newBrowserContext()`: `apiRequest.newContext` passes its own `extraHTTPHeaders` (Origin), which REPLACES the config default per key - so it spreads the tag explicitly.
- The daemon MCP RPC helpers in `mcp-contract.test.ts` / `mcp-daemon.test.ts` tag their `fetch` too (loopback today, but keeps the contract uniform).

## Known gap

Requests the CLI *subprocess* makes to the live stack (OAuth, sync over git smart-HTTP) still go out untagged - the test harness cannot inject a header into the built binary. Closing that needs a client-side hook in the CLI itself (e.g. honoring an `AGENTAGE_CLIENT_TYPE` env var); flagged, not fixed here.

## Verified

`prettier --check` clean; `playwright test --list` loads the config (44 tests in 11 files). No suite run against a deployed stack.
