### PR TITLE
chore: ignore memory-core majors until the 1.x migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
       # typescript-eslint peer-caps typescript <6.1.0 - drop when it supports 7.x
       - dependency-name: 'typescript'
         update-types: ['version-update:semver-major']
+      # memory-core 1.x is a breaking new engine - migrate deliberately, not via dependabot
+      - dependency-name: '@agentage/memory-core'
+        update-types: ['version-update:semver-major']
     groups:
       all-dependencies:
         patterns:


### PR DESCRIPTION
Guard: @agentage/memory-core@1.0.0 is a breaking new engine (ADR-017); tomorrow 16:00 UTC dependabot would open a hard-failing 0.5->1.0 bump. Ignore majors; drop this when the migration PR lands.