### PR TITLE
fix: cap train ncu at --target minor

### DIFF
--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -89,7 +89,8 @@ jobs:
           set -euo pipefail
           # L2 upgrade: pull in memory-core + server-memory versions released
           # earlier tonight. A dep change alone justifies the weekly release.
-          npx --yes npm-check-updates -u --dep prod,dev --filter "@agentage/*"
+          # --target minor: majors stay a deliberate human/dependabot call, not an auto-bump.
+          npx --yes npm-check-updates -u --target minor --dep prod,dev --filter "@agentage/*"
           npm install
           if git diff --quiet -- package.json package-lock.json; then
             echo "No @agentage/* dependency changes."


### PR DESCRIPTION
Friday train's `npx npm-check-updates -u --dep prod,dev --filter "@agentage/*"` had no major guard and force-bumped `@agentage/memory-core` ^0.5.0 -> ^1.0.0 (breaking rewrite), failing `npm run verify` on TS2305 - run [32527573819](https://github.com/agentage/cli/actions/runs/32527573819) red. This defeated the deliberate major-ignore merged in #286.

Fix: add `--target minor` to the ncu invocation so majors stay a deliberate human/dependabot call.

Dry-run evidence in the worktree (`npx npm-check-updates --filter "@agentage/*" --target minor`, no `-u`): "All dependencies match the minor package versions :)" - does NOT propose memory-core ^1.0.x. Without the cap, ncu currently proposes `@agentage/memory-core ^0.5.0 -> ^1.0.1`.